### PR TITLE
Add random vector implementation

### DIFF
--- a/hoomd-rs-vector/Cargo.toml
+++ b/hoomd-rs-vector/Cargo.toml
@@ -13,11 +13,11 @@ version.workspace = true
 
 [dependencies]
 thiserror = "1.0.64"
+rand = {version = "0.8.5", features=["min_const_gen"]}
 
 [dev-dependencies]
 divan = "0.1.14"
 paste = "1.0.15"
-rand = "0.8.5"
 
 [[bench]]
 name = "cartesian"

--- a/hoomd-rs-vector/Cargo.toml
+++ b/hoomd-rs-vector/Cargo.toml
@@ -13,7 +13,7 @@ version.workspace = true
 
 [dependencies]
 thiserror = "1.0.64"
-rand = {version = "0.8.5", features=["min_const_gen"]}
+rand = {version = "0.8.5"}
 
 [dev-dependencies]
 divan = "0.1.14"

--- a/hoomd-rs-vector/benches/cartesian.rs
+++ b/hoomd-rs-vector/benches/cartesian.rs
@@ -8,13 +8,15 @@ use rand::{thread_rng, Rng};
 
 use hoomd_rs_vector::{vector::Cartesian, Cross, Vector};
 
-
 fn main() {
     divan::main();
 }
 
 fn create_random_vector_pair<const N: usize>() -> (Cartesian<N>, Cartesian<N>) {
-    (rand::random::<Cartesian<N>>(), rand::random::<Cartesian<N>>())
+    (
+        rand::random::<Cartesian<N>>(),
+        rand::random::<Cartesian<N>>(),
+    )
 }
 
 const DIMENSIONS: &[usize] = &[2, 3, 8, 16, 32, 128];

--- a/hoomd-rs-vector/benches/cartesian.rs
+++ b/hoomd-rs-vector/benches/cartesian.rs
@@ -8,16 +8,13 @@ use rand::{thread_rng, Rng};
 
 use hoomd_rs_vector::{vector::Cartesian, Cross, Vector};
 
+
 fn main() {
     divan::main();
 }
 
 fn create_random_vector_pair<const N: usize>() -> (Cartesian<N>, Cartesian<N>) {
-    let mut rng = thread_rng();
-    (
-        Cartesian::from(std::array::from_fn::<_, N, _>(|_| rng.gen::<f64>())),
-        Cartesian::from(std::array::from_fn::<_, N, _>(|_| rng.gen::<f64>())),
-    )
+    (rand::random::<Cartesian<N>>(), rand::random::<Cartesian<N>>())
 }
 
 const DIMENSIONS: &[usize] = &[2, 3, 8, 16, 32, 128];

--- a/hoomd-rs-vector/benches/cartesian.rs
+++ b/hoomd-rs-vector/benches/cartesian.rs
@@ -81,3 +81,10 @@ fn cross_vec3(bencher: Bencher) {
         .with_inputs(create_random_vector_pair::<3>)
         .bench_local_values(|(a, b)| black_box(a.cross(&b)));
 }
+
+#[divan::bench(consts = DIMENSIONS)]
+fn gen_random<const N: usize>(bencher: Bencher) {
+    bencher
+        .counter(ItemsCount::from(1_u32))
+        .bench(|| black_box(rand::random::<Cartesian<N>>()));
+}

--- a/hoomd-rs-vector/src/vector.rs
+++ b/hoomd-rs-vector/src/vector.rs
@@ -9,8 +9,8 @@ use std::fmt;
 use std::iter::zip;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use rand::Rng;
 use rand::distributions::{Distribution, Standard};
+use rand::Rng;
 
 use crate::{Cross, Dimension, Error, Vector};
 
@@ -303,7 +303,9 @@ impl Cross for Cartesian<3> {
 impl<const N: usize> Distribution<Cartesian<N>> for Standard {
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Cartesian<N> {
-        Cartesian { coordinates: rng.gen() }
+        Cartesian {
+            coordinates: rng.gen(),
+        }
     }
 }
 

--- a/hoomd-rs-vector/src/vector.rs
+++ b/hoomd-rs-vector/src/vector.rs
@@ -301,7 +301,7 @@ impl Cross for Cartesian<3> {
 }
 
 impl<const N: usize> Distribution<Cartesian<N>> for Standard {
-    /** Create a Cartesian vector with coordinates drawn from a unit (hyper)cube.
+    /** Create a Cartesian vector with coordinates drawn from a unit hypercube.
 
     ```
     # use hoomd_rs_vector::vector;

--- a/hoomd-rs-vector/src/vector.rs
+++ b/hoomd-rs-vector/src/vector.rs
@@ -18,11 +18,13 @@ use crate::{Cross, Dimension, Error, Vector};
 
 `Cartesian` is the canonical implementation of [`Vector`].
 
-## Examples:
+All examples assume:
 
 ```
 use hoomd_rs_vector::vector;
 ```
+
+## Constructing vectors
 
 Create a vector with an array of coordinates:
 ```
@@ -36,6 +38,20 @@ let v = vector::Cartesian::from([1.0, 2.0, 3.0, 4.0, 5.0]);
 let a = vector::Cartesian::from((1.0, 2.0, 3.0));
 let b = vector::Cartesian::from((4.0, 5.0));
 ```
+
+Construct a random vector in the [-1, 1] hypercube:
+
+```
+# use hoomd_rs_vector::vector;
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+use rand::{thread_rng, Rng};
+let mut rng = rand::thread_rng();
+let v: vector::Cartesian::<3> = rng.gen();
+# Ok(())
+# }
+``` 
+
+## Operating on vectors
 
 Use vector math operations when you can:
 ```
@@ -301,7 +317,7 @@ impl Cross for Cartesian<3> {
 }
 
 impl<const N: usize> Distribution<Cartesian<N>> for Standard {
-    /** Create a Cartesian vector with coordinates drawn from a unit hypercube.
+    /** Create a Cartesian vector with coordinates drawn from the [-1, 1] hypercube.
 
     Each coordinate in the vector is in the closed range [-1, 1].
 

--- a/hoomd-rs-vector/src/vector.rs
+++ b/hoomd-rs-vector/src/vector.rs
@@ -49,7 +49,7 @@ let mut rng = rand::thread_rng();
 let v: vector::Cartesian::<3> = rng.gen();
 # Ok(())
 # }
-``` 
+```
 
 ## Operating on vectors
 

--- a/hoomd-rs-vector/src/vector.rs
+++ b/hoomd-rs-vector/src/vector.rs
@@ -9,6 +9,9 @@ use std::fmt;
 use std::iter::zip;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
+use rand::Rng;
+use rand::distributions::{Distribution, Standard};
+
 use crate::{Cross, Dimension, Error, Vector};
 
 /** A Cartesian vector represented by an array of `N` `f64` coordinates.
@@ -294,6 +297,13 @@ impl Cross for Cartesian<3> {
             self.coordinates[2] * rhs.coordinates[0] - self.coordinates[0] * rhs.coordinates[2],
             self.coordinates[0] * rhs.coordinates[1] - self.coordinates[1] * rhs.coordinates[0],
         ))
+    }
+}
+
+impl<const N: usize> Distribution<Cartesian<N>> for Standard {
+    #[inline]
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Cartesian<N> {
+        Cartesian { coordinates: rng.gen() }
     }
 }
 

--- a/hoomd-rs-vector/src/vector.rs
+++ b/hoomd-rs-vector/src/vector.rs
@@ -303,13 +303,15 @@ impl Cross for Cartesian<3> {
 impl<const N: usize> Distribution<Cartesian<N>> for Standard {
     /** Create a Cartesian vector with coordinates drawn from a unit hypercube.
 
+    Each coordinate in the vector is in the closed range [-1, 1].
+
+
     ```
     # use hoomd_rs_vector::vector;
-    # use rand::{thread_rng, Rng};
     # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use rand::{thread_rng, Rng};
     let mut rng = rand::thread_rng();
     let v: vector::Cartesian::<3> = rng.gen();
-    // assert_eq!(v, [3.0, 4.0, 5.0].into());
     # Ok(())
     # }
     ```

--- a/hoomd-rs-vector/src/vector.rs
+++ b/hoomd-rs-vector/src/vector.rs
@@ -596,11 +596,13 @@ mod tests {
         let mut rng = rand::thread_rng();
         let a: Cartesian<N> = rng.gen();
 
-        assert!(a
-            .coordinates
-            .map(|x| -1.0 < x && x < 1.0)
-            .iter()
-            .all(|&x| x));
+        assert!(a.coordinates.iter().all(|&x| -1.0 < x && x < 1.0));
+
+        // This test will fail ~1e-3008 percent of the time - it's probably fine
+        if N == 10_000 {
+            assert!(a.coordinates.iter().any(|&x| x < 0.0));
+        }
     }
+
     parameterize_vector_length!(random_in_range, [2, 3, 4, 8, 16, 32, 10_000]);
 }

--- a/hoomd-rs-vector/src/vector.rs
+++ b/hoomd-rs-vector/src/vector.rs
@@ -592,7 +592,7 @@ mod tests {
     parameterize_vector_length!(from_vec, [2, 3, 4, 8, 16, 32]);
 
     fn random_in_range<const N: usize>() {
-        // At a minimum, this check should verify that we are drawing from a unit cube
+        // Loosely verify we are drawing from the correct distribution
         let mut rng = rand::thread_rng();
         let a: Cartesian<N> = rng.gen();
 

--- a/hoomd-rs-vector/src/vector.rs
+++ b/hoomd-rs-vector/src/vector.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::iter::zip;
 use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-use rand::distributions::{Distribution, Standard};
+use rand::distributions::{Distribution, Standard, Uniform};
 use rand::Rng;
 
 use crate::{Cross, Dimension, Error, Vector};
@@ -301,10 +301,24 @@ impl Cross for Cartesian<3> {
 }
 
 impl<const N: usize> Distribution<Cartesian<N>> for Standard {
+    /** Create a Cartesian vector with coordinates drawn from a unit (hyper)cube.
+
+    ```
+    # use hoomd_rs_vector::vector;
+    # use rand::{thread_rng, Rng};
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut rng = rand::thread_rng();
+    let v: vector::Cartesian::<3> = rng.gen();
+    // assert_eq!(v, [3.0, 4.0, 5.0].into());
+    # Ok(())
+    # }
+    ```
+    */
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Cartesian<N> {
+        let dist = Uniform::new_inclusive(-1.0, 1.0);
         Cartesian {
-            coordinates: rng.gen(),
+            coordinates: array::from_fn(|_| dist.sample(rng)),
         }
     }
 }
@@ -576,4 +590,17 @@ mod tests {
         );
     }
     parameterize_vector_length!(from_vec, [2, 3, 4, 8, 16, 32]);
+
+    fn random_in_range<const N: usize>() {
+        // At a minimum, this check should verify that we are drawing from a unit cube
+        let mut rng = rand::thread_rng();
+        let a: Cartesian<N> = rng.gen();
+
+        assert!(a
+            .coordinates
+            .map(|x| -1.0 < x && x < 1.0)
+            .iter()
+            .all(|&x| x));
+    }
+    parameterize_vector_length!(random_in_range, [2, 3, 4, 8, 16, 32, 10_000]);
 }


### PR DESCRIPTION
`rand` makes it [extremely easy](https://docs.rs/rand/latest/rand/distributions/struct.Standard.html#custom-implementations) to implement random generators for custom types, and by enabling the "min_const_gen" flag for the package we can trivially generate arrays of any size. This implementation lets `Cartesian` be generated from any rand::distribution, with the default  `Standard` distribution being a unit hypercube.


Sidebar - it would be nice to increase the struct_lit_width rustfmt setting to allow slightly longer lines initializing a struct. For example:
```rust
//Before
Self {
	coordinates: coordinates.into()
}

//After
Self { coordinates: coordinates.into() }
```

```toml
struct_lit_width = 32 # Default is 20, anywhere 32-48ish works well imo
```