### PR TITLE
Boundary conditions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,6 @@ jobs:
           # - macos-14
         rust:
           # Test multiple rust versions on multiple platforms in debug mode.
-          - 1.85.0
           - 1.86.0
         mode:
          - debug

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +365,7 @@ dependencies = [
 name = "hoomd-microstate"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "approx",
  "divan",
  "hoomd-utility",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,6 +43,21 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cfg-if"
@@ -82,6 +103,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "condtype"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +129,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -122,6 +217,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,8 +235,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "futures-core"
@@ -189,7 +302,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -203,6 +316,17 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hoomd-interaction"
@@ -227,6 +351,7 @@ dependencies = [
  "hoomd-utility",
  "hoomd-vector",
  "rand",
+ "ratatui",
  "rstest",
 ]
 
@@ -269,6 +394,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indexmap"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,10 +410,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
+name = "instability"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -291,10 +462,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "mio"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "num-traits"
@@ -303,6 +511,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
 ]
 
 [[package]]
@@ -396,6 +627,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "strum_macros",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +738,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
@@ -484,9 +758,27 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.9.3",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -495,12 +787,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]
@@ -520,8 +882,8 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix",
- "windows-sys",
+ "rustix 1.0.3",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -568,12 +930,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "wasi"
 version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,6 +240,7 @@ dependencies = [
  "hoomd-vector",
  "rand",
  "rstest",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ thiserror = "2.0.12"
 approx = "0.5.1"
 divan = "0.1.17"
 rstest = "0.25.0"
+anyhow = "1.0.98"
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,3 +75,6 @@ unwrap_used = "warn"
 fallible_impl_from = "warn"
 needless_collect = "warn"
 needless_pass_by_ref_mut = "warn"
+
+[workspace.metadata.typos]
+default.extend-words = { ratatui = "ratatui" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "3"
 [workspace.package]
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.86"
 homepage = "https://glotzerlab.engin.umich.edu"
 repository = "https://github.com/glotzerlab/hoomd"
 license = "BSD-3-Clause"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ hoomd-vector = { path = "hoomd-vector" }
 # Common dependencies
 rand = "0.9.0"
 thiserror = "2.0.12"
+# Note: thiserror does not appear in the public API and therefore does not
+# impact semantic versioning.
 
 # Common dev dependencies
 approx = "0.5.1"

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ with a variety of particle interaction. **HOOMD-rs** provides public APIs for ve
 math, spatial data structures, energy calculations, and all other components of the
 simulation that users can employ in their own analysis and simulation methods.
 
-**HOOMD-rs** implements a subset of the methods available in the Python package
-[HOOMD-blue] but can be customized in many ways that [HOOMD-blue] cannot, such as:
+**HOOMD-rs** implements many of the methods available in the Python package
+[HOOMD-blue] and can be customized in many ways that [HOOMD-blue] cannot, such as:
 
 * Custom per-particle attributes.
 * Custom particle interactions that can _depend on custom per-particle attributes_.
@@ -19,12 +19,12 @@ simulation that users can employ in their own analysis and simulation methods.
 
 Users are expected to make use of these customization opportunities. **HOOMD-rs** _does
 not_ come with batteries included. It provides built-in implementations only for the
-most commonly used methods. Users compile their simulation code with [Rust], which
-will inline user-provided code in the innermost loops allowing the resulting executables
+most commonly used methods. Users compile their simulation code with [Rust], which will
+inline user-provided code in the innermost loops allowing the resulting executables
 can realize the full performance of the CPU. In contrast, [HOOMD-blue] offers limited
-opportunities for user customization with Python scripts _interpreted_ at runtime.
-Furthermore, configuring an environment to build **HOOMD-rs** code takes far fewer steps
-than even installing a Python environment for [HOOMD-blue]!
+opportunities for user customization with Python scripts that are _interpreted_ at
+runtime. Furthermore, configuring an environment to build **HOOMD-rs** code takes far
+fewer steps than even installing a Python environment for [HOOMD-blue]!
 
 **HOOMD-rs** lacks domain decomposition and GPU parallelization, so it is best for small
 to moderate sized simulations or when customization is important. [HOOMD-blue] is best
@@ -40,6 +40,21 @@ is HOOMD-blue or HOOMD-rs faster on the same CPU?
 [C++ component for HOOMD-blue]: https://github.com/glotzerlab/hoomd-component-template/
 
 ## Resources
+
+To view the documentation, clone this repository if you haven't already done so:
+```shell
+git clone git@github.com:glotzerlab/hoomd-rs
+```
+
+Enter the `hoomd-rs` directory:
+```shell
+cd hoomd-rs
+```
+
+Build the documentation and open it in your browser:
+```shell
+cargo doc --no-deps --open
+```
 
 ## Example
 

--- a/hoomd-interaction/benches/angular-mask.rs
+++ b/hoomd-interaction/benches/angular-mask.rs
@@ -35,19 +35,27 @@ fn energy_2d(bencher: Bencher) {
 
     let masks = [
         Patch::new(
-            [1.0, 0.0].try_into().expect("valid unit vector"),
+            [1.0, 0.0]
+                .try_into()
+                .expect("hard-coded vector should have non-zero length"),
             (PI / 8.0).cos(),
         ),
         Patch::new(
-            [-1.0, 0.0].try_into().expect("valid unit vector"),
+            [-1.0, 0.0]
+                .try_into()
+                .expect("hard-coded vector should have non-zero length"),
             (PI / 16.0).cos(),
         ),
         Patch::new(
-            [0.0, 1.0].try_into().expect("valid unit vector"),
+            [0.0, 1.0]
+                .try_into()
+                .expect("hard-coded vector should have non-zero length"),
             (PI / 16.0).cos(),
         ),
         Patch::new(
-            [0.0, -1.0].try_into().expect("valid unit vector"),
+            [0.0, -1.0]
+                .try_into()
+                .expect("hard-coded vector should have non-zero length"),
             (PI / 16.0).cos(),
         ),
     ];
@@ -72,19 +80,27 @@ fn energy_3d(bencher: Bencher) {
 
     let masks = [
         Patch::new(
-            [1.0, 0.0, 0.0].try_into().expect("valid unit vector"),
+            [1.0, 0.0, 0.0]
+                .try_into()
+                .expect("hard-coded vector should have non-zero length"),
             (PI / 16.0).cos(),
         ),
         Patch::new(
-            [-1.0, 0.0, 0.0].try_into().expect("valid unit vector"),
+            [-1.0, 0.0, 0.0]
+                .try_into()
+                .expect("hard-coded vector should have non-zero length"),
             (PI / 16.0).cos(),
         ),
         Patch::new(
-            [0.0, 1.0, 0.0].try_into().expect("valid unit vector"),
+            [0.0, 1.0, 0.0]
+                .try_into()
+                .expect("hard-coded vector should have non-zero length"),
             (PI / 16.0).cos(),
         ),
         Patch::new(
-            [0.0, -1.0, 0.0].try_into().expect("valid unit vector"),
+            [0.0, -1.0, 0.0]
+                .try_into()
+                .expect("hard-coded vector should have non-zero length"),
             (PI / 16.0).cos(),
         ),
     ];
@@ -98,9 +114,3 @@ fn energy_3d(bencher: Bencher) {
         })
         .bench_local_values(|(r_ij, angle)| black_box(angular_mask.energy(&r_ij, &angle)));
 }
-
-// To inspect the energy function with cargo-show-asm
-// #[no_mangle]
-// pub fn asm(angular_mask: &AngularMask<LennardJones, Cartesian<3>>, r_ij: &Cartesian<3>, v: &Versor) -> f64 {
-//     angular_mask.energy(r_ij, v)
-// }

--- a/hoomd-interaction/src/external/linear.rs
+++ b/hoomd-interaction/src/external/linear.rs
@@ -99,7 +99,8 @@ mod tests {
         #[values([0.0, 0.0], [-10.0, 15.0], [16.0, 3.0])] plane_origin: [f64; 2],
         #[values([1.0, 1.0], [-1.0, 0.2], [-5.0, -1.0])] plane_normal: [f64; 2],
     ) {
-        let n = Unit::<Cartesian<2>>::try_from(plane_normal).expect("normalizable vector");
+        let n = Unit::<Cartesian<2>>::try_from(plane_normal)
+            .expect("hard-coded vector should have non-zero length");
 
         let linear = Linear {
             plane_origin: plane_origin.into(),

--- a/hoomd-interaction/src/lib.rs
+++ b/hoomd-interaction/src/lib.rs
@@ -69,7 +69,7 @@ where
 
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 let mut microstate = Microstate::new();
-microstate.try_extend_bodies([Body::point(Cartesian::from([1.0, 0.0])),
+microstate.extend_bodies([Body::point(Cartesian::from([1.0, 0.0])),
                               Body::point(Cartesian::from([-1.0, 2.0]))])?;
 
 let custom_evaluator = Custom { a: 1.0, b: 10.0 };
@@ -107,7 +107,7 @@ use hoomd_vector::Cartesian;
 
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 let mut microstate = Microstate::new();
-microstate.try_extend_bodies([Body::point(Cartesian::from([1.0, 0.0])),
+microstate.extend_bodies([Body::point(Cartesian::from([1.0, 0.0])),
                               Body::point(Cartesian::from([-1.0, 2.0]))])?;
 
 let linear = Single(Linear{ alpha: 1.0,
@@ -175,7 +175,7 @@ mod tests {
     fn microstate() -> Microstate<Cartesian<2>, Point<Cartesian<2>>, Point<Cartesian<2>>, Open> {
         let mut microstate = Microstate::new();
         microstate
-            .try_extend_bodies([
+            .extend_bodies([
                 Body::point(Cartesian::from([1.0, 0.0])),
                 Body::point(Cartesian::from([-1.0, 3.0])),
             ])

--- a/hoomd-interaction/src/lib.rs
+++ b/hoomd-interaction/src/lib.rs
@@ -69,8 +69,8 @@ where
 
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 let mut microstate = Microstate::new();
-microstate.extend_bodies([Body::point(Cartesian::from([1.0, 0.0])),
-                          Body::point(Cartesian::from([-1.0, 2.0]))]);
+microstate.try_extend_bodies([Body::point(Cartesian::from([1.0, 0.0])),
+                              Body::point(Cartesian::from([-1.0, 2.0]))])?;
 
 let custom_evaluator = Custom { a: 1.0, b: 10.0 };
 let site_energy = custom_evaluator.site_energy(&microstate.sites()[0].properties);
@@ -107,8 +107,8 @@ use hoomd_vector::Cartesian;
 
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 let mut microstate = Microstate::new();
-microstate.extend_bodies([Body::point(Cartesian::from([1.0, 0.0])),
-                          Body::point(Cartesian::from([-1.0, 2.0]))]);
+microstate.try_extend_bodies([Body::point(Cartesian::from([1.0, 0.0])),
+                              Body::point(Cartesian::from([-1.0, 2.0]))])?;
 
 let linear = Single(Linear{ alpha: 1.0,
     plane_origin: Cartesian::default(),
@@ -174,10 +174,12 @@ mod tests {
     #[fixture]
     fn microstate() -> Microstate<Point<Cartesian<2>>, Point<Cartesian<2>>, Open> {
         let mut microstate = Microstate::new();
-        microstate.extend_bodies([
-            Body::point(Cartesian::from([1.0, 0.0])),
-            Body::point(Cartesian::from([-1.0, 3.0])),
-        ]);
+        microstate
+            .try_extend_bodies([
+                Body::point(Cartesian::from([1.0, 0.0])),
+                Body::point(Cartesian::from([-1.0, 3.0])),
+            ])
+            .expect("valid bodies");
         microstate
     }
 

--- a/hoomd-interaction/src/lib.rs
+++ b/hoomd-interaction/src/lib.rs
@@ -122,7 +122,7 @@ assert_eq!(total_energy, 2.0);
 */
 pub struct Single<E>(pub E);
 
-impl<B, S, C, E> TotalEnergy<Microstate<B, S, C>> for Single<E>
+impl<V, B, S, C, E> TotalEnergy<Microstate<V, B, S, C>> for Single<E>
 where
     E: SiteEnergy<S>,
 {
@@ -133,7 +133,7 @@ where
     to sites. Use a custom implementation to compute energies over body centers.
     */
     #[inline]
-    fn total_energy(&self, microstate: &Microstate<B, S, C>) -> f64 {
+    fn total_energy(&self, microstate: &Microstate<V, B, S, C>) -> f64 {
         microstate
             .sites()
             .iter()
@@ -172,7 +172,7 @@ mod tests {
     }
 
     #[fixture]
-    fn microstate() -> Microstate<Point<Cartesian<2>>, Point<Cartesian<2>>, Open> {
+    fn microstate() -> Microstate<Cartesian<2>, Point<Cartesian<2>>, Point<Cartesian<2>>, Open> {
         let mut microstate = Microstate::new();
         microstate
             .try_extend_bodies([
@@ -184,7 +184,9 @@ mod tests {
     }
 
     #[rstest]
-    fn single_total(microstate: Microstate<Point<Cartesian<2>>, Point<Cartesian<2>>, Open>) {
+    fn single_total(
+        microstate: Microstate<Cartesian<2>, Point<Cartesian<2>>, Point<Cartesian<2>>, Open>,
+    ) {
         let test_se = TestSE;
         let single = Single(test_se);
 
@@ -192,7 +194,9 @@ mod tests {
     }
 
     #[rstest]
-    fn single_site(microstate: Microstate<Point<Cartesian<2>>, Point<Cartesian<2>>, Open>) {
+    fn single_site(
+        microstate: Microstate<Cartesian<2>, Point<Cartesian<2>>, Point<Cartesian<2>>, Open>,
+    ) {
         let test_se = TestSE;
         let single = Single(test_se);
 

--- a/hoomd-interaction/src/lib.rs
+++ b/hoomd-interaction/src/lib.rs
@@ -179,7 +179,7 @@ mod tests {
                 Body::point(Cartesian::from([1.0, 0.0])),
                 Body::point(Cartesian::from([-1.0, 3.0])),
             ])
-            .expect("valid bodies");
+            .expect("hard-coded bodies should be in the boundary");
         microstate
     }
 

--- a/hoomd-interaction/src/pairwise/angular_mask.rs
+++ b/hoomd-interaction/src/pairwise/angular_mask.rs
@@ -166,7 +166,7 @@ use std::f64::consts::PI;
 let boxcar = Boxcar::new(-1.0, 1.0, 1.5);
 
 let mask = [Patch::new(
-    [0.0, 0.0, 1.0].try_into().expect("hard-coded vector should have non-zero length"),
+    [0.0, 0.0, 1.0].try_into()?,
     (PI / 8.0).cos(),
 )];
 let (x_axis, _) = Cartesian::from([1.0, 0.0, 0.0]).to_unit_unchecked();

--- a/hoomd-interaction/src/pairwise/angular_mask.rs
+++ b/hoomd-interaction/src/pairwise/angular_mask.rs
@@ -166,7 +166,7 @@ use std::f64::consts::PI;
 let boxcar = Boxcar::new(-1.0, 1.0, 1.5);
 
 let mask = [Patch::new(
-    [0.0, 0.0, 1.0].try_into().expect("valid unit vector"),
+    [0.0, 0.0, 1.0].try_into().expect("hard-coded vector should have non-zero length"),
     (PI / 8.0).cos(),
 )];
 let (x_axis, _) = Cartesian::from([1.0, 0.0, 0.0]).to_unit_unchecked();
@@ -292,7 +292,9 @@ mod tests {
 
         // First case: identical directors in the +x direction
         let mask = [Patch::new(
-            [1.0, 0.0].try_into().expect("valid unit vector"),
+            [1.0, 0.0]
+                .try_into()
+                .expect("hard-coded vector should have non-zero length"),
             (PI / 8.0).cos(),
         )];
         let angular_mask = AngularMask::new(boxcar, mask, mask);
@@ -338,7 +340,9 @@ mod tests {
 
         // Second case: identical directors in the 1,1 direction
         let mask = [Patch::new(
-            [1.0, 1.0].try_into().expect("valid unit vector"),
+            [1.0, 1.0]
+                .try_into()
+                .expect("hard-coded vector should have non-zero length"),
             (PI / 3.0).cos(),
         )];
         let angular_mask = AngularMask::new(boxcar, mask, mask);
@@ -412,29 +416,41 @@ mod tests {
         // Third case: multiple patches and different i,j masks.
         let mask_i = [
             Patch::new(
-                [0.0, 1.0].try_into().expect("valid unit vector"),
+                [0.0, 1.0]
+                    .try_into()
+                    .expect("hard-coded vector should have non-zero length"),
                 (PI / 8.0).cos(),
             ),
             Patch::new(
-                [0.0, -1.0].try_into().expect("valid unit vector"),
+                [0.0, -1.0]
+                    .try_into()
+                    .expect("hard-coded vector should have non-zero length"),
                 (PI / 8.0).cos(),
             ),
             Patch::new(
-                [1.0, 0.0].try_into().expect("valid unit vector"),
+                [1.0, 0.0]
+                    .try_into()
+                    .expect("hard-coded vector should have non-zero length"),
                 (PI / 8.0).cos(),
             ),
             Patch::new(
-                [-1.0, 0.0].try_into().expect("valid unit vector"),
+                [-1.0, 0.0]
+                    .try_into()
+                    .expect("hard-coded vector should have non-zero length"),
                 (PI / 8.0).cos(),
             ),
         ];
         let mask_j = [
             Patch::new(
-                [0.0, 1.0].try_into().expect("valid unit vector"),
+                [0.0, 1.0]
+                    .try_into()
+                    .expect("hard-coded vector should have non-zero length"),
                 (PI / 8.0).cos(),
             ),
             Patch::new(
-                [0.0, -1.0].try_into().expect("valid unit vector"),
+                [0.0, -1.0]
+                    .try_into()
+                    .expect("hard-coded vector should have non-zero length"),
                 (PI / 8.0).cos(),
             ),
         ];
@@ -450,7 +466,9 @@ mod tests {
         let lj: LennardJones = LennardJones::new(epsilon, sigma);
 
         let mask = [Patch::new(
-            [1.0, 0.0].try_into().expect("valid unit vector"),
+            [1.0, 0.0]
+                .try_into()
+                .expect("hard-coded vector should have non-zero length"),
             (PI).cos(),
         )];
         let angular_mask = AngularMask::new(lj, mask, mask);
@@ -476,7 +494,9 @@ mod tests {
 
         // First case: identical directors in the +z direction
         let mask = [Patch::new(
-            [0.0, 0.0, 1.0].try_into().expect("valid unit vector"),
+            [0.0, 0.0, 1.0]
+                .try_into()
+                .expect("hard-coded vector should have non-zero length"),
             (PI / 8.0).cos(),
         )];
         let angular_mask = AngularMask::new(boxcar, mask, mask);

--- a/hoomd-mc/Cargo.toml
+++ b/hoomd-mc/Cargo.toml
@@ -26,3 +26,4 @@ approx.workspace = true
 divan.workspace = true
 rstest.workspace = true
 rand.workspace = true
+ratatui = "0.28.0"

--- a/hoomd-mc/examples/free-fall.rs
+++ b/hoomd-mc/examples/free-fall.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let d = 0.1;
 
     let translate = Translate::new(d.try_into()?);
-    let translate_sweep = Sweep::new(translate);
+    let translate_sweep = Sweep { local: translate };
 
     for _ in 0..100_000 {
         translate_sweep.apply(&mut microstate, &hamiltonian, &kt);

--- a/hoomd-mc/examples/free-fall.rs
+++ b/hoomd-mc/examples/free-fall.rs
@@ -11,7 +11,7 @@ use hoomd_vector::Cartesian;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut microstate = Microstate::new();
-    microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
+    microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])))?;
 
     let kt = 1.0;
     let hamiltonian = Single(Linear {

--- a/hoomd-mc/examples/random-walk.rs
+++ b/hoomd-mc/examples/random-walk.rs
@@ -39,7 +39,7 @@ fn run(mut terminal: DefaultTerminal) -> Result<(), Box<dyn std::error::Error>> 
     let hamiltonian = Zero;
     let d = 0.1;
 
-    let translate = Translate::new(d.try_into().expect("positive real"));
+    let translate = Translate::new(d.try_into().expect("hard-coded value should be positive"));
     let translate_sweep = Sweep { local: translate };
 
     loop {

--- a/hoomd-mc/examples/random-walk.rs
+++ b/hoomd-mc/examples/random-walk.rs
@@ -40,7 +40,7 @@ fn run(mut terminal: DefaultTerminal) -> Result<(), Box<dyn std::error::Error>> 
     let d = 0.1;
 
     let translate = Translate::new(d.try_into().expect("positive real"));
-    let translate_sweep = Sweep::new(translate);
+    let translate_sweep = Sweep { local: translate };
 
     loop {
         terminal.draw(|frame| render(frame, &microstate))?;

--- a/hoomd-mc/examples/random-walk.rs
+++ b/hoomd-mc/examples/random-walk.rs
@@ -4,13 +4,34 @@
 */
 
 use hoomd_mc::{Sweep, Translate, Trial, Zero};
-use hoomd_microstate::property::Position;
-use hoomd_microstate::{Body, Microstate};
+use hoomd_microstate::{Body, Microstate, MicrostateBuilder, boundary::Square, property::Point};
 use hoomd_vector::Cartesian;
 
+use ratatui::{
+    crossterm::event::{self, Event, poll},
+    layout::{Flex, Layout},
+    style::Color,
+    symbols::Marker,
+    widgets::{
+        Block,
+        canvas::{Canvas, Circle},
+    },
+    {DefaultTerminal, Frame},
+};
+use std::time::Duration;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut microstate = Microstate::new();
-    microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])))?;
+    let terminal = ratatui::init();
+    let result = run(terminal);
+    ratatui::restore();
+    result
+}
+
+/// Run the simulation
+fn run(mut terminal: DefaultTerminal) -> Result<(), Box<dyn std::error::Error>> {
+    let mut microstate = MicrostateBuilder::with_boundary(Square { l: 10.0 })
+        .bodies([Body::point(Cartesian::from([0.0, 0.0]))])
+        .try_build()?;
 
     let kt = 1.0;
     let hamiltonian = Zero;
@@ -19,11 +40,43 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let translate = Translate::new(d.try_into().expect("positive real"));
     let translate_sweep = Sweep::new(translate);
 
-    for _ in 0..100_000 {
+    loop {
+        terminal.draw(|frame| render(frame, &microstate))?;
+
+        if poll(Duration::from_millis(0))? && matches!(event::read()?, Event::Key(_)) {
+            break Ok(());
+        }
+
         translate_sweep.apply(&mut microstate, &hamiltonian, &kt);
-        println!("{}", microstate.bodies()[0].item.properties.position());
         microstate.increment_step();
     }
+}
 
-    Ok(())
+/// Render the system state.
+fn render(
+    frame: &mut Frame,
+    microstate: &Microstate<Cartesian<2>, Point<Cartesian<2>>, Point<Cartesian<2>>, Square>,
+) {
+    let properties = &microstate.bodies()[0].item.properties;
+
+    let l = microstate.boundary().l;
+
+    let canvas = Canvas::default()
+        .block(Block::bordered().title("Bounded random walk"))
+        .marker(Marker::Braille)
+        .paint(|ctx| {
+            ctx.draw(&Circle {
+                x: properties.position[0],
+                y: properties.position[1],
+                radius: 0.5,
+                color: Color::Yellow,
+            });
+        })
+        .x_bounds([-l / 2.0, l / 2.0])
+        .y_bounds([-l / 2.0, l / 2.0]);
+
+    let horizontal = Layout::horizontal([frame.area().height * 2]).flex(Flex::Center);
+    let [area] = horizontal.areas(frame.area());
+
+    frame.render_widget(canvas, area);
 }

--- a/hoomd-mc/examples/random-walk.rs
+++ b/hoomd-mc/examples/random-walk.rs
@@ -29,9 +29,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 /// Run the simulation
 fn run(mut terminal: DefaultTerminal) -> Result<(), Box<dyn std::error::Error>> {
-    let mut microstate = MicrostateBuilder::with_boundary(Square { l: 10.0 })
-        .bodies([Body::point(Cartesian::from([0.0, 0.0]))])
-        .try_build()?;
+    let mut microstate = MicrostateBuilder::with_boundary(Square {
+        l: 10.0.try_into()?,
+    })
+    .bodies([Body::point(Cartesian::from([0.0, 0.0]))])
+    .try_build()?;
 
     let kt = 1.0;
     let hamiltonian = Zero;
@@ -59,7 +61,7 @@ fn render(
 ) {
     let properties = &microstate.bodies()[0].item.properties;
 
-    let l = microstate.boundary().l;
+    let l = microstate.boundary().l.get();
 
     let canvas = Canvas::default()
         .block(Block::bordered().title("Bounded random walk"))

--- a/hoomd-mc/examples/random-walk.rs
+++ b/hoomd-mc/examples/random-walk.rs
@@ -8,9 +8,9 @@ use hoomd_microstate::property::Position;
 use hoomd_microstate::{Body, Microstate};
 use hoomd_vector::Cartesian;
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut microstate = Microstate::new();
-    microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
+    microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])))?;
 
     let kt = 1.0;
     let hamiltonian = Zero;
@@ -24,4 +24,6 @@ fn main() {
         println!("{}", microstate.bodies()[0].item.properties.position());
         microstate.increment_step();
     }
+
+    Ok(())
 }

--- a/hoomd-mc/src/external.rs
+++ b/hoomd-mc/src/external.rs
@@ -6,12 +6,14 @@
 
 use super::DeltaEnergyOne;
 use hoomd_interaction::{Single, SiteEnergy};
-use hoomd_microstate::{Body, Microstate, Transform};
+use hoomd_microstate::{Body, boundary::Boundary, Microstate, Transform, property::Position};
 
 impl<V, B, S, C, E> DeltaEnergyOne<V, B, S, C> for Single<E>
 where
     E: SiteEnergy<S>,
     B: Transform<S>,
+    S: Position<V>,
+    C: Boundary<V, B, S>,
 {
     #[inline]
     fn delta_energy_one(
@@ -20,17 +22,59 @@ where
         body_index: usize,
         final_body: &Body<B, S>,
     ) -> f64 {
-        let energy_final = final_body.sites.iter().fold(0.0, |total, s| {
-            let new_site = final_body.properties.transform(s);
-            // TODO: boundary conditions
-            // TODO: What is the energy if a site cannot be wrapped? infinite?
-            total + self.site_energy(&new_site)
-        });
+        let mut energy_final = 0.0;
+        for s in &final_body.sites {
+            match initial_microstate.boundary().wrap_site(final_body.properties.transform(s)) {
+                Ok(wrapped_site) => energy_final += self.site_energy(&wrapped_site),
+                Err(_) => return f64::INFINITY
+            }
+        }
 
         let energy_initial = initial_microstate
             .iter_body_sites(body_index)
             .fold(0.0, |total, s| total + self.site_energy(&s.properties));
 
         energy_final - energy_initial
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hoomd_microstate::{boundary::Square, property::Point, MicrostateBuilder};
+    use hoomd_vector::Cartesian;
+
+    struct Zero;
+
+    impl SiteEnergy<Point<Cartesian<2>>> for Zero {
+        fn site_energy(&self, _site_properties: &Point<Cartesian<2>>) -> f64 {
+            0.0
+        }
+    }
+
+    #[test]
+    fn site_outside() {
+        let square = Square {
+            l: 4.0
+                .try_into()
+                .expect("hard-coded constant should be positive"),
+        };
+
+        let body = Body {
+            properties: Point::new(Cartesian::from([0.0, 0.0])),
+            sites: [Point::new(Cartesian::from([1.0, 0.0]))].into(),
+        };
+        let mut final_body = body.clone();
+        final_body.properties.position[0] = 1.0;
+        
+        let microstate = MicrostateBuilder::with_boundary(square)
+            .bodies([body])
+            .try_build()
+            .expect("the hard-coded bodies should be in the boundary");
+
+        let energy = Single(Zero);
+
+        assert_eq!(energy.delta_energy_one(&microstate, 0, &final_body), f64::INFINITY);
+
     }
 }

--- a/hoomd-mc/src/external.rs
+++ b/hoomd-mc/src/external.rs
@@ -8,7 +8,7 @@ use super::DeltaEnergyOne;
 use hoomd_interaction::{Single, SiteEnergy};
 use hoomd_microstate::{Body, Microstate, Transform};
 
-impl<B, S, C, E> DeltaEnergyOne<B, S, C> for Single<E>
+impl<V, B, S, C, E> DeltaEnergyOne<V, B, S, C> for Single<E>
 where
     E: SiteEnergy<S>,
     B: Transform<S>,
@@ -16,7 +16,7 @@ where
     #[inline]
     fn delta_energy_one(
         &self,
-        initial_microstate: &Microstate<B, S, C>,
+        initial_microstate: &Microstate<V, B, S, C>,
         body_index: usize,
         final_body: &Body<B, S>,
     ) -> f64 {

--- a/hoomd-mc/src/external.rs
+++ b/hoomd-mc/src/external.rs
@@ -6,7 +6,7 @@
 
 use super::DeltaEnergyOne;
 use hoomd_interaction::{Single, SiteEnergy};
-use hoomd_microstate::{Body, boundary::Boundary, Microstate, Transform, property::Position};
+use hoomd_microstate::{Body, Microstate, Transform, boundary::Boundary, property::Position};
 
 impl<V, B, S, C, E> DeltaEnergyOne<V, B, S, C> for Single<E>
 where
@@ -24,9 +24,12 @@ where
     ) -> f64 {
         let mut energy_final = 0.0;
         for s in &final_body.sites {
-            match initial_microstate.boundary().wrap_site(final_body.properties.transform(s)) {
+            match initial_microstate
+                .boundary()
+                .wrap_site(final_body.properties.transform(s))
+            {
                 Ok(wrapped_site) => energy_final += self.site_energy(&wrapped_site),
-                Err(_) => return f64::INFINITY
+                Err(_) => return f64::INFINITY,
             }
         }
 
@@ -41,7 +44,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hoomd_microstate::{boundary::Square, property::Point, MicrostateBuilder};
+    use hoomd_microstate::{MicrostateBuilder, boundary::Square, property::Point};
     use hoomd_vector::Cartesian;
 
     struct Zero;
@@ -66,7 +69,7 @@ mod tests {
         };
         let mut final_body = body.clone();
         final_body.properties.position[0] = 1.0;
-        
+
         let microstate = MicrostateBuilder::with_boundary(square)
             .bodies([body])
             .try_build()
@@ -74,7 +77,9 @@ mod tests {
 
         let energy = Single(Zero);
 
-        assert_eq!(energy.delta_energy_one(&microstate, 0, &final_body), f64::INFINITY);
-
+        assert_eq!(
+            energy.delta_energy_one(&microstate, 0, &final_body),
+            f64::INFINITY
+        );
     }
 }

--- a/hoomd-mc/src/lib.rs
+++ b/hoomd-mc/src/lib.rs
@@ -140,7 +140,7 @@ use hoomd_vector::Cartesian;
 let mut microstate = Microstate::new();
 microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
 let d = 0.1;
-let translate_sweep = Sweep::new(Translate::new(d.try_into()?));
+let translate_sweep = Sweep{ local: Translate::new(d.try_into()?) };
 
 let mut count = Count::default();
 

--- a/hoomd-mc/src/lib.rs
+++ b/hoomd-mc/src/lib.rs
@@ -81,7 +81,7 @@ Some implementations of [`Trial`] apply to a single body at a time and use a
 Hamiltonian that implements `DeltaEnergyOne` to efficiently compute the change
 in energy.
 */
-pub trait DeltaEnergyOne<B, S, C> {
+pub trait DeltaEnergyOne<V, B, S, C> {
     /** Compute the change in energy.
 
     `initial_microstate` describes the initial configuration and `final_body`
@@ -96,7 +96,7 @@ pub trait DeltaEnergyOne<B, S, C> {
     #[must_use]
     fn delta_energy_one(
         &self,
-        initial_microstate: &Microstate<B, S, C>,
+        initial_microstate: &Microstate<V, B, S, C>,
         body_index: usize,
         final_body: &Body<B, S>,
     ) -> f64;
@@ -109,11 +109,11 @@ It returns 0 for all delta energies.
 */
 pub struct Zero;
 
-impl<B, S, C> DeltaEnergyOne<B, S, C> for Zero {
+impl<V, B, S, C> DeltaEnergyOne<V, B, S, C> for Zero {
     #[inline]
     fn delta_energy_one(
         &self,
-        _initial_microstate: &Microstate<B, S, C>,
+        _initial_microstate: &Microstate<V, B, S, C>,
         _body_index: usize,
         _final_body: &Body<B, S>,
     ) -> f64 {

--- a/hoomd-mc/src/sweep.rs
+++ b/hoomd-mc/src/sweep.rs
@@ -45,10 +45,6 @@ for _ in 0..1_000 {
 # }
 ```
 */
-#[expect(
-    clippy::partial_pub_fields,
-    reason = "Users do not need to be aware of phantom data."
-)]
 pub struct Sweep<L> {
     /// The local trial to apply.
     pub local: L,

--- a/hoomd-mc/src/sweep.rs
+++ b/hoomd-mc/src/sweep.rs
@@ -207,11 +207,15 @@ mod tests {
 
     #[test]
     fn reject_boundary_body() {
-        let square = Square { l: 4.0 };
+        let square = Square {
+            l: 4.0
+                .try_into()
+                .expect("hard-coded constant should be positive"),
+        };
         let mut microstate = MicrostateBuilder::with_boundary(square)
             .bodies([Body::point([0.0, 0.0].into())])
             .try_build()
-            .expect("the hard-coded bodies should be in the boundary.");
+            .expect("the hard-coded bodies should be in the boundary");
         let hamiltonian = Zero;
         let translate = Right;
         let translate_sweep = Sweep::new(translate);
@@ -235,11 +239,15 @@ mod tests {
             sites: [Point::new(Cartesian::from([1.0, 0.0]))].into(),
         };
 
-        let square = Square { l: 6.0 };
+        let square = Square {
+            l: 6.0
+                .try_into()
+                .expect("hard-coded constant should be positive"),
+        };
         let mut microstate = MicrostateBuilder::with_boundary(square)
             .bodies([body])
             .try_build()
-            .expect("the hard-coded bodies should be in the boundary.");
+            .expect("the hard-coded bodies should be in the boundary");
         let hamiltonian = Zero;
         let translate = Right;
         let translate_sweep = Sweep::new(translate);

--- a/hoomd-mc/src/sweep.rs
+++ b/hoomd-mc/src/sweep.rs
@@ -47,6 +47,10 @@ for _ in 0..1_000 {
 # }
 ```
 */
+#[expect(
+    clippy::partial_pub_fields,
+    reason = "Users do not need to be aware of phantom data."
+)]
 pub struct Sweep<L, V> {
     /// The local trial to apply.
     pub local: L,
@@ -67,13 +71,13 @@ impl<L, V> Sweep<L, V> {
     }
 }
 
-impl<B, S, C, L, H, V> Trial<Microstate<B, S, C>, H> for Sweep<L, V>
+impl<V, B, S, C, L, H> Trial<Microstate<V, B, S, C>, H> for Sweep<L, V>
 where
     B: Copy + Clone + Default + Transform<S> + Position<V>,
     S: Clone + Default + Position<V>,
     L: LocalTrial<B>,
-    H: DeltaEnergyOne<B, S, C>,
-    C: Boundary<V>,
+    H: DeltaEnergyOne<V, B, S, C>,
+    C: Boundary<V, B, S>,
 {
     type Count = Count;
     type Macrostate = f64;
@@ -81,7 +85,7 @@ where
     #[inline]
     fn apply(
         &self,
-        microstate: &mut Microstate<B, S, C>,
+        microstate: &mut Microstate<V, B, S, C>,
         hamiltonian: &H,
         state: &Self::Macrostate,
     ) -> Self::Count where {
@@ -103,7 +107,7 @@ where
             // energy and update methods.
             match microstate
                 .boundary()
-                .wrap(self.local.propose(&mut rng, trial.properties))
+                .wrap_body(self.local.propose(&mut rng, trial.properties))
             {
                 Ok(new_properties) => {
                     trial.properties = new_properties;

--- a/hoomd-mc/src/sweep.rs
+++ b/hoomd-mc/src/sweep.rs
@@ -10,9 +10,8 @@ use hoomd_microstate::property::Position;
 use hoomd_microstate::{Body, Microstate, Transform};
 
 use rand::Rng;
-use std::marker::PhantomData;
 
-/** Apply a local trial move to every body in the microstate.
+/** Apply a local trial move to each body in the microstate.
 
 Each trial move is accepted when:
 <!-- r < \exp\left(\frac{-\Delta H}{kT}\right) -->
@@ -20,7 +19,6 @@ Each trial move is accepted when:
 where `r` is a random value uniformly distributed in `[0,1)`, `\Delta H` is
 the change in energy computed by the given `hamiltonian` and `kT` is the given
 `state` value (the last argument to `apply`).
-
 
 # Example
 
@@ -34,7 +32,7 @@ use hoomd_vector::Cartesian;
 let mut microstate = Microstate::new();
 microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
 let d = 0.1;
-let translate_sweep = Sweep::new(Translate::new(d.try_into()?));
+let translate_sweep = Sweep { local: Translate::new(d.try_into()?) };
 
 let hamiltonian = Zero;
 let kt = 1.0;
@@ -51,27 +49,21 @@ for _ in 0..1_000 {
     clippy::partial_pub_fields,
     reason = "Users do not need to be aware of phantom data."
 )]
-pub struct Sweep<L, V> {
+pub struct Sweep<L> {
     /// The local trial to apply.
     pub local: L,
-
-    /// Make sweep depend on the vector type V even though it doesn't store a vector.
-    vector_type: PhantomData<V>,
 }
 
-impl<L, V> Sweep<L, V> {
+impl<L> Sweep<L> {
     /// Construct a new `Sweep` with the given local trial.
     #[inline]
     #[must_use]
     pub fn new(local: L) -> Self {
-        Self {
-            local,
-            vector_type: PhantomData,
-        }
+        Self { local }
     }
 }
 
-impl<V, B, S, C, L, H> Trial<Microstate<V, B, S, C>, H> for Sweep<L, V>
+impl<V, B, S, C, L, H> Trial<Microstate<V, B, S, C>, H> for Sweep<L>
 where
     B: Copy + Clone + Default + Transform<S> + Position<V>,
     S: Clone + Default + Position<V>,
@@ -183,7 +175,7 @@ mod tests {
 
         let d = 0.1;
         let translate = Translate::new(d.try_into().expect("positive real"));
-        let translate_sweep = Sweep::new(translate);
+        let translate_sweep = Sweep { local: translate };
 
         let mut position_accumulator = Cartesian::default();
         let mut energy_accumulator = 0.0;
@@ -218,7 +210,7 @@ mod tests {
             .expect("the hard-coded bodies should be in the boundary");
         let hamiltonian = Zero;
         let translate = Right;
-        let translate_sweep = Sweep::new(translate);
+        let translate_sweep = Sweep { local: translate };
 
         // The first move to the right ends in the boundary and should be accepted.
         let counter = translate_sweep.apply(&mut microstate, &hamiltonian, &1.0);
@@ -250,7 +242,7 @@ mod tests {
             .expect("the hard-coded bodies should be in the boundary");
         let hamiltonian = Zero;
         let translate = Right;
-        let translate_sweep = Sweep::new(translate);
+        let translate_sweep = Sweep { local: translate };
 
         // The first move to the right ends in the boundary and should be accepted.
         let counter = translate_sweep.apply(&mut microstate, &hamiltonian, &1.0);

--- a/hoomd-mc/src/sweep.rs
+++ b/hoomd-mc/src/sweep.rs
@@ -166,11 +166,14 @@ mod tests {
         let mut microstate = Microstate::new();
         microstate
             .add_body(Body::point(origin))
-            .expect("valid body");
+            .expect("the hard-coded body should be inside the boundary");
         let hamiltonian = Single(Harmonic(origin));
 
         let d = 0.1;
-        let translate = Translate::new(d.try_into().expect("positive real"));
+        let translate = Translate::new(
+            d.try_into()
+                .expect("hard-coded constant should be positive"),
+        );
         let translate_sweep = Sweep { local: translate };
 
         let mut position_accumulator = Cartesian::default();

--- a/hoomd-mc/src/sweep.rs
+++ b/hoomd-mc/src/sweep.rs
@@ -5,8 +5,12 @@
 */
 
 use super::{Count, DeltaEnergyOne, LocalTrial, Trial};
+use hoomd_microstate::boundary::Boundary;
+use hoomd_microstate::property::Position;
 use hoomd_microstate::{Body, Microstate, Transform};
+
 use rand::Rng;
+use std::marker::PhantomData;
 
 /** Apply a local trial move to every body in the microstate.
 
@@ -43,26 +47,33 @@ for _ in 0..1_000 {
 # }
 ```
 */
-pub struct Sweep<L> {
+pub struct Sweep<L, V> {
     /// The local trial to apply.
     pub local: L,
+
+    /// Make sweep depend on the vector type V even though it doesn't store a vector.
+    vector_type: PhantomData<V>,
 }
 
-impl<L> Sweep<L> {
+impl<L, V> Sweep<L, V> {
     /// Construct a new `Sweep` with the given local trial.
     #[inline]
     #[must_use]
     pub fn new(local: L) -> Self {
-        Self { local }
+        Self {
+            local,
+            vector_type: PhantomData,
+        }
     }
 }
 
-impl<B, S, C, L, H> Trial<Microstate<B, S, C>, H> for Sweep<L>
+impl<B, S, C, L, H, V> Trial<Microstate<B, S, C>, H> for Sweep<L, V>
 where
-    B: Copy + Clone + Default + Transform<S>,
-    S: Clone + Default,
+    B: Copy + Clone + Default + Transform<S> + Position<V>,
+    S: Clone + Default + Position<V>,
     L: LocalTrial<B>,
     H: DeltaEnergyOne<B, S, C>,
+    C: Boundary<V>,
 {
     type Count = Count;
     type Macrostate = f64;
@@ -83,16 +94,32 @@ where
         // The call to `update_body_properties` makes a mutable borrow of microstate.
         for body_index in 0..microstate.bodies().len() {
             trial.clone_from(&microstate.bodies()[body_index].item);
-            trial.properties = self.local.propose(&mut rng, trial.properties);
 
-            // TODO: Handle boundary conditions
+            // Wrap the body position here. The site positions will be wrapped
+            // by the delta_energy methods and again by update_body_properties.
+            // We could early reject if we checked the site properties first. If
+            // performance becomes an issue, we could also wrap site properties
+            // once here and pass those to unchecked variants of the delta
+            // energy and update methods.
+            match microstate
+                .boundary()
+                .wrap(self.local.propose(&mut rng, trial.properties))
+            {
+                Ok(new_properties) => {
+                    trial.properties = new_properties;
 
-            let delta_h = hamiltonian.delta_energy_one(microstate, body_index, &trial);
-            if rng.random::<f64>() < (-delta_h / kt).exp() {
-                microstate.update_body_properties(body_index, trial.properties);
-                count.accepted += 1;
-            } else {
-                count.rejected += 1;
+                    let delta_h = hamiltonian.delta_energy_one(microstate, body_index, &trial);
+                    if rng.random::<f64>() < (-delta_h / kt).exp()
+                        && microstate
+                            .update_body_properties(body_index, trial.properties)
+                            .is_ok()
+                    {
+                        count.accepted += 1;
+                    } else {
+                        count.rejected += 1;
+                    }
+                }
+                Err(_) => count.rejected += 1,
             }
         }
 

--- a/hoomd-mc/src/sweep.rs
+++ b/hoomd-mc/src/sweep.rs
@@ -132,7 +132,9 @@ mod tests {
         let origin = Cartesian::from([1.0, -2.0]);
 
         let mut microstate = Microstate::new();
-        microstate.add_body(Body::point(origin));
+        microstate
+            .add_body(Body::point(origin))
+            .expect("valid body");
         let hamiltonian = Single(Harmonic(origin));
 
         let d = 0.1;

--- a/hoomd-mc/src/sweep.rs
+++ b/hoomd-mc/src/sweep.rs
@@ -135,10 +135,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Translate;
+    use crate::{Translate, Zero};
     use ::approx::assert_relative_eq;
     use hoomd_interaction::{Single, SiteEnergy, TotalEnergy};
-    use hoomd_microstate::property::Point;
+    use hoomd_microstate::{MicrostateBuilder, boundary::Square, property::Point};
     use hoomd_vector::{Cartesian, Vector};
     use rstest::*;
 
@@ -150,6 +150,19 @@ mod tests {
     impl SiteEnergy<Point<Cartesian<2>>> for Harmonic {
         fn site_energy(&self, site_properties: &Point<Cartesian<2>>) -> f64 {
             1.0 / 2.0 * K * (site_properties.position - self.0).norm_squared()
+        }
+    }
+
+    struct Right;
+    impl LocalTrial<Point<Cartesian<2>>> for Right {
+        fn propose<R: Rng>(
+            &self,
+            _rng: &mut R,
+            body_properties: Point<Cartesian<2>>,
+        ) -> Point<Cartesian<2>> {
+            let mut trial = body_properties;
+            trial.position_mut()[0] += 1.0;
+            trial
         }
     }
 
@@ -190,5 +203,56 @@ mod tests {
 
         let energy_average = energy_accumulator / (N_STEPS as f64);
         assert_relative_eq!(energy_average, kt, epsilon = EPSILON);
+    }
+
+    #[test]
+    fn reject_boundary_body() {
+        let square = Square { l: 4.0 };
+        let mut microstate = MicrostateBuilder::with_boundary(square)
+            .bodies([Body::point([0.0, 0.0].into())])
+            .try_build()
+            .expect("the hard-coded bodies should be in the boundary.");
+        let hamiltonian = Zero;
+        let translate = Right;
+        let translate_sweep = Sweep::new(translate);
+
+        // The first move to the right ends in the boundary and should be accepted.
+        let counter = translate_sweep.apply(&mut microstate, &hamiltonian, &1.0);
+        assert_eq!(counter.accepted, 1);
+        assert_eq!(counter.rejected, 0);
+
+        // The second move to the right places the body just on the boundary and should be
+        // rejected.
+        let counter = translate_sweep.apply(&mut microstate, &hamiltonian, &1.0);
+        assert_eq!(counter.accepted, 0);
+        assert_eq!(counter.rejected, 1);
+    }
+
+    #[test]
+    fn reject_boundary_site() {
+        let body = Body {
+            properties: Point::new(Cartesian::from([0.0, 0.0])),
+            sites: [Point::new(Cartesian::from([1.0, 0.0]))].into(),
+        };
+
+        let square = Square { l: 6.0 };
+        let mut microstate = MicrostateBuilder::with_boundary(square)
+            .bodies([body])
+            .try_build()
+            .expect("the hard-coded bodies should be in the boundary.");
+        let hamiltonian = Zero;
+        let translate = Right;
+        let translate_sweep = Sweep::new(translate);
+
+        // The first move to the right ends in the boundary and should be accepted.
+        let counter = translate_sweep.apply(&mut microstate, &hamiltonian, &1.0);
+        assert_eq!(counter.accepted, 1);
+        assert_eq!(counter.rejected, 0);
+
+        // The second move to the right places the body just on the boundary and should be
+        // rejected.
+        let counter = translate_sweep.apply(&mut microstate, &hamiltonian, &1.0);
+        assert_eq!(counter.accepted, 0);
+        assert_eq!(counter.rejected, 1);
     }
 }

--- a/hoomd-mc/src/translate.rs
+++ b/hoomd-mc/src/translate.rs
@@ -121,7 +121,10 @@ mod tests {
 
         let mut rng = StdRng::seed_from_u64(1);
         let a = Point::new(Cartesian::from([1.0, -5.0, 2.5]));
-        let translate = Translate::new(d.try_into().expect("positive real"));
+        let translate = Translate::new(
+            d.try_into()
+                .expect("hard-coded constant should be a positive real"),
+        );
 
         for _ in 0..N {
             let b = translate.propose(&mut rng, a);

--- a/hoomd-microstate/ARCHITECTURE.md
+++ b/hoomd-microstate/ARCHITECTURE.md
@@ -231,7 +231,24 @@ scale with the number of neighbors.
 
 ## Boundary conditions
 
-TODO
+The microstate's **boundary** defines a subset of the vector space that contains
+all body and site positions. This boundary *may* be periodic, but does not
+necessarily need to tile space. A `Boundary` type expresses this interface via
+these methods:
+
+* `is_inside` - test if a point is inside the boundary.
+* `wrap` - wrap any site/body properties into the boundary.
+* TODO: Additional methods to generate ghost particles (possibly including
+  a `distance_to` - but what would that return for open boundaries?).
+
+`wrap` is fallible. It returns `None` when it is not possible to wrap the given
+properties into the boundary. It takes a properties type to enable use-cases
+where wrapping applies operations other than translation. For example, a twisted
+cylinder.
+
+The TBD methods allow callers to generate ghost sites outside, but within a
+defined distance range, to the edge of the boundary. The ghost sites facilitate
+pairwise interactions across periodic boundaries.
 
 ## Body storage
 

--- a/hoomd-microstate/ARCHITECTURE.md
+++ b/hoomd-microstate/ARCHITECTURE.md
@@ -241,7 +241,7 @@ these methods:
 * TODO: Additional methods to generate ghost particles (possibly including
   a `distance_to` - but what would that return for open boundaries?).
 
-`wrap` is fallible. It returns `None` when it is not possible to wrap the given
+`wrap` is fallible. It returns `Err` when it is not possible to wrap the given
 properties into the boundary. It takes a properties type to enable use-cases
 where wrapping applies operations other than translation. For example, a twisted
 cylinder.

--- a/hoomd-microstate/Cargo.toml
+++ b/hoomd-microstate/Cargo.toml
@@ -24,3 +24,4 @@ rand.workspace = true
 divan.workspace = true
 rstest.workspace = true
 approx.workspace = true
+anyhow.workspace = true

--- a/hoomd-microstate/Cargo.toml
+++ b/hoomd-microstate/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 [dependencies]
 hoomd-vector.workspace = true
 hoomd-utility.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/hoomd-microstate/examples/error.rs
+++ b/hoomd-microstate/examples/error.rs
@@ -1,0 +1,34 @@
+#![allow(clippy::print_stdout, reason = "Demonstration purposes")]
+
+/*! Demonstrate how to report unhandled errors.
+
+    Execute this example with `RUST_BACKTRACE=1 cargo run --example error` to see full
+    backtrace information.
+*/
+
+use hoomd_microstate::{Body, Microstate, MicrostateBuilder, boundary::Square, property::Point};
+use hoomd_vector::Cartesian;
+
+use anyhow::Context;
+
+/// Add an invalid body to the microstate.
+fn my_method(
+    microstate: &mut Microstate<Cartesian<2>, Point<Cartesian<2>>, Point<Cartesian<2>>, Square>,
+) -> anyhow::Result<()> {
+    microstate
+        .add_body(Body::point(Cartesian::from([5.0, 0.0])))
+        .context("Adding body in my_method")?;
+    Ok(())
+}
+
+fn main() -> anyhow::Result<()> {
+    let mut microstate = MicrostateBuilder::with_boundary(Square {
+        l: 10.0.try_into()?,
+    })
+    .bodies([Body::point(Cartesian::from([0.0, 0.0]))])
+    .try_build()?;
+
+    my_method(&mut microstate)?;
+
+    Ok(())
+}

--- a/hoomd-microstate/src/boundary.rs
+++ b/hoomd-microstate/src/boundary.rs
@@ -7,7 +7,7 @@ See the [crate-level documentation](crate) for an overview of how [`Boundary`]
 interacts with [`Microstate`](crate::Microstate) and model methods.
  */
 
-use crate::property::Position;
+use crate::{Error, property::Position};
 
 /** Define the subset of the vector space where body and site positions exist.
 
@@ -19,7 +19,7 @@ When implementing a custom [`Boundary`], you need to implement
 methods describe fully non-periodic boundary conditions. You can make your
 boundary periodic by implementing the other methods accordingly.
 */
-pub trait Boundary<V, P: Position<V>> {
+pub trait Boundary<V> {
     /// Test whether a given point is inside the boundary.
     fn is_inside(&self, point: &V) -> bool;
 
@@ -27,18 +27,24 @@ pub trait Boundary<V, P: Position<V>> {
 
     `wrap` takes a body/site with a position that may be outside the boundary.
     It attempts to wrap that body/site back inside following the boundary's
-    periodicity. `wrap` returns `Some(properties)` when this process is
-    successful.  When it fails `wrap` returns [`None`].
+    periodicity. `wrap` returns [`Ok(properties)`](Ok) when this process is
+    successful.
 
-    For example, [`None`] would be returned when a body's position is outside the
-    radius of a cylinder that is only periodic along its axis.
+    # Errors
+
+    `wrap` returns [`Error::CannotWrapPosition`] when it is not possible to wrap
+    the body/site into the boundary. For example, when the position is outside
+    the radius of a cylinder that is only periodic along its axis.
     */
     #[inline]
-    fn wrap(&self, properties: P) -> Option<P> {
+    fn wrap<P>(&self, properties: P) -> Result<P, Error>
+    where
+        P: Position<V>,
+    {
         if self.is_inside(properties.position()) {
-            Some(properties)
+            Ok(properties)
         } else {
-            None
+            Err(Error::CannotWrapPosition)
         }
     }
 }
@@ -50,10 +56,7 @@ Every point lies inside `Open` boundary conditions.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Open;
 
-impl<V, P> Boundary<V, P> for Open
-where
-    P: Position<V>,
-{
+impl<V> Boundary<V> for Open {
     #[inline]
     fn is_inside(&self, _point: &V) -> bool {
         true

--- a/hoomd-microstate/src/boundary.rs
+++ b/hoomd-microstate/src/boundary.rs
@@ -9,6 +9,12 @@ interacts with [`Microstate`](crate::Microstate) and model methods.
 
 use crate::{Error, property::Position};
 
+mod open;
+mod square;
+
+pub use open::Open;
+pub use square::Square;
+
 /** Define the subset of the vector space where body and site positions exist.
 
 A [`Boundary`] also describes how body and site properties transform from/to
@@ -37,7 +43,7 @@ pub trait Boundary<V, B, S> {
 
     # Errors
 
-    `wrap` returns [`Error::CannotWrapPosition`] when it is not possible to wrap
+    `wrap` returns [`Error::CannotWrapProperties`] when it is not possible to wrap
     the body into the boundary. For example, when the position is outside the
     radius of a cylinder that is only periodic along its axis.
     */
@@ -45,12 +51,11 @@ pub trait Boundary<V, B, S> {
     fn wrap_body(&self, body_properties: B) -> Result<B, Error>
     where
         B: Position<V>,
-        S: Position<V>,
     {
         if self.is_inside(body_properties.position()) {
             Ok(body_properties)
         } else {
-            Err(Error::CannotWrapPosition)
+            Err(Error::CannotWrapProperties)
         }
     }
 
@@ -63,34 +68,19 @@ pub trait Boundary<V, B, S> {
 
     # Errors
 
-    `wrap` returns [`Error::CannotWrapPosition`] when it is not possible to wrap
+    `wrap` returns [`Error::CannotWrapProperties`] when it is not possible to wrap
     the site into the boundary. For example, when the position is outside the
     radius of a cylinder that is only periodic along its axis.
     */
     #[inline]
     fn wrap_site(&self, site_properties: S) -> Result<S, Error>
     where
-        B: Position<V>,
         S: Position<V>,
     {
         if self.is_inside(site_properties.position()) {
             Ok(site_properties)
         } else {
-            Err(Error::CannotWrapPosition)
+            Err(Error::CannotWrapProperties)
         }
-    }
-}
-
-/** Allow bodies and sites to exist anywhere in space.
-
-Every point lies inside `Open` boundary conditions.
-*/
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Open;
-
-impl<V, B, S> Boundary<V, B, S> for Open {
-    #[inline]
-    fn is_inside(&self, _point: &V) -> bool {
-        true
     }
 }

--- a/hoomd-microstate/src/boundary.rs
+++ b/hoomd-microstate/src/boundary.rs
@@ -7,13 +7,28 @@ See the [crate-level documentation](crate) for an overview of how [`Boundary`]
 interacts with [`Microstate`](crate::Microstate) and model methods.
  */
 
-use crate::{Error, property::Position};
+use crate::property::Position;
+
+use thiserror::Error;
 
 mod open;
 mod square;
 
 pub use open::Open;
 pub use square::Square;
+
+/// Enumerate possible sources of error in fallible boundary methods.
+#[non_exhaustive]
+#[derive(Error, PartialEq, Debug)]
+pub enum Error {
+    /// Failed to wrap body properties.
+    #[error("body property cannot be wrapped")]
+    CannotWrapBodyProperties,
+
+    /// Failed to wrap site properties.
+    #[error("site property cannot be wrapped")]
+    CannotWrapSiteProperties,
+}
 
 /** Define the subset of the vector space where body and site positions exist.
 
@@ -43,9 +58,9 @@ pub trait Boundary<V, B, S> {
 
     # Errors
 
-    `wrap` returns [`Error::CannotWrapProperties`] when it is not possible to wrap
-    the body into the boundary. For example, when the position is outside the
-    radius of a cylinder that is only periodic along its axis.
+    `wrap` returns [`Error::CannotWrapBodyProperties`] when it is not possible
+    to wrap the body into the boundary. For example, when the position is
+    outside the radius of a cylinder that is only periodic along its axis.
     */
     #[inline]
     fn wrap_body(&self, body_properties: B) -> Result<B, Error>
@@ -55,7 +70,7 @@ pub trait Boundary<V, B, S> {
         if self.is_inside(body_properties.position()) {
             Ok(body_properties)
         } else {
-            Err(Error::CannotWrapProperties)
+            Err(Error::CannotWrapBodyProperties)
         }
     }
 
@@ -68,9 +83,9 @@ pub trait Boundary<V, B, S> {
 
     # Errors
 
-    `wrap` returns [`Error::CannotWrapProperties`] when it is not possible to wrap
-    the site into the boundary. For example, when the position is outside the
-    radius of a cylinder that is only periodic along its axis.
+    `wrap` returns [`Error::CannotWrapSiteProperties`] when it is not possible
+    to wrap the site into the boundary. For example, when the position is
+    outside the radius of a cylinder that is only periodic along its axis.
     */
     #[inline]
     fn wrap_site(&self, site_properties: S) -> Result<S, Error>
@@ -80,7 +95,7 @@ pub trait Boundary<V, B, S> {
         if self.is_inside(site_properties.position()) {
             Ok(site_properties)
         } else {
-            Err(Error::CannotWrapProperties)
+            Err(Error::CannotWrapSiteProperties)
         }
     }
 }

--- a/hoomd-microstate/src/boundary.rs
+++ b/hoomd-microstate/src/boundary.rs
@@ -2,19 +2,22 @@
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
 /*! Traits that describe boundary conditions and a selection of types that implement them.
+
+See the [crate-level documentation](crate) for an overview of how [`Boundary`]
+interacts with [`Microstate`](crate::Microstate) and model methods.
  */
 
 use crate::property::Position;
 
 /** Define the subset of the vector space where body and site positions exist.
 
-A `Boundary` also describes how body and site properties transform to periodic
-images. See the specific implementations of `Boundary` for examples.
+A [`Boundary`] also describes how body and site properties transform from/to
+periodic images. See the specific implementations of [`Boundary`] for examples.
 
-When implementing a custom `Boundary`, you need to implement `is_inside` at
-a minimum. The default implementations of the other methods describe fully
-non-periodic boundary conditions. You can make your boundary periodic by
-implementing the other methods accordingly.
+When implementing a custom [`Boundary`], you need to implement
+[`Boundary::is_inside`] at a minimum. The default implementations of the other
+methods describe fully non-periodic boundary conditions. You can make your
+boundary periodic by implementing the other methods accordingly.
 */
 pub trait Boundary<V, P: Position<V>> {
     /// Test whether a given point is inside the boundary.
@@ -22,12 +25,13 @@ pub trait Boundary<V, P: Position<V>> {
 
     /** Transform body and site properties into the boundary.
 
-    `wrap` takes a body/site properties type with a position that may be outside
-    the boundary. It attempts to wrap that body/site back inside the following
-    the boundary's periodicity. `wrap` returns `Some(properties)` when this
-    process is successful.  When it fails (i.e. a body's position is outside the
-    radius of a cylinder that is only periodic along its: axis), `wrap` returns
-    `None`.
+    `wrap` takes a body/site with a position that may be outside the boundary.
+    It attempts to wrap that body/site back inside following the boundary's
+    periodicity. `wrap` returns `Some(properties)` when this process is
+    successful.  When it fails `wrap` returns [`None`].
+
+    For example, [`None`] would be returned when a body's position is outside the
+    radius of a cylinder that is only periodic along its axis.
     */
     #[inline]
     fn wrap(&self, properties: P) -> Option<P> {
@@ -39,7 +43,9 @@ pub trait Boundary<V, P: Position<V>> {
     }
 }
 
-/** Open boundary conditions.
+/** Allow bodies and sites to exist anywhere in space.
+
+Every point lies inside `Open` boundary conditions.
 */
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Open;

--- a/hoomd-microstate/src/boundary.rs
+++ b/hoomd-microstate/src/boundary.rs
@@ -26,7 +26,7 @@ methods describe fully non-periodic boundary conditions. You can make your
 boundary periodic by implementing the other methods accordingly.
 
 The generic type names are:
-* `V`: The [`Vector`] space in which bodies and sites exist.
+* `V`: The [`Vector`](hoomd_vector::Vector) space in which bodies and sites exist.
 * `B`: The [`Body::properties`](crate::Body) type.
 * `S`: The [`Site::properties`](crate::Site) type.
 */

--- a/hoomd-microstate/src/boundary.rs
+++ b/hoomd-microstate/src/boundary.rs
@@ -18,31 +18,63 @@ When implementing a custom [`Boundary`], you need to implement
 [`Boundary::is_inside`] at a minimum. The default implementations of the other
 methods describe fully non-periodic boundary conditions. You can make your
 boundary periodic by implementing the other methods accordingly.
+
+The generic type names are:
+* `V`: The [`Vector`] space in which bodies and sites exist.
+* `B`: The [`Body::properties`](crate::Body) type.
+* `S`: The [`Site::properties`](crate::Site) type.
 */
-pub trait Boundary<V> {
+pub trait Boundary<V, B, S> {
     /// Test whether a given point is inside the boundary.
     fn is_inside(&self, point: &V) -> bool;
 
-    /** Transform body and site properties into the boundary.
+    /** Transform body properties into the boundary.
 
-    `wrap` takes a body/site with a position that may be outside the boundary.
-    It attempts to wrap that body/site back inside following the boundary's
+    `wrap_body` takes a body with a position that may be outside the boundary.
+    It attempts to wrap that body back inside following the boundary's
     periodicity. `wrap` returns [`Ok(properties)`](Ok) when this process is
     successful.
 
     # Errors
 
     `wrap` returns [`Error::CannotWrapPosition`] when it is not possible to wrap
-    the body/site into the boundary. For example, when the position is outside
-    the radius of a cylinder that is only periodic along its axis.
+    the body into the boundary. For example, when the position is outside the
+    radius of a cylinder that is only periodic along its axis.
     */
     #[inline]
-    fn wrap<P>(&self, properties: P) -> Result<P, Error>
+    fn wrap_body(&self, body_properties: B) -> Result<B, Error>
     where
-        P: Position<V>,
+        B: Position<V>,
+        S: Position<V>,
     {
-        if self.is_inside(properties.position()) {
-            Ok(properties)
+        if self.is_inside(body_properties.position()) {
+            Ok(body_properties)
+        } else {
+            Err(Error::CannotWrapPosition)
+        }
+    }
+
+    /** Transform site properties into the boundary.
+
+    `wrap_site` takes a site with a position that may be outside the boundary.
+    It attempts to wrap that site back inside following the boundary's
+    periodicity. `wrap` returns [`Ok(properties)`](Ok) when this process is
+    successful.
+
+    # Errors
+
+    `wrap` returns [`Error::CannotWrapPosition`] when it is not possible to wrap
+    the site into the boundary. For example, when the position is outside the
+    radius of a cylinder that is only periodic along its axis.
+    */
+    #[inline]
+    fn wrap_site(&self, site_properties: S) -> Result<S, Error>
+    where
+        B: Position<V>,
+        S: Position<V>,
+    {
+        if self.is_inside(site_properties.position()) {
+            Ok(site_properties)
         } else {
             Err(Error::CannotWrapPosition)
         }
@@ -56,7 +88,7 @@ Every point lies inside `Open` boundary conditions.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Open;
 
-impl<V> Boundary<V> for Open {
+impl<V, B, S> Boundary<V, B, S> for Open {
     #[inline]
     fn is_inside(&self, _point: &V) -> bool {
         true

--- a/hoomd-microstate/src/boundary.rs
+++ b/hoomd-microstate/src/boundary.rs
@@ -4,7 +4,52 @@
 /*! Traits that describe boundary conditions and a selection of types that implement them.
  */
 
+use crate::property::Position;
+
+/** Define the subset of the vector space where body and site positions exist.
+
+A `Boundary` also describes how body and site properties transform to periodic
+images. See the specific implementations of `Boundary` for examples.
+
+When implementing a custom `Boundary`, you need to implement `is_inside` at
+a minimum. The default implementations of the other methods describe fully
+non-periodic boundary conditions. You can make your boundary periodic by
+implementing the other methods accordingly.
+*/
+pub trait Boundary<V, P: Position<V>> {
+    /// Test whether a given point is inside the boundary.
+    fn is_inside(&self, point: &V) -> bool;
+
+    /** Transform body and site properties into the boundary.
+
+    `wrap` takes a body/site properties type with a position that may be outside
+    the boundary. It attempts to wrap that body/site back inside the following
+    the boundary's periodicity. `wrap` returns `Some(properties)` when this
+    process is successful.  When it fails (i.e. a body's position is outside the
+    radius of a cylinder that is only periodic along its: axis), `wrap` returns
+    `None`.
+    */
+    #[inline]
+    fn wrap(&self, properties: P) -> Option<P> {
+        if self.is_inside(properties.position()) {
+            Some(properties)
+        } else {
+            None
+        }
+    }
+}
+
 /** Open boundary conditions.
 */
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Open;
+
+impl<V, P> Boundary<V, P> for Open
+where
+    P: Position<V>,
+{
+    #[inline]
+    fn is_inside(&self, _point: &V) -> bool {
+        true
+    }
+}

--- a/hoomd-microstate/src/boundary/open.rs
+++ b/hoomd-microstate/src/boundary/open.rs
@@ -1,0 +1,21 @@
+// Copyright (c) 2024-2025 The Regents of the University of Michigan.
+// Part of hoomd-rs, released under the BSD 3-Clause License.
+
+/*! Implement Open
+*/
+
+use super::Boundary;
+
+/** Allow bodies and sites to exist anywhere in space.
+
+Every point lies inside `Open` boundary conditions.
+*/
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Open;
+
+impl<V, B, S> Boundary<V, B, S> for Open {
+    #[inline]
+    fn is_inside(&self, _point: &V) -> bool {
+        true
+    }
+}

--- a/hoomd-microstate/src/boundary/square.rs
+++ b/hoomd-microstate/src/boundary/square.rs
@@ -17,7 +17,7 @@ The square covers the points:
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Square {
     /// Side length *(\[length\])*.
-    l: f64,
+    pub l: f64,
 }
 
 impl Boundary<Cartesian<2>, Point<Cartesian<2>>, Point<Cartesian<2>>> for Square {

--- a/hoomd-microstate/src/boundary/square.rs
+++ b/hoomd-microstate/src/boundary/square.rs
@@ -1,0 +1,77 @@
+// Copyright (c) 2024-2025 The Regents of the University of Michigan.
+// Part of hoomd-rs, released under the BSD 3-Clause License.
+
+/*! Implement Square
+*/
+
+use super::Boundary;
+use crate::property::Point;
+use hoomd_vector::Cartesian;
+
+/** Restrict bodies and sites to the inside of a square.
+
+The square covers the points:
+* `-l/2 <= x < l/2`
+* `-l/2 <= y < l/2`
+*/
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Square {
+    /// Side length *(\[length\])*.
+    l: f64,
+}
+
+impl Boundary<Cartesian<2>, Point<Cartesian<2>>, Point<Cartesian<2>>> for Square {
+    #[inline]
+    fn is_inside(&self, point: &Cartesian<2>) -> bool {
+        point[0] >= -self.l / 2.0
+            && point[1] >= -self.l / 2.0
+            && point[0] < self.l / 2.0
+            && point[1] < self.l / 2.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Body, Error, Transform};
+
+    use rstest::*;
+
+    const TOP: f64 = 1.0_f64.next_down();
+    const OUTSIDE_BOTTOM: f64 = (-1.0_f64).next_down();
+    const OUTSIDE_TOP: f64 = 1.0;
+
+    #[rstest]
+    fn valid_points(#[values([0.0, 0.0], [-1.0, -1.0], [-1.0, 0.0], [TOP, TOP])] v: [f64; 2]) {
+        let square = Square { l: 2.0 };
+        let v = v.into();
+
+        assert!(square.is_inside(&v));
+
+        let body = Body::point(v);
+        assert_eq!(square.wrap_body(body.properties), Ok(body.properties));
+
+        let site = body.properties.transform(&body.sites[0]);
+        assert_eq!(square.wrap_site(site), Ok(site));
+    }
+
+    #[rstest]
+    fn invalid_points(
+        #[values([-10.0, 10.0], [OUTSIDE_BOTTOM, 0.0], [-1.0, OUTSIDE_BOTTOM], [OUTSIDE_BOTTOM, 0.0], [OUTSIDE_TOP, OUTSIDE_TOP])]
+        v: [f64; 2],
+    ) {
+        let square = Square { l: 2.0 };
+        let v = v.into();
+
+        assert!(!square.is_inside(&v));
+
+        let body = Body::point(v);
+        assert_eq!(
+            square.wrap_body(body.properties),
+            Err(Error::CannotWrapProperties)
+        );
+
+        let site = body.properties.transform(&body.sites[0]);
+        assert_eq!(square.wrap_site(site), Err(Error::CannotWrapProperties));
+    }
+}

--- a/hoomd-microstate/src/boundary/square.rs
+++ b/hoomd-microstate/src/boundary/square.rs
@@ -6,6 +6,7 @@
 
 use super::Boundary;
 use crate::property::Point;
+use hoomd_utility::valid::PositiveReal;
 use hoomd_vector::Cartesian;
 
 /** Restrict bodies and sites to the inside of a square.
@@ -13,20 +14,30 @@ use hoomd_vector::Cartesian;
 The square covers the points:
 * `-l/2 <= x < l/2`
 * `-l/2 <= y < l/2`
+
+# Example
+
+```
+use hoomd_microstate::boundary::Square;
+
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
+let square = Square { l: 10.0.try_into()? };
+
+assert_eq!(square.l.get(), 10.0);
+# Ok(())
+# }
 */
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Square {
     /// Side length *(\[length\])*.
-    pub l: f64,
+    pub l: PositiveReal,
 }
 
 impl Boundary<Cartesian<2>, Point<Cartesian<2>>, Point<Cartesian<2>>> for Square {
     #[inline]
     fn is_inside(&self, point: &Cartesian<2>) -> bool {
-        point[0] >= -self.l / 2.0
-            && point[1] >= -self.l / 2.0
-            && point[0] < self.l / 2.0
-            && point[1] < self.l / 2.0
+        let l = self.l.get();
+        point[0] >= -l / 2.0 && point[1] >= -l / 2.0 && point[0] < l / 2.0 && point[1] < l / 2.0
     }
 }
 
@@ -43,7 +54,11 @@ mod tests {
 
     #[rstest]
     fn valid_points(#[values([0.0, 0.0], [-1.0, -1.0], [-1.0, 0.0], [TOP, TOP])] v: [f64; 2]) {
-        let square = Square { l: 2.0 };
+        let square = Square {
+            l: 2.0
+                .try_into()
+                .expect("hard-coded constant should be positive"),
+        };
         let v = v.into();
 
         assert!(square.is_inside(&v));
@@ -60,7 +75,11 @@ mod tests {
         #[values([-10.0, 10.0], [OUTSIDE_BOTTOM, 0.0], [-1.0, OUTSIDE_BOTTOM], [OUTSIDE_BOTTOM, 0.0], [OUTSIDE_TOP, OUTSIDE_TOP])]
         v: [f64; 2],
     ) {
-        let square = Square { l: 2.0 };
+        let square = Square {
+            l: 2.0
+                .try_into()
+                .expect("hard-coded constant should be positive"),
+        };
         let v = v.into();
 
         assert!(!square.is_inside(&v));

--- a/hoomd-microstate/src/boundary/square.rs
+++ b/hoomd-microstate/src/boundary/square.rs
@@ -44,7 +44,7 @@ impl Boundary<Cartesian<2>, Point<Cartesian<2>>, Point<Cartesian<2>>> for Square
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Body, boundary::Error, Transform};
+    use crate::{Body, Transform, boundary::Error};
 
     use rstest::*;
 

--- a/hoomd-microstate/src/boundary/square.rs
+++ b/hoomd-microstate/src/boundary/square.rs
@@ -44,7 +44,7 @@ impl Boundary<Cartesian<2>, Point<Cartesian<2>>, Point<Cartesian<2>>> for Square
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Body, Error, Transform};
+    use crate::{Body, boundary::Error, Transform};
 
     use rstest::*;
 
@@ -87,10 +87,10 @@ mod tests {
         let body = Body::point(v);
         assert_eq!(
             square.wrap_body(body.properties),
-            Err(Error::CannotWrapProperties)
+            Err(Error::CannotWrapBodyProperties)
         );
 
         let site = body.properties.transform(&body.sites[0]);
-        assert_eq!(square.wrap_site(site), Err(Error::CannotWrapProperties));
+        assert_eq!(square.wrap_site(site), Err(Error::CannotWrapSiteProperties));
     }
 }

--- a/hoomd-microstate/src/lib.rs
+++ b/hoomd-microstate/src/lib.rs
@@ -147,7 +147,7 @@ initializes the seed and step to 0.
 use hoomd_microstate::{Microstate, property::Point};
 use hoomd_vector::Cartesian;
 
-let microstate = Microstate::<Point<Cartesian<2>>>::new();
+let microstate = Microstate::<Cartesian<2>, Point<Cartesian<2>>>::new();
 ```
 
 When you need more control, use [`MicrostateBuilder`] to set the boundary conditions,

--- a/hoomd-microstate/src/lib.rs
+++ b/hoomd-microstate/src/lib.rs
@@ -323,7 +323,11 @@ pub trait Transform<S> {
 #[non_exhaustive]
 #[derive(Error, PartialEq, Debug)]
 pub enum Error {
-    /// Attempted to wrap a body/site with a position not covered by the periodic boundary.
-    #[error("This position cannot be wrapped into the boundary.")]
-    CannotWrapProperties,
+    /// Failed to add a body to a `Microstate`.
+    #[error("failed to add body (tag={0})")]
+    AddBody(usize, #[source] boundary::Error),
+
+    /// Failed to update a body in a `Microstate`.
+    #[error("failed to update body (tag={0})")]
+    UpdateBody(usize, #[source] boundary::Error),
 }

--- a/hoomd-microstate/src/lib.rs
+++ b/hoomd-microstate/src/lib.rs
@@ -323,11 +323,11 @@ pub trait Transform<S> {
 #[non_exhaustive]
 #[derive(Error, PartialEq, Debug)]
 pub enum Error {
-    /// Failed to add a body to a `Microstate`.
+    /// Failed to add a body to a [`Microstate`].
     #[error("failed to add body (tag={0})")]
     AddBody(usize, #[source] boundary::Error),
 
-    /// Failed to update a body in a `Microstate`.
+    /// Failed to update a body in a [`Microstate`].
     #[error("failed to update body (tag={0})")]
     UpdateBody(usize, #[source] boundary::Error),
 }

--- a/hoomd-microstate/src/lib.rs
+++ b/hoomd-microstate/src/lib.rs
@@ -124,10 +124,9 @@ cannot be wrapped. MD models fail with an error should bodies or sites move in a
 way that cannot be wrapped.
 
 [`Microstate`] is generic on the type of boundary condition. The [`boundary`]
-module implements standard types and documents how you can implement custom
-implementations.
-
-TODO: Implement boundary conditions, then document.
+module implements standard types and documents how you can provide custom
+implementations. For example [`Square`](boundary::Square) restricts 2D
+particles inside a square.
 
 ## Ghost sites
 
@@ -140,7 +139,7 @@ TODO: Implement spatial search, then document.
 ## Constructing Microstate
 
 You will find many examples in this documentation using [`Microstate::new`].
-It is designed to be terse, is inflexible as a consequence.
+It is designed to be terse, and is inflexible as a consequence.
 [`Microstate::new`] always sets [`Open`](boundary::Open) boundary conditions and
 initializes the seed and step to 0.
 ```
@@ -155,19 +154,19 @@ use a different seed or starting step:
 
 ```
 use hoomd_microstate::{Microstate, MicrostateBuilder, property::Point};
-use hoomd_microstate::boundary::Open;
+use hoomd_microstate::boundary::Square;
 use hoomd_vector::Cartesian;
 
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
-let microstate = MicrostateBuilder::<Point<Cartesian<2>>>::with_boundary(Open)
+let square = Square { l: 10.0.try_into()? };
+
+let microstate = MicrostateBuilder::with_boundary(square)
     .seed(0x43abf1)
     .step(100_000)
     .try_build()?;
 # Ok(())
 # }
 ```
-
-TODO: Show a non-trivial boundary condition.
 
 TODO: Show a GSD file example when implemented.
 

--- a/hoomd-microstate/src/lib.rs
+++ b/hoomd-microstate/src/lib.rs
@@ -158,10 +158,13 @@ use hoomd_microstate::{Microstate, MicrostateBuilder, property::Point};
 use hoomd_microstate::boundary::Open;
 use hoomd_vector::Cartesian;
 
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
 let microstate = MicrostateBuilder::<Point<Cartesian<2>>>::with_boundary(Open)
     .seed(0x43abf1)
     .step(100_000)
-    .build();
+    .try_build()?;
+# Ok(())
+# }
 ```
 
 TODO: Show a non-trivial boundary condition.
@@ -176,8 +179,9 @@ mod microstate;
 pub mod property;
 
 pub use microstate::{Microstate, MicrostateBuilder, Tagged};
-
 use property::Point;
+
+use thiserror::Error;
 
 /** Interactions in `hoomd-rs` apply between sites.
 
@@ -199,15 +203,18 @@ Find the center of all interaction sites in a [`Microstate`]:
 use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
 use hoomd_vector::{Vector, Cartesian};
 
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
 let microstate = MicrostateBuilder::new()
     .bodies([Body::point(Cartesian::from([1.0, 0.0])),
              Body::point(Cartesian::from([-1.0, 2.0]))])
-    .build();
+    .try_build()?;
 
 let average_site_position = microstate.sites()
     .iter()
     .map(|site| site.properties.position)
     .sum::<Cartesian<2>>() / (microstate.sites().len() as f64);
+# Ok(())
+# }
 ```
 */
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -311,4 +318,13 @@ pub trait Transform<S> {
     */
     #[must_use]
     fn transform(&self, site_properties: &S) -> S;
+}
+
+/// Enumerate possible sources of error in fallible microstate methods.
+#[non_exhaustive]
+#[derive(Error, PartialEq, Debug)]
+pub enum Error {
+    /// Attempted to wrap a body/site with a position not covered by the periodic boundary.
+    #[error("This position cannot be wrapped into the boundary.")]
+    CannotWrapPosition,
 }

--- a/hoomd-microstate/src/lib.rs
+++ b/hoomd-microstate/src/lib.rs
@@ -326,5 +326,5 @@ pub trait Transform<S> {
 pub enum Error {
     /// Attempted to wrap a body/site with a position not covered by the periodic boundary.
     #[error("This position cannot be wrapped into the boundary.")]
-    CannotWrapPosition,
+    CannotWrapProperties,
 }

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -568,6 +568,12 @@ impl<B, S, C> Microstate<B, S, C> {
     Also updates the properties of the sites (in the system frame) associated
     with the body.
 
+    # Errors
+
+    [`Error::CannotWrapPosition`] when any the body position or one of the
+    site positions cannot be wrapped into the boundary. When an error occurs,
+    `update_body_properties` makes no change to the microstate.
+
     # Example
 
     ```
@@ -580,7 +586,7 @@ impl<B, S, C> Microstate<B, S, C> {
         .bodies([Body::point(Cartesian::from([1.0, 0.0]))])
         .try_build()?;
 
-    microstate.update_body_properties(0, Point::new(Cartesian::from([-2.0, 3.0])));
+    microstate.update_body_properties(0, Point::new(Cartesian::from([-2.0, 3.0])))?;
     assert_eq!(microstate.bodies()[0].item.properties.position, [-2.0, 3.0].into());
     assert_eq!(microstate.sites()[0].properties.position, [-2.0, 3.0].into());
     # Ok(())
@@ -592,18 +598,40 @@ impl<B, S, C> Microstate<B, S, C> {
         clippy::missing_panics_doc,
         reason = "Panic would occur due to a bug in hoomd-rs."
     )]
-    pub fn update_body_properties(&mut self, body_index: usize, properties: B)
+    pub fn update_body_properties<V>(
+        &mut self,
+        body_index: usize,
+        properties: B,
+    ) -> Result<(), Error>
     where
-        B: Transform<S>,
+        B: Transform<S> + Position<V>,
+        S: Position<V>,
+        C: Boundary<V>,
     {
         let body = &mut self.bodies[body_index].item;
-        body.properties = properties;
+        let new_body_properties = self.boundary.wrap(properties)?;
+
+        // An unknown site in the body might not wrap into the boundary.
+        // Check that they do first before starting to modify internal data
+        // structures. This wraps every site twice on update. Should that prove
+        // to be a performance bottleneck, we could alternately implement a
+        // staging Vec (would require allocation/deallocation per update or a
+        // reusable scratch storage).
+        for s in &body.sites {
+            self.boundary.wrap(new_body_properties.transform(s))?;
+        }
+
+        body.properties = new_body_properties;
 
         // Update site properties
         for (i, site_tag) in self.bodies_sites[body_index].iter().enumerate() {
             let site_index = self.site_indices[*site_tag].expect("site_tag should be a valid tag");
-            self.sites[site_index].properties = body.properties.transform(&body.sites[i]);
+            self.sites[site_index].properties = self
+                .boundary
+                .wrap(body.properties.transform(&body.sites[i]))?;
         }
+
+        Ok(())
     }
 }
 
@@ -1153,7 +1181,9 @@ mod tests {
                 let body = reference_bodies.get_mut(&tag).expect("valid body tag");
 
                 body.properties.position += rng.random::<Cartesian<2>>() * MAX_BODY_TRANSLATE;
-                microstate.update_body_properties(index, body.properties);
+                microstate
+                    .update_body_properties(index, body.properties)
+                    .expect("valid update");
             }
         }
 

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -388,8 +388,8 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
 
     # Errors
 
-    [`Error::CannotWrapProperties`] when either the body position or one of the site
-    positions cannot be wrapped into the boundary.
+    [`Error::AddBody`] when the body cannot be added to the microstate because
+    the body position or any site position cannot be wrapped into the boundary
 
     # Example
 
@@ -420,8 +420,15 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
         S: Position<V>,
         C: Boundary<V, B, S>,
     {
+        // Find the tag of the new body.
+        let body_tag = self
+            .free_body_tags
+            .peek()
+            .map_or(self.body_indices.len(), |t| t.0);
+            
         let mut body = body;
-        body.properties = self.boundary.wrap_body(body.properties)?;
+        body.properties = self.boundary.wrap_body(body.properties)
+            .map_err(|e| Error::AddBody(body_tag, e))?;
 
         // An unknown site in the body might not wrap into the boundary.
         // Check that they do first before starting to modify internal data
@@ -430,15 +437,14 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
         // (complicated) or a staging Vec (would require additional allocations
         // or a reusable scratch storage).
         for s in &body.sites {
-            self.boundary.wrap_site(body.properties.transform(s))?;
+            self.boundary.wrap_site(body.properties.transform(s))
+                .map_err(|e| Error::AddBody(body_tag, e))?;
         }
 
-        // Find body tag before adding sites
-        let body_tag = self
-            .free_body_tags
-            .pop()
-            .map_or(self.body_indices.len(), |t| t.0);
-
+        // Now that all errors have been checked, it is safe to mark the tag as
+        // used.
+        self.free_body_tags.pop();
+        
         // Add sites.
         // Should the Vec allocation prove a bottleneck, we could recycle the body_sites
         // vecs along with the tags.
@@ -495,11 +501,10 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
 
     # Errors
 
-    [`Error::CannotWrapProperties`] when any of the body positions or one of the
-    site positions cannot be wrapped into the boundary. `extend_bodies` adds
-    each body one by one. When an error occurs, it short-circuits and does not
-    attempt to add any further bodies. The bodies added before the error will
-    remain in the microstate.
+    [`Error::AddBody`] when any of the bodies cannot be added to the microstate.
+    `extend_bodies` adds each body one by one. When an error occurs, it
+    short-circuits and does not attempt to add any further bodies. The bodies
+    added before the error will remain in the microstate.
 
     # Example
 
@@ -605,9 +610,9 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
 
     # Errors
 
-    [`Error::CannotWrapProperties`] when any the body position or one of the
-    site positions cannot be wrapped into the boundary. When an error occurs,
-    `update_body_properties` makes no change to the microstate.
+    [`Error::UpdateBody`] the body properties cannot be updated because the body
+    position or any site position cannot be wrapped into the boundary. When an
+    error occurs, `update_body_properties` makes no change to the microstate.
 
     # Example
 
@@ -639,8 +644,10 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
         S: Position<V>,
         C: Boundary<V, B, S>,
     {
-        let body = &mut self.bodies[body_index].item;
-        let new_body_properties = self.boundary.wrap_body(properties)?;
+        let body = &mut self.bodies[body_index];
+        
+        let new_body_properties = self.boundary.wrap_body(properties)
+            .map_err(|e| Error::UpdateBody(body.tag, e))?;
 
         // An unknown site in the body might not wrap into the boundary.
         // Check that they do first before starting to modify internal data
@@ -648,11 +655,13 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
         // to be a performance bottleneck, we could alternately implement a
         // staging Vec (would require allocation/deallocation per update or a
         // reusable scratch storage).
-        for s in &body.sites {
-            self.boundary.wrap_site(new_body_properties.transform(s))?;
+        for s in &body.item.sites {
+            self.boundary.wrap_site(new_body_properties.transform(s))
+                .map_err(|e| Error::UpdateBody(body.tag, e))?;
+
         }
 
-        body.properties = new_body_properties;
+        body.item.properties = new_body_properties;
 
         // Update site properties
         for (i, site_tag) in self.bodies_sites[body_index].iter().enumerate() {
@@ -660,7 +669,7 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
                 .expect("bodies_sites and site_indices should be consistent");
             self.sites[site_index].properties = self
                 .boundary
-                .wrap_site(body.properties.transform(&body.sites[i]))
+                .wrap_site(body.item.properties.transform(&body.item.sites[i]))
                 .expect("sites should be validated as wrappable prior to this loop");
         }
 
@@ -1159,7 +1168,7 @@ impl<B, S, C> MicrostateBuilder<B, S, C> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{boundary::Square, property::Point};
+    use crate::{boundary::{self, Square}, property::Point};
     use hoomd_vector::Cartesian;
 
     use rand::{Rng, SeedableRng, rngs::StdRng, seq::SliceRandom};
@@ -1331,7 +1340,7 @@ mod tests {
 
         assert_eq!(
             microstate.add_body(Body::point([2.0, 0.0].into())),
-            Err(Error::CannotWrapProperties)
+            Err(Error::AddBody(0, boundary::Error::CannotWrapBodyProperties))
         );
     }
 
@@ -1349,7 +1358,7 @@ mod tests {
                     position: [2.0, 0.0].into()
                 }
             ),
-            Err(Error::CannotWrapProperties)
+            Err(Error::UpdateBody(0, boundary::Error::CannotWrapBodyProperties))
         );
     }
 
@@ -1364,7 +1373,7 @@ mod tests {
             .try_build()
             .expect("the hard-coded bodies should be in the boundary");
 
-        assert_eq!(microstate.add_body(body), Err(Error::CannotWrapProperties));
+        assert_eq!(microstate.add_body(body), Err(Error::AddBody(0, boundary::Error::CannotWrapSiteProperties)));
     }
 
     #[rstest]
@@ -1386,7 +1395,7 @@ mod tests {
                     position: [1.0, 0.0].into()
                 }
             ),
-            Err(Error::CannotWrapProperties)
+            Err(Error::UpdateBody(0, boundary::Error::CannotWrapSiteProperties))
         );
     }
 

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -468,7 +468,7 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
     # Errors
 
     [`Error::CannotWrapProperties`] when any of the body positions or one of the
-    site positions cannot be wrapped into the boundary. `try_extend_bodies` adds
+    site positions cannot be wrapped into the boundary. `extend_bodies` adds
     each body one by one. When an error occurs, it short-circuits and does not
     attempt to add any further bodies. The bodies added before the error will
     remain in the microstate.
@@ -481,7 +481,7 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
 
     # fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut microstate = Microstate::new();
-    microstate.try_extend_bodies([Body::point(Cartesian::from([1.0, 0.0])),
+    microstate.extend_bodies([Body::point(Cartesian::from([1.0, 0.0])),
                                   Body::point(Cartesian::from([-1.0, 2.0]))])?;
 
     assert_eq!(microstate.bodies().len(), 2);
@@ -490,7 +490,7 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
     ```
     */
     #[inline]
-    pub fn try_extend_bodies<T>(&mut self, bodies: T) -> Result<(), Error>
+    pub fn extend_bodies<T>(&mut self, bodies: T) -> Result<(), Error>
     where
         T: IntoIterator<Item = Body<B, S>>,
         B: Transform<S> + Position<V>,
@@ -1049,7 +1049,7 @@ impl<B, S, C> MicrostateBuilder<B, S, C> {
 
     # Errors
 
-    See [`Microstate::try_extend_bodies()`].
+    See [`Microstate::extend_bodies()`].
 
     # Example
 
@@ -1094,7 +1094,7 @@ impl<B, S, C> MicrostateBuilder<B, S, C> {
             vector_type: PhantomData,
         };
 
-        microstate.try_extend_bodies(self.bodies)?;
+        microstate.extend_bodies(self.bodies)?;
 
         Ok(microstate)
     }

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -7,7 +7,9 @@
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 
-use crate::{Body, Site, Transform, boundary::Open};
+use crate::boundary::{Boundary, Open};
+use crate::property::Position;
+use crate::{Body, Error, Site, Transform};
 use hoomd_utility::random::Counter;
 
 /** Track a unique identifier for an item in [`Microstate`].
@@ -137,10 +139,13 @@ impl<B, S, C> Microstate<B, S, C> {
     use hoomd_microstate::{Microstate, MicrostateBuilder, property::Point};
     use hoomd_vector::Cartesian;
 
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     let microstate = MicrostateBuilder::<Point<Cartesian<2>>>::new()
         .step(100_000)
-        .build();
+        .try_build()?;
     assert_eq!(microstate.step(), 100_000);
+    # Ok(())
+    # }
     ```
     */
     #[inline]
@@ -246,10 +251,13 @@ impl<B, S, C> Microstate<B, S, C> {
     use hoomd_microstate::{Microstate, MicrostateBuilder, property::Point};
     use hoomd_vector::Cartesian;
 
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     let microstate = MicrostateBuilder::<Point<Cartesian<2>>>::new()
         .seed(0x1234abcd)
-        .build();
+        .try_build()?;
     assert_eq!(microstate.seed(), 0x1234abcd);
+    # Ok(())
+    # }
     ```
     */
     #[inline]
@@ -333,6 +341,9 @@ impl<B, S, C> Microstate<B, S, C> {
     [`sites`](Microstate::sites) (in system coordinates) and assigns unique tags
     to the sites similarly.
 
+    `add_body` wraps the body's position (and the positions of its sites in
+    system coordinates) into the boundary (see `Boundary::wrap()`).
+
     # Cost
 
     The cost of adding a body is proportional to the number of sites in the
@@ -340,7 +351,12 @@ impl<B, S, C> Microstate<B, S, C> {
 
     # Returns
 
-    The tag of the added body.
+    [`Ok(tag)`] with the tag of the added body on success.
+
+    # Errors
+
+    [`Error::CannotWrapPosition`] when either the body position or one of the site
+    positions cannot be wrapped into the boundary.
 
     # Example
 
@@ -348,27 +364,51 @@ impl<B, S, C> Microstate<B, S, C> {
     use hoomd_microstate::{Microstate, Body};
     use hoomd_vector::Cartesian;
 
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut microstate = Microstate::new();
-    let first_tag = microstate.add_body(Body::point(Cartesian::from([1.0, 0.0])));
-    let second_tag = microstate.add_body(Body::point(Cartesian::from([-1.0, 2.0])));
+    let first_tag = microstate.add_body(Body::point(Cartesian::from([1.0, 0.0])))?;
+    let second_tag = microstate.add_body(Body::point(Cartesian::from([-1.0, 2.0])))?;
 
     assert_eq!(microstate.bodies().len(), 2);
     assert_eq!(first_tag, 0);
     assert_eq!(second_tag, 1);
+    # Ok(())
+    # }
     ```
     */
     #[inline]
-    pub fn add_body(&mut self, body: Body<B, S>) -> usize
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "Panic would occur due to a bug in hoomd-rs."
+    )]
+    pub fn add_body<V>(&mut self, body: Body<B, S>) -> Result<usize, Error>
     where
-        B: Transform<S>,
+        B: Transform<S> + Position<V>,
+        S: Position<V>,
+        C: Boundary<V>,
     {
+        let mut body = body;
+        body.properties = self.boundary.wrap(body.properties)?;
+
+        // An unknown site in the body might not wrap into the boundary.
+        // Check that they do first before starting to modify internal data
+        // structures. This wraps every site twice on add. Should that prove to
+        // be a performance bottleneck, we could alternately implement rollback
+        // (complicated) or a staging Vec (would require additional allocations
+        // or a reusable scratch storage).
+        for s in &body.sites {
+            self.boundary.wrap(body.properties.transform(s))?;
+        }
+
         // Find body tag before adding sites
         let body_tag = match self.free_body_tags.pop() {
             None => self.body_indices.len(),
             Some(t) => t.0,
         };
 
-        // Add sites
+        // Add sites.
+        // Should the Vec allocation prove a bottleneck, we could recycle the body_sites
+        // vecs along with the tags.
         let mut body_sites = Vec::with_capacity(body.sites.len());
         for s in &body.sites {
             let site_tag = match self.free_site_tags.pop() {
@@ -377,7 +417,10 @@ impl<B, S, C> Microstate<B, S, C> {
             };
             self.sites.push(Site {
                 site_tag,
-                properties: body.properties.transform(s),
+                properties: self
+                    .boundary
+                    .wrap(body.properties.transform(s))
+                    .expect("can wrap site"),
                 body_tag,
             });
 
@@ -409,12 +452,20 @@ impl<B, S, C> Microstate<B, S, C> {
             self.body_indices[body_tag] = index;
         }
 
-        body_tag
+        Ok(body_tag)
     }
 
     /** Add multiple bodies to the microstate.
 
     See [`Microstate::add_body()`] for details.
+
+    # Errors
+
+    [`Error::CannotWrapPosition`] when any of the body positions or one of the
+    site positions cannot be wrapped into the boundary. `try_extend_bodies` adds
+    each body one by one. When an error occurs, it short-circuits and does not
+    attempt to add any further bodies. The bodies added before the error will
+    remain in the microstate.
 
     # Example
 
@@ -422,22 +473,29 @@ impl<B, S, C> Microstate<B, S, C> {
     use hoomd_microstate::{Microstate, Body};
     use hoomd_vector::Cartesian;
 
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut microstate = Microstate::new();
-    microstate.extend_bodies([Body::point(Cartesian::from([1.0, 0.0])),
-                              Body::point(Cartesian::from([-1.0, 2.0]))]);
+    microstate.try_extend_bodies([Body::point(Cartesian::from([1.0, 0.0])),
+                                  Body::point(Cartesian::from([-1.0, 2.0]))])?;
 
     assert_eq!(microstate.bodies().len(), 2);
+    # Ok(())
+    # }
     ```
     */
     #[inline]
-    pub fn extend_bodies<T>(&mut self, bodies: T)
+    pub fn try_extend_bodies<T, V>(&mut self, bodies: T) -> Result<(), Error>
     where
         T: IntoIterator<Item = Body<B, S>>,
-        B: Transform<S>,
+        B: Transform<S> + Position<V>,
+        S: Position<V>,
+        C: Boundary<V>,
     {
         for body in bodies {
-            self.add_body(body);
+            self.add_body(body)?;
         }
+
+        Ok(())
     }
 
     /** Remove a body at the given *index* from the microstate.
@@ -464,14 +522,17 @@ impl<B, S, C> Microstate<B, S, C> {
     use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
     use hoomd_vector::Cartesian;
 
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut microstate = MicrostateBuilder::new()
         .bodies([Body::point(Cartesian::from([1.0, 0.0])),
                  Body::point(Cartesian::from([-1.0, 2.0]))])
-        .build();
+        .try_build()?;
 
     microstate.remove_body(0);
 
     assert_eq!(microstate.bodies().len(), 1);
+    # Ok(())
+    # }
     ```
     */
     #[inline]
@@ -514,13 +575,16 @@ impl<B, S, C> Microstate<B, S, C> {
     use hoomd_microstate::property::Point;
     use hoomd_vector::Cartesian;
 
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut microstate = MicrostateBuilder::new()
         .bodies([Body::point(Cartesian::from([1.0, 0.0]))])
-        .build();
+        .try_build()?;
 
     microstate.update_body_properties(0, Point::new(Cartesian::from([-2.0, 3.0])));
     assert_eq!(microstate.bodies()[0].item.properties.position, [-2.0, 3.0].into());
     assert_eq!(microstate.sites()[0].properties.position, [-2.0, 3.0].into());
+    # Ok(())
+    # }
     ```
     */
     #[inline]
@@ -564,14 +628,17 @@ impl<B, S, C> Microstate<B, S, C> {
     use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
     use hoomd_vector::Cartesian;
 
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     let microstate = MicrostateBuilder::new()
         .bodies([Body::point(Cartesian::from([1.0, 0.0])),
                  Body::point(Cartesian::from([-1.0, 2.0]))])
-        .build();
+        .try_build()?;
 
     // The initial index order is equivalent to the tag order.
     assert_eq!(microstate.bodies()[0].tag, 0);
     assert_eq!(microstate.bodies()[1].tag, 1);
+    # Ok(())
+    # }
     ```
 
     Compute system-wide properties that are order-independent:
@@ -579,15 +646,18 @@ impl<B, S, C> Microstate<B, S, C> {
     use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
     use hoomd_vector::{Vector, Cartesian};
 
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     let microstate = MicrostateBuilder::new()
         .bodies([Body::point(Cartesian::from([1.0, 0.0])),
                  Body::point(Cartesian::from([-1.0, 2.0]))])
-        .build();
+        .try_build()?;
 
     let average_position = microstate.bodies()
         .iter()
         .map(|tagged_body| tagged_body.item.properties.position)
         .sum::<Cartesian<2>>() / (microstate.bodies().len() as f64);
+    # Ok(())
+    # }
     ```
     */
     #[inline]
@@ -611,12 +681,13 @@ impl<B, S, C> Microstate<B, S, C> {
     use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
     use hoomd_vector::Cartesian;
 
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut microstate = MicrostateBuilder::new()
         .bodies([Body::point(Cartesian::from([1.0, 2.0])),
                  Body::point(Cartesian::from([3.0, 4.0])),
                  Body::point(Cartesian::from([5.0, 6.0])),
                  Body::point(Cartesian::from([7.0, 8.0]))])
-        .build();
+        .try_build()?;
 
     microstate.remove_body(microstate.body_indices()[0].expect("valid tag"));
 
@@ -626,6 +697,8 @@ impl<B, S, C> Microstate<B, S, C> {
     if let Some(index) = microstate.body_indices()[2] {
         assert_eq!(microstate.bodies()[index].item.properties.position, [5.0, 6.0].into());
     }
+    # Ok(())
+    # }
     ```
     */
     #[inline]
@@ -655,10 +728,11 @@ impl<B, S, C> Microstate<B, S, C> {
     use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
     use hoomd_vector::Cartesian;
 
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     let microstate = MicrostateBuilder::new()
         .bodies([Body::point(Cartesian::from([1.0, 0.0])),
                  Body::point(Cartesian::from([-1.0, 2.0]))])
-        .build();
+        .try_build()?;
 
     // The initial index order is equivalent to the tag order.
     assert_eq!(microstate.sites()[0].site_tag, 0);
@@ -666,6 +740,8 @@ impl<B, S, C> Microstate<B, S, C> {
 
     assert_eq!(microstate.sites()[1].body_tag, 1);
     assert_eq!(microstate.sites()[1].body_tag, 1);
+    # Ok(())
+    # }
     ```
 
     Compute system-wide properties that are order-independent:
@@ -673,15 +749,18 @@ impl<B, S, C> Microstate<B, S, C> {
     use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
     use hoomd_vector::{Vector, Cartesian};
 
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     let microstate = MicrostateBuilder::new()
         .bodies([Body::point(Cartesian::from([1.0, 0.0])),
                  Body::point(Cartesian::from([-1.0, 2.0]))])
-        .build();
+        .try_build()?;
 
     let average_position = microstate.sites()
         .iter()
         .map(|site| site.properties.position)
         .sum::<Cartesian<2>>() / (microstate.sites().len() as f64);
+    # Ok(())
+    # }
     ```
     */
     #[inline]
@@ -714,14 +793,17 @@ impl<B, S, C> Microstate<B, S, C> {
     use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
     use hoomd_vector::{Vector, Cartesian};
 
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     let microstate = MicrostateBuilder::new()
         .bodies([Body::point(Cartesian::from([1.0, 0.0])),
                  Body::point(Cartesian::from([-1.0, 2.0]))])
-        .build();
+        .try_build()?;
 
     let average_position = microstate.iter_body_sites(0)
         .map(|site| site.properties.position)
         .sum::<Cartesian<2>>() / (microstate.bodies()[0].item.sites.len() as f64);
+    # Ok(())
+    # }
     ```
     */
     #[inline]
@@ -748,16 +830,19 @@ cannot be directly modified after building the [`Microstate`].
 use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
 use hoomd_vector::Cartesian;
 
+# fn main() -> Result<(), Box<dyn std::error::Error>> {
 let mut microstate = MicrostateBuilder::new()
     .step(100_000)
     .seed(0x1234abcd)
     .bodies([Body::point(Cartesian::from([1.0, 0.0])),
              Body::point(Cartesian::from([-1.0, 2.0]))])
-    .build();
+    .try_build()?;
 
 assert_eq!(microstate.step(), 100_000);
 assert_eq!(microstate.seed(), 0x1234abcd);
 assert_eq!(microstate.bodies().len(), 2);
+# Ok(())
+# }
 ```
 */
 pub struct MicrostateBuilder<B, S = B, C = Open> {
@@ -782,12 +867,15 @@ impl<B, S> MicrostateBuilder<B, S, Open> {
     use hoomd_microstate::{Microstate, MicrostateBuilder, property::Point};
     use hoomd_vector::Cartesian;
 
-    let microstate = MicrostateBuilder::<Point<Cartesian<2>>>::new().build();
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let microstate = MicrostateBuilder::<Point<Cartesian<2>>>::new().try_build()?;
 
     assert_eq!(microstate.step(), 0);
     assert_eq!(microstate.seed(), 0);
     assert_eq!(microstate.bodies().len(), 0);
     assert_eq!(*microstate.boundary(), hoomd_microstate::boundary::Open);
+    # Ok(())
+    # }
     ```
     */
     #[inline]
@@ -816,12 +904,15 @@ impl<B, S, C> MicrostateBuilder<B, S, C> {
     use hoomd_microstate::boundary::Open;
     use hoomd_vector::Cartesian;
 
-    let microstate = MicrostateBuilder::<Point<Cartesian<2>>>::with_boundary(Open).build();
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let microstate = MicrostateBuilder::<Point<Cartesian<2>>>::with_boundary(Open).try_build()?;
 
     assert_eq!(microstate.step(), 0);
     assert_eq!(microstate.seed(), 0);
     assert_eq!(microstate.bodies().len(), 0);
     assert_eq!(*microstate.boundary(), hoomd_microstate::boundary::Open);
+    # Ok(())
+    # }
     ```
 
     TODO: Show non-trivial boundary conditions.
@@ -847,11 +938,14 @@ impl<B, S, C> MicrostateBuilder<B, S, C> {
     use hoomd_microstate::boundary::Open;
     use hoomd_vector::Cartesian;
 
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     let microstate = MicrostateBuilder::<Point<Cartesian<2>>>::new()
         .step(100_000)
-        .build();
+        .try_build()?;
 
     assert_eq!(microstate.step(), 100_000);
+    # Ok(())
+    # }
     ```
     */
     #[inline]
@@ -872,11 +966,14 @@ impl<B, S, C> MicrostateBuilder<B, S, C> {
     use hoomd_microstate::boundary::Open;
     use hoomd_vector::Cartesian;
 
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     let microstate = MicrostateBuilder::<Point<Cartesian<2>>>::new()
         .seed(0x1234abcd)
-        .build();
+        .try_build()?;
 
     assert_eq!(microstate.seed(), 0x1234abcd);
+    # Ok(())
+    # }
     ```
     */
     #[inline]
@@ -896,12 +993,15 @@ impl<B, S, C> MicrostateBuilder<B, S, C> {
     use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
     use hoomd_vector::Cartesian;
 
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut microstate = MicrostateBuilder::new()
         .bodies([Body::point(Cartesian::from([1.0, 0.0])),
                  Body::point(Cartesian::from([-1.0, 2.0]))])
-        .build();
+        .try_build()?;
 
     assert_eq!(microstate.bodies().len(), 2);
+    # Ok(())
+    # }
     ```
     */
     #[inline]
@@ -916,29 +1016,37 @@ impl<B, S, C> MicrostateBuilder<B, S, C> {
 
     /** Construct a [`Microstate`] with the chosen options.
 
+    # Errors
+
+    See [`Microstate::try_extend_bodies()`].
+
     # Example
 
     ```
     use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
     use hoomd_vector::Cartesian;
 
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut microstate = MicrostateBuilder::new()
         .step(100_000)
         .seed(0x1234abcd)
         .bodies([Body::point(Cartesian::from([1.0, 0.0])),
                  Body::point(Cartesian::from([-1.0, 2.0]))])
-        .build();
+        .try_build()?;
 
     assert_eq!(microstate.step(), 100_000);
     assert_eq!(microstate.seed(), 0x1234abcd);
     assert_eq!(microstate.bodies().len(), 2);
+    # Ok(())
+    # }
     ```
     */
     #[inline]
-    #[must_use]
-    pub fn build(self) -> Microstate<B, S, C>
+    pub fn try_build<V>(self) -> Result<Microstate<B, S, C>, Error>
     where
-        B: Transform<S>,
+        B: Transform<S> + Position<V>,
+        S: Position<V>,
+        C: Boundary<V>,
     {
         let mut microstate = Microstate {
             step: self.step,
@@ -954,9 +1062,9 @@ impl<B, S, C> MicrostateBuilder<B, S, C> {
             bodies_sites: Vec::new(),
         };
 
-        microstate.extend_bodies(self.bodies);
+        microstate.try_extend_bodies(self.bodies)?;
 
-        microstate
+        Ok(microstate)
     }
 }
 
@@ -1032,7 +1140,7 @@ mod tests {
                 // Add bodies more often than removing bodies so that typical
                 // test executions will result in a non-empty microstate.
                 let body = create_body(&mut rng);
-                let tag = microstate.add_body(body.clone());
+                let tag = microstate.add_body(body.clone()).expect("valid body");
                 reference_bodies.insert(tag, body);
             } else if move_type_r > 0.5 && !microstate.bodies.is_empty() {
                 let index = rng.random_range(..microstate.bodies.len());
@@ -1114,7 +1222,7 @@ mod tests {
 
         for _ in 0..N_STEPS {
             let body = create_body(&mut rng);
-            microstate.add_body(body);
+            microstate.add_body(body).expect("valid body");
         }
 
         let mut removal_order = (0..N_STEPS).collect::<Vec<_>>();
@@ -1129,4 +1237,7 @@ mod tests {
         assert!(microstate.bodies_sites.is_empty());
         assert!(microstate.sites().is_empty());
     }
+
+    // TODO: Test add_bodies and update_body_properties with boundaries that result in errors.
+    // TODO: Test add_bodies and update_body_properties with periodic boundaries that result in wrapping.
 }

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -30,7 +30,7 @@ documentation](crate) for a full overview and the method-specific documentation
 for additional details.
 
 The generic type names are:
-* `V`: The [`Vector`] space in which bodies and sites exist.
+* `V`: The [`Vector`](hoomd_vector::Vector) space in which bodies and sites exist.
 * `B`: The [`Body::properties`](crate::Body) type.
 * `S`: The [`Site::properties`](crate::Site) type.
 * `C`: The [`boundary`](crate::boundary) condition type.
@@ -314,7 +314,20 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
 
     # Example
 
-    TODO: Write once we have a non-trivial boundary type.
+    ```
+    use hoomd_microstate::{Microstate, MicrostateBuilder, boundary::Square};
+    use hoomd_vector::Cartesian;
+
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let square = Square { l: 10.0.try_into()? };
+
+    let microstate = MicrostateBuilder::with_boundary(square)
+        .try_build()?;
+
+    assert_eq!(microstate.boundary().l.get(), 10.0);
+    # Ok(())
+    # }
+    ```
     */
     #[inline]
     pub fn boundary(&self) -> &C {
@@ -325,7 +338,21 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
 
     # Example
 
-    TODO: Write once we have a non-trivial boundary type.
+    ```
+    use hoomd_microstate::{Microstate, MicrostateBuilder, boundary::Square};
+    use hoomd_vector::Cartesian;
+
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let square = Square { l: 10.0.try_into()? };
+
+    let mut microstate = MicrostateBuilder::with_boundary(square)
+        .try_build()?;
+
+    microstate.boundary_mut().l = 11.0.try_into()?;
+    assert_eq!(microstate.boundary().l.get(), 11.0);
+    # Ok(())
+    # }
+    ```
     */
     #[inline]
     pub fn boundary_mut(&mut self) -> &mut C {
@@ -407,20 +434,21 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
         }
 
         // Find body tag before adding sites
-        let body_tag = match self.free_body_tags.pop() {
-            None => self.body_indices.len(),
-            Some(t) => t.0,
-        };
+        let body_tag = self
+            .free_body_tags
+            .pop()
+            .map_or(self.body_indices.len(), |t| t.0);
 
         // Add sites.
         // Should the Vec allocation prove a bottleneck, we could recycle the body_sites
         // vecs along with the tags.
         let mut body_sites = Vec::with_capacity(body.sites.len());
         for s in &body.sites {
-            let site_tag = match self.free_site_tags.pop() {
-                None => self.site_indices.len(),
-                Some(t) => t.0,
-            };
+            let site_tag = self
+                .free_site_tags
+                .pop()
+                .map_or(self.site_indices.len(), |t| t.0);
+
             self.sites.push(Site {
                 site_tag,
                 properties: self
@@ -931,22 +959,22 @@ impl<B, S, C> MicrostateBuilder<B, S, C> {
     # Example
 
     ```
-    use hoomd_microstate::{Microstate, MicrostateBuilder, property::Point};
-    use hoomd_microstate::boundary::Open;
+    use hoomd_microstate::{Microstate, MicrostateBuilder, boundary::Square};
     use hoomd_vector::Cartesian;
 
     # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let microstate = MicrostateBuilder::<Point<Cartesian<2>>>::with_boundary(Open).try_build()?;
+    let square = Square { l: 10.0.try_into()? };
+
+    let microstate = MicrostateBuilder::with_boundary(square)
+        .try_build()?;
 
     assert_eq!(microstate.step(), 0);
     assert_eq!(microstate.seed(), 0);
     assert_eq!(microstate.bodies().len(), 0);
-    assert_eq!(*microstate.boundary(), hoomd_microstate::boundary::Open);
+    assert_eq!(microstate.boundary().l.get(), 10.0);
     # Ok(())
     # }
     ```
-
-    TODO: Show non-trivial boundary conditions.
     */
     #[inline]
     pub fn with_boundary(boundary: C) -> Self {

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -425,9 +425,11 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
             .free_body_tags
             .peek()
             .map_or(self.body_indices.len(), |t| t.0);
-            
+
         let mut body = body;
-        body.properties = self.boundary.wrap_body(body.properties)
+        body.properties = self
+            .boundary
+            .wrap_body(body.properties)
             .map_err(|e| Error::AddBody(body_tag, e))?;
 
         // An unknown site in the body might not wrap into the boundary.
@@ -437,14 +439,15 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
         // (complicated) or a staging Vec (would require additional allocations
         // or a reusable scratch storage).
         for s in &body.sites {
-            self.boundary.wrap_site(body.properties.transform(s))
+            self.boundary
+                .wrap_site(body.properties.transform(s))
                 .map_err(|e| Error::AddBody(body_tag, e))?;
         }
 
         // Now that all errors have been checked, it is safe to mark the tag as
         // used.
         self.free_body_tags.pop();
-        
+
         // Add sites.
         // Should the Vec allocation prove a bottleneck, we could recycle the body_sites
         // vecs along with the tags.
@@ -645,8 +648,10 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
         C: Boundary<V, B, S>,
     {
         let body = &mut self.bodies[body_index];
-        
-        let new_body_properties = self.boundary.wrap_body(properties)
+
+        let new_body_properties = self
+            .boundary
+            .wrap_body(properties)
             .map_err(|e| Error::UpdateBody(body.tag, e))?;
 
         // An unknown site in the body might not wrap into the boundary.
@@ -656,9 +661,9 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
         // staging Vec (would require allocation/deallocation per update or a
         // reusable scratch storage).
         for s in &body.item.sites {
-            self.boundary.wrap_site(new_body_properties.transform(s))
+            self.boundary
+                .wrap_site(new_body_properties.transform(s))
                 .map_err(|e| Error::UpdateBody(body.tag, e))?;
-
         }
 
         body.item.properties = new_body_properties;
@@ -1168,7 +1173,10 @@ impl<B, S, C> MicrostateBuilder<B, S, C> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{boundary::{self, Square}, property::Point};
+    use crate::{
+        boundary::{self, Square},
+        property::Point,
+    };
     use hoomd_vector::Cartesian;
 
     use rand::{Rng, SeedableRng, rngs::StdRng, seq::SliceRandom};
@@ -1358,7 +1366,10 @@ mod tests {
                     position: [2.0, 0.0].into()
                 }
             ),
-            Err(Error::UpdateBody(0, boundary::Error::CannotWrapBodyProperties))
+            Err(Error::UpdateBody(
+                0,
+                boundary::Error::CannotWrapBodyProperties
+            ))
         );
     }
 
@@ -1373,7 +1384,10 @@ mod tests {
             .try_build()
             .expect("the hard-coded bodies should be in the boundary");
 
-        assert_eq!(microstate.add_body(body), Err(Error::AddBody(0, boundary::Error::CannotWrapSiteProperties)));
+        assert_eq!(
+            microstate.add_body(body),
+            Err(Error::AddBody(0, boundary::Error::CannotWrapSiteProperties))
+        );
     }
 
     #[rstest]
@@ -1395,7 +1409,10 @@ mod tests {
                     position: [1.0, 0.0].into()
                 }
             ),
-            Err(Error::UpdateBody(0, boundary::Error::CannotWrapSiteProperties))
+            Err(Error::UpdateBody(
+                0,
+                boundary::Error::CannotWrapSiteProperties
+            ))
         );
     }
 

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -1287,7 +1287,10 @@ mod tests {
             .try_build()
             .expect("the hard-coded bodies should be in the boundary");
 
-        assert_eq!(microstate.add_body(Body::point([2.0, 0.0].into())), Err(Error::CannotWrapProperties));
+        assert_eq!(
+            microstate.add_body(Body::point([2.0, 0.0].into())),
+            Err(Error::CannotWrapProperties)
+        );
     }
 
     #[rstest]
@@ -1297,7 +1300,15 @@ mod tests {
             .try_build()
             .expect("the hard-coded bodies should be in the boundary");
 
-        assert_eq!(microstate.update_body_properties(0, Point { position: [2.0, 0.0].into() }), Err(Error::CannotWrapProperties));
+        assert_eq!(
+            microstate.update_body_properties(
+                0,
+                Point {
+                    position: [2.0, 0.0].into()
+                }
+            ),
+            Err(Error::CannotWrapProperties)
+        );
     }
 
     #[rstest]
@@ -1306,7 +1317,7 @@ mod tests {
             properties: Point::new(Cartesian::from([1.0, 0.0])),
             sites: [Point::new(Cartesian::from([1.0, 0.0]))].into(),
         };
-        
+
         let mut microstate = MicrostateBuilder::with_boundary(square)
             .try_build()
             .expect("the hard-coded bodies should be in the boundary");
@@ -1326,7 +1337,15 @@ mod tests {
             .try_build()
             .expect("the hard-coded bodies should be in the boundary");
 
-        assert_eq!(microstate.update_body_properties(0, Point { position: [1.0, 0.0].into() }), Err(Error::CannotWrapProperties));
+        assert_eq!(
+            microstate.update_body_properties(
+                0,
+                Point {
+                    position: [1.0, 0.0].into()
+                }
+            ),
+            Err(Error::CannotWrapProperties)
+        );
     }
 
     // TODO: Test add_bodies and update_body_properties with periodic boundaries that result in wrapping.

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -1127,7 +1127,7 @@ impl<B, S, C> MicrostateBuilder<B, S, C> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::property::Point;
+    use crate::{boundary::Square, property::Point};
     use hoomd_vector::Cartesian;
 
     use rand::{Rng, SeedableRng, rngs::StdRng, seq::SliceRandom};
@@ -1272,6 +1272,62 @@ mod tests {
         assert!(microstate.sites().is_empty());
     }
 
-    // TODO: Test add_bodies and update_body_properties with boundaries that result in errors.
+    #[fixture]
+    fn square() -> Square {
+        Square {
+            l: 4.0
+                .try_into()
+                .expect("hard-coded constant should be positive"),
+        }
+    }
+
+    #[rstest]
+    fn add_body_outside(square: Square) {
+        let mut microstate = MicrostateBuilder::with_boundary(square)
+            .try_build()
+            .expect("the hard-coded bodies should be in the boundary");
+
+        assert_eq!(microstate.add_body(Body::point([2.0, 0.0].into())), Err(Error::CannotWrapProperties));
+    }
+
+    #[rstest]
+    fn update_body_outside(square: Square) {
+        let mut microstate = MicrostateBuilder::with_boundary(square)
+            .bodies([Body::point(Cartesian::from([0.0, 0.0]))])
+            .try_build()
+            .expect("the hard-coded bodies should be in the boundary");
+
+        assert_eq!(microstate.update_body_properties(0, Point { position: [2.0, 0.0].into() }), Err(Error::CannotWrapProperties));
+    }
+
+    #[rstest]
+    fn add_site_outside(square: Square) {
+        let body = Body {
+            properties: Point::new(Cartesian::from([1.0, 0.0])),
+            sites: [Point::new(Cartesian::from([1.0, 0.0]))].into(),
+        };
+        
+        let mut microstate = MicrostateBuilder::with_boundary(square)
+            .try_build()
+            .expect("the hard-coded bodies should be in the boundary");
+
+        assert_eq!(microstate.add_body(body), Err(Error::CannotWrapProperties));
+    }
+
+    #[rstest]
+    fn update_site_outside(square: Square) {
+        let body = Body {
+            properties: Point::new(Cartesian::from([0.0, 0.0])),
+            sites: [Point::new(Cartesian::from([1.0, 0.0]))].into(),
+        };
+
+        let mut microstate = MicrostateBuilder::with_boundary(square)
+            .bodies([body])
+            .try_build()
+            .expect("the hard-coded bodies should be in the boundary");
+
+        assert_eq!(microstate.update_body_properties(0, Point { position: [1.0, 0.0].into() }), Err(Error::CannotWrapProperties));
+    }
+
     // TODO: Test add_bodies and update_body_properties with periodic boundaries that result in wrapping.
 }

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -367,15 +367,14 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
 
     Each body is assigned a unique tag. The first body is given tag 0,
     the second is given tag 1, and so on. When a body is removed (see
-    [`Microstate::remove_body()`], its tag becomes unused. The next call to
+    [`Microstate::remove_body()`]), its tag becomes unused. The next call to
     `add_body` will assign the smallest unused tag.
 
     `add_body` also adds the body's sites to the microstate's
-    [`sites`](Microstate::sites) (in system coordinates) and assigns unique tags
-    to the sites similarly.
-
-    `add_body` wraps the body's position (and the positions of its sites in
-    system coordinates) into the boundary (see `Boundary::wrap()`).
+    [`sites`](Microstate::sites) (in system coordinates) and assigns unique
+    tags to the sites similarly. It wraps the body's position (and the
+    positions of its sites in system coordinates) into the boundary (see
+    [`Boundary`]).
 
     # Cost
 
@@ -384,7 +383,7 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
 
     # Returns
 
-    [`Ok(tag)`] with the tag of the added body on success.
+    [`Ok(tag)`](Result::Ok) with the tag of the added body on success.
 
     # Errors
 
@@ -608,14 +607,14 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
 
     /** Sets the properties of the given body.
 
-    Also updates the properties of the sites (in the system frame) associated
-    with the body.
+    `update_body_properties` also updates the properties of the sites (in the
+    system frame) associated with the body accordingly.
 
     # Errors
 
     [`Error::UpdateBody`] the body properties cannot be updated because the body
     position or any site position cannot be wrapped into the boundary. When an
-    error occurs, `update_body_properties` makes no change to the microstate.
+    error occurs, `update_body_properties` makes no change to the [`Microstate`].
 
     # Example
 
@@ -746,9 +745,9 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
     [`Microstate::bodies`].
 
     `body_indices()[tag]` is:
-    * `None` when there is no body with the given tag in the microstate.
-    * `Some(index)` when the body with the given tag is in the microstate.
-      `index` is the index of the body in [`Microstate::bodies`].
+    * [`None`] when there is no body with the given tag in the microstate.
+    * [`Some(index)`](Option::Some) when the body with the given tag is in the
+      microstate. `index` is the index of the body in [`Microstate::bodies`].
 
     # Example
 
@@ -792,8 +791,8 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
     the associated body tag in [`Site::body_tag`] and the site's properties in
     [`Site::properties`].
 
-    [`sites`](Microstate::sites) provides direct immutable access to
-    this slice. To mutate a body (and by extension, its sites), see
+    [`sites`](Microstate::sites) provides direct immutable access to the
+    slice of all sites. To mutate a body (and by extension, its sites), see
     [`Microstate::update_body_properties()`].
 
     # Examples

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -361,7 +361,7 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
 
     # Errors
 
-    [`Error::CannotWrapPosition`] when either the body position or one of the site
+    [`Error::CannotWrapProperties`] when either the body position or one of the site
     positions cannot be wrapped into the boundary.
 
     # Example
@@ -467,7 +467,7 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
 
     # Errors
 
-    [`Error::CannotWrapPosition`] when any of the body positions or one of the
+    [`Error::CannotWrapProperties`] when any of the body positions or one of the
     site positions cannot be wrapped into the boundary. `try_extend_bodies` adds
     each body one by one. When an error occurs, it short-circuits and does not
     attempt to add any further bodies. The bodies added before the error will
@@ -576,7 +576,7 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
 
     # Errors
 
-    [`Error::CannotWrapPosition`] when any the body position or one of the
+    [`Error::CannotWrapProperties`] when any the body position or one of the
     site positions cannot be wrapped into the boundary. When an error occurs,
     `update_body_properties` makes no change to the microstate.
 

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -454,7 +454,7 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
                 properties: self
                     .boundary
                     .wrap_site(body.properties.transform(s))
-                    .expect("can wrap site"),
+                    .expect("sites should be validated as wrappable prior to this loop"),
                 body_tag,
             });
 
@@ -579,7 +579,8 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
         // in increasing order.
         let body_sites = self.bodies_sites.swap_remove(body_index);
         for site_tag in body_sites.iter().rev() {
-            let site_index = self.site_indices[*site_tag].expect("A valid site.");
+            let site_index = self.site_indices[*site_tag]
+                .expect("bodies_sites and site_indices should be consistent");
             let removed_site = self.sites.swap_remove(site_index);
             if site_index < self.sites.len() {
                 self.site_indices[self.sites[site_index].site_tag] = Some(site_index);
@@ -655,11 +656,12 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
 
         // Update site properties
         for (i, site_tag) in self.bodies_sites[body_index].iter().enumerate() {
-            let site_index = self.site_indices[*site_tag].expect("site_tag should be a valid tag");
+            let site_index = self.site_indices[*site_tag]
+                .expect("bodies_sites and site_indices should be consistent");
             self.sites[site_index].properties = self
                 .boundary
                 .wrap_site(body.properties.transform(&body.sites[i]))
-                .expect("valid site");
+                .expect("sites should be validated as wrappable prior to this loop");
         }
 
         Ok(())
@@ -748,7 +750,8 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
                  Body::point(Cartesian::from([7.0, 8.0]))])
         .try_build()?;
 
-    microstate.remove_body(microstate.body_indices()[0].expect("valid tag"));
+    microstate.remove_body(microstate.body_indices()[0]
+        .expect("the body with index 0 should be present in the microstate"));
 
     assert_eq!(microstate.body_indices()[0], None);
     assert!(matches!(microstate.body_indices()[3], Some(_)));
@@ -871,9 +874,10 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
         reason = "Panic would occur due to a bug in hoomd-rs."
     )]
     pub fn iter_body_sites(&self, body_index: usize) -> impl Iterator<Item = &Site<S>> {
-        self.bodies_sites[body_index]
-            .iter()
-            .map(|site_tag| &self.sites[self.site_indices[*site_tag].expect("valid site tag")])
+        self.bodies_sites[body_index].iter().map(|site_tag| {
+            &self.sites[self.site_indices[*site_tag]
+                .expect("bodies_sites and site_indices should be consistent")]
+        })
     }
 }
 
@@ -1200,7 +1204,9 @@ mod tests {
                 // Add bodies more often than removing bodies so that typical
                 // test executions will result in a non-empty microstate.
                 let body = create_body(&mut rng);
-                let tag = microstate.add_body(body.clone()).expect("valid body");
+                let tag = microstate
+                    .add_body(body.clone())
+                    .expect("all bodies should be allowed with open boundary conditions");
                 reference_bodies.insert(tag, body);
             } else if move_type_r > 0.5 && !microstate.bodies.is_empty() {
                 let index = rng.random_range(..microstate.bodies.len());
@@ -1210,12 +1216,14 @@ mod tests {
             } else if !microstate.bodies.is_empty() {
                 let index = rng.random_range(..microstate.bodies.len());
                 let tag = microstate.bodies()[index].tag;
-                let body = reference_bodies.get_mut(&tag).expect("valid body tag");
+                let body = reference_bodies
+                    .get_mut(&tag)
+                    .expect("tags in the microstate should also be present in the reference");
 
                 body.properties.position += rng.random::<Cartesian<2>>() * MAX_BODY_TRANSLATE;
                 microstate
                     .update_body_properties(index, body.properties)
-                    .expect("valid update");
+                    .expect("all bodies should be allowed with open boundary conditions");
             }
         }
 
@@ -1235,7 +1243,8 @@ mod tests {
         }
 
         for (tag, body) in &reference_bodies {
-            let body_index = microstate.body_indices()[*tag].expect("valid index");
+            let body_index = microstate.body_indices()[*tag]
+                .expect("tags in the reference should also be present in the microstate");
             assert_eq!(microstate.bodies()[body_index].item, *body);
         }
 
@@ -1246,7 +1255,8 @@ mod tests {
         }
 
         for site in microstate.sites() {
-            let body_index = microstate.body_indices()[site.body_tag].expect("valid body");
+            let body_index = microstate.body_indices()[site.body_tag]
+                .expect("tags in the microstate should also be in the reference");
             assert!(microstate.bodies_sites[body_index].contains(&site.site_tag));
         }
 
@@ -1258,7 +1268,8 @@ mod tests {
         {
             assert_eq!(body.item.sites.len(), body_sites.len());
             for site_tag in body_sites {
-                let site_index = microstate.site_indices()[*site_tag].expect("valid index");
+                let site_index = microstate.site_indices()[*site_tag]
+                    .expect("body_sites should be consistent with site_indices");
                 assert_eq!(microstate.sites()[site_index].body_tag, body.tag);
             }
         }
@@ -1284,14 +1295,17 @@ mod tests {
 
         for _ in 0..N_STEPS {
             let body = create_body(&mut rng);
-            microstate.add_body(body).expect("valid body");
+            microstate
+                .add_body(body)
+                .expect("all bodies should be allowed in open boundary conditions");
         }
 
         let mut removal_order = (0..N_STEPS).collect::<Vec<_>>();
         removal_order.shuffle(&mut rng);
 
         for body_tag in removal_order {
-            let body_index = microstate.body_indices()[body_tag].expect("valid tag");
+            let body_index =
+                microstate.body_indices()[body_tag].expect("body tags should be assigned in order");
             microstate.remove_body(body_index);
         }
 

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -6,6 +6,7 @@
 
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
+use std::marker::PhantomData;
 
 use crate::boundary::{Boundary, Open};
 use crate::property::Position;
@@ -29,12 +30,13 @@ documentation](crate) for a full overview and the method-specific documentation
 for additional details.
 
 The generic type names are:
+* `V`: The [`Vector`] space in which bodies and sites exist.
 * `B`: The [`Body::properties`](crate::Body) type.
 * `S`: The [`Site::properties`](crate::Site) type.
 * `C`: The [`boundary`](crate::boundary) condition type.
 */
 #[derive(Clone)]
-pub struct Microstate<B, S = B, C = Open> {
+pub struct Microstate<V, B, S = B, C = Open> {
     /// Total number of steps that this microstate has been advanced in a simulation model.
     step: u64,
 
@@ -67,9 +69,12 @@ pub struct Microstate<B, S = B, C = Open> {
 
     /// The range of allowed particle positions and a description of any periodicity.
     boundary: C,
+
+    /// Make Microstate depend on the vector type V even though it doesn't store a vector.
+    vector_type: PhantomData<V>,
 }
 
-impl<B, S> Default for Microstate<B, S, Open> {
+impl<V, B, S> Default for Microstate<V, B, S, Open> {
     /** Construct an empty microstate with open boundary conditions.
 
     See [`Microstate::new`].
@@ -80,7 +85,7 @@ impl<B, S> Default for Microstate<B, S, Open> {
     }
 }
 
-impl<B, S> Microstate<B, S, Open> {
+impl<V, B, S> Microstate<V, B, S, Open> {
     /** Construct an empty microstate with open boundary conditions.
 
     The microstate starts at step 0, substep 0, random number seed 0,
@@ -92,7 +97,7 @@ impl<B, S> Microstate<B, S, Open> {
     use hoomd_microstate::{Microstate, property::Point};
     use hoomd_vector::Cartesian;
 
-    let microstate = Microstate::<Point<Cartesian<2>>>::new();
+    let microstate = Microstate::<Cartesian<2>, Point<Cartesian<2>>>::new();
     assert_eq!(microstate.step(), 0);
     assert_eq!(microstate.substep(), 0);
     assert_eq!(microstate.seed(), 0);
@@ -115,12 +120,13 @@ impl<B, S> Microstate<B, S, Open> {
             free_site_tags: BinaryHeap::new(),
             bodies_sites: Vec::new(),
             boundary: Open,
+            vector_type: PhantomData,
         }
     }
 }
 
 /// Access and manage the simulation step, substep, RNG seeds.
-impl<B, S, C> Microstate<B, S, C> {
+impl<V, B, S, C> Microstate<V, B, S, C> {
     /** Get the simulation step.
 
     # Examples
@@ -130,7 +136,7 @@ impl<B, S, C> Microstate<B, S, C> {
     use hoomd_microstate::{Microstate, property::Point};
     use hoomd_vector::Cartesian;
 
-    let microstate = Microstate::<Point<Cartesian<2>>>::new();
+    let microstate = Microstate::<Cartesian<2>, Point<Cartesian<2>>>::new();
     assert_eq!(microstate.step(), 0);
     ```
 
@@ -165,7 +171,7 @@ impl<B, S, C> Microstate<B, S, C> {
     use hoomd_microstate::{Microstate, property::Point};
     use hoomd_vector::Cartesian;
 
-    let mut microstate = Microstate::<Point<Cartesian<2>>>::new();
+    let mut microstate = Microstate::<Cartesian<2>, Point<Cartesian<2>>>::new();
     microstate.increment_step();
 
     assert_eq!(microstate.step(), 1);
@@ -176,7 +182,7 @@ impl<B, S, C> Microstate<B, S, C> {
     use hoomd_microstate::{Microstate, property::Point};
     use hoomd_vector::Cartesian;
 
-    let mut microstate = Microstate::<Point<Cartesian<2>>>::new();
+    let mut microstate = Microstate::<Cartesian<2>, Point<Cartesian<2>>>::new();
 
     microstate.increment_substep();
     microstate.increment_substep();
@@ -202,7 +208,7 @@ impl<B, S, C> Microstate<B, S, C> {
     use hoomd_microstate::{Microstate, property::Point};
     use hoomd_vector::Cartesian;
 
-    let mut microstate = Microstate::<Point<Cartesian<2>>>::new();
+    let mut microstate = Microstate::<Cartesian<2>, Point<Cartesian<2>>>::new();
     microstate.increment_substep();
 
     assert_eq!(microstate.substep(), 1);
@@ -221,7 +227,7 @@ impl<B, S, C> Microstate<B, S, C> {
     use hoomd_microstate::{Microstate, property::Point};
     use hoomd_vector::Cartesian;
 
-    let mut microstate = Microstate::<Point<Cartesian<2>>>::new();
+    let mut microstate = Microstate::<Cartesian<2>, Point<Cartesian<2>>>::new();
     microstate.increment_substep();
 
     assert_eq!(microstate.substep(), 1);
@@ -241,7 +247,7 @@ impl<B, S, C> Microstate<B, S, C> {
     use hoomd_microstate::{Microstate, property::Point};
     use hoomd_vector::Cartesian;
 
-    let mut microstate = Microstate::<Point<Cartesian<2>>>::new();
+    let mut microstate = Microstate::<Cartesian<2>, Point<Cartesian<2>>>::new();
 
     assert_eq!(microstate.seed(), 0);
     ```
@@ -279,7 +285,7 @@ impl<B, S, C> Microstate<B, S, C> {
     use hoomd_microstate::{Microstate, property::Point};
     use hoomd_vector::Cartesian;
 
-    let mut microstate = Microstate::<Point<Cartesian<2>>>::new();
+    let mut microstate = Microstate::<Cartesian<2>, Point<Cartesian<2>>>::new();
 
     let rng = microstate.counter().make_rng();
     ```
@@ -290,7 +296,7 @@ impl<B, S, C> Microstate<B, S, C> {
     use hoomd_microstate::{Microstate, property::Point};
     use hoomd_vector::Cartesian;
 
-    let mut microstate = Microstate::<Point<Cartesian<2>>>::new();
+    let mut microstate = Microstate::<Cartesian<2>, Point<Cartesian<2>>>::new();
 
     let tag = 10;
     let rng = microstate.counter().index(tag).make_rng();
@@ -303,7 +309,7 @@ impl<B, S, C> Microstate<B, S, C> {
 }
 
 /// Access and manage the boundary condition.
-impl<B, S, C> Microstate<B, S, C> {
+impl<V, B, S, C> Microstate<V, B, S, C> {
     /** Get the boundary condition.
 
     # Example
@@ -329,7 +335,7 @@ impl<B, S, C> Microstate<B, S, C> {
 
 /** Manage bodies in the microstate.
 */
-impl<B, S, C> Microstate<B, S, C> {
+impl<V, B, S, C> Microstate<V, B, S, C> {
     /** Add a new body to the microstate.
 
     Each body is assigned a unique tag. The first body is given tag 0,
@@ -381,14 +387,14 @@ impl<B, S, C> Microstate<B, S, C> {
         clippy::missing_panics_doc,
         reason = "Panic would occur due to a bug in hoomd-rs."
     )]
-    pub fn add_body<V>(&mut self, body: Body<B, S>) -> Result<usize, Error>
+    pub fn add_body(&mut self, body: Body<B, S>) -> Result<usize, Error>
     where
         B: Transform<S> + Position<V>,
         S: Position<V>,
-        C: Boundary<V>,
+        C: Boundary<V, B, S>,
     {
         let mut body = body;
-        body.properties = self.boundary.wrap(body.properties)?;
+        body.properties = self.boundary.wrap_body(body.properties)?;
 
         // An unknown site in the body might not wrap into the boundary.
         // Check that they do first before starting to modify internal data
@@ -397,7 +403,7 @@ impl<B, S, C> Microstate<B, S, C> {
         // (complicated) or a staging Vec (would require additional allocations
         // or a reusable scratch storage).
         for s in &body.sites {
-            self.boundary.wrap(body.properties.transform(s))?;
+            self.boundary.wrap_site(body.properties.transform(s))?;
         }
 
         // Find body tag before adding sites
@@ -419,7 +425,7 @@ impl<B, S, C> Microstate<B, S, C> {
                 site_tag,
                 properties: self
                     .boundary
-                    .wrap(body.properties.transform(s))
+                    .wrap_site(body.properties.transform(s))
                     .expect("can wrap site"),
                 body_tag,
             });
@@ -484,12 +490,12 @@ impl<B, S, C> Microstate<B, S, C> {
     ```
     */
     #[inline]
-    pub fn try_extend_bodies<T, V>(&mut self, bodies: T) -> Result<(), Error>
+    pub fn try_extend_bodies<T>(&mut self, bodies: T) -> Result<(), Error>
     where
         T: IntoIterator<Item = Body<B, S>>,
         B: Transform<S> + Position<V>,
         S: Position<V>,
-        C: Boundary<V>,
+        C: Boundary<V, B, S>,
     {
         for body in bodies {
             self.add_body(body)?;
@@ -598,18 +604,14 @@ impl<B, S, C> Microstate<B, S, C> {
         clippy::missing_panics_doc,
         reason = "Panic would occur due to a bug in hoomd-rs."
     )]
-    pub fn update_body_properties<V>(
-        &mut self,
-        body_index: usize,
-        properties: B,
-    ) -> Result<(), Error>
+    pub fn update_body_properties(&mut self, body_index: usize, properties: B) -> Result<(), Error>
     where
         B: Transform<S> + Position<V>,
         S: Position<V>,
-        C: Boundary<V>,
+        C: Boundary<V, B, S>,
     {
         let body = &mut self.bodies[body_index].item;
-        let new_body_properties = self.boundary.wrap(properties)?;
+        let new_body_properties = self.boundary.wrap_body(properties)?;
 
         // An unknown site in the body might not wrap into the boundary.
         // Check that they do first before starting to modify internal data
@@ -618,7 +620,7 @@ impl<B, S, C> Microstate<B, S, C> {
         // staging Vec (would require allocation/deallocation per update or a
         // reusable scratch storage).
         for s in &body.sites {
-            self.boundary.wrap(new_body_properties.transform(s))?;
+            self.boundary.wrap_site(new_body_properties.transform(s))?;
         }
 
         body.properties = new_body_properties;
@@ -628,7 +630,8 @@ impl<B, S, C> Microstate<B, S, C> {
             let site_index = self.site_indices[*site_tag].expect("site_tag should be a valid tag");
             self.sites[site_index].properties = self
                 .boundary
-                .wrap(body.properties.transform(&body.sites[i]))?;
+                .wrap_site(body.properties.transform(&body.sites[i]))
+                .expect("valid site");
         }
 
         Ok(())
@@ -637,7 +640,7 @@ impl<B, S, C> Microstate<B, S, C> {
 
 /** Access contents of the microstate.
 */
-impl<B, S, C> Microstate<B, S, C> {
+impl<V, B, S, C> Microstate<V, B, S, C> {
     /** Access the microstate's tagged bodies in index order.
 
     [`Microstate`] stores bodies in a flat memory region. The [`Tagged`] type
@@ -1070,11 +1073,11 @@ impl<B, S, C> MicrostateBuilder<B, S, C> {
     ```
     */
     #[inline]
-    pub fn try_build<V>(self) -> Result<Microstate<B, S, C>, Error>
+    pub fn try_build<V>(self) -> Result<Microstate<V, B, S, C>, Error>
     where
         B: Transform<S> + Position<V>,
         S: Position<V>,
-        C: Boundary<V>,
+        C: Boundary<V, B, S>,
     {
         let mut microstate = Microstate {
             step: self.step,
@@ -1088,6 +1091,7 @@ impl<B, S, C> MicrostateBuilder<B, S, C> {
             site_indices: Vec::new(),
             free_site_tags: BinaryHeap::new(),
             bodies_sites: Vec::new(),
+            vector_type: PhantomData,
         };
 
         microstate.try_extend_bodies(self.bodies)?;

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -754,6 +754,7 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
     ```
     use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
     use hoomd_vector::Cartesian;
+    use anyhow::anyhow;
 
     # fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut microstate = MicrostateBuilder::new()
@@ -763,15 +764,17 @@ impl<V, B, S, C> Microstate<V, B, S, C> {
                  Body::point(Cartesian::from([7.0, 8.0]))])
         .try_build()?;
 
-    microstate.remove_body(microstate.body_indices()[0]
-        .expect("the body with index 0 should be present in the microstate"));
+    let index = microstate.body_indices()[0]
+        .ok_or(anyhow!("body 0 is not present"))?;
+    microstate.remove_body(index);
 
     assert_eq!(microstate.body_indices()[0], None);
     assert!(matches!(microstate.body_indices()[3], Some(_)));
 
-    if let Some(index) = microstate.body_indices()[2] {
-        assert_eq!(microstate.bodies()[index].item.properties.position, [5.0, 6.0].into());
-    }
+    let index = microstate.body_indices()[2]
+        .ok_or(anyhow!("body 2 is not present"))?;
+    assert_eq!(microstate.bodies()[index].item.properties.position,
+        [5.0, 6.0].into());
     # Ok(())
     # }
     ```

--- a/hoomd-utility/src/lib.rs
+++ b/hoomd-utility/src/lib.rs
@@ -23,10 +23,10 @@ use thiserror::Error;
 #[derive(Error, PartialEq, Debug)]
 pub enum Error {
     /// A positive value greater than 0 is required.
-    #[error("Expected a value greater than 0, got: {0}")]
+    #[error("{0} is not greater than 0")]
     NotPositive(f64),
 
     /// A finite value is required.
-    #[error("Expected a real value, got: {0}")]
+    #[error("{0} is not finite")]
     NotFinite(f64),
 }

--- a/hoomd-vector/src/angle.rs
+++ b/hoomd-vector/src/angle.rs
@@ -264,7 +264,7 @@ impl Distribution<Angle> for StandardUniform {
             clippy::expect_used,
             reason = "This constants chosen for this distribution are valid"
         )]
-        let uniform = Uniform::new(0.0, 2.0 * PI).expect("a valid distribution");
+        let uniform = Uniform::new(0.0, 2.0 * PI).expect("hard-coded distribution should be valid");
         Angle::from(uniform.sample(rng))
     }
 }

--- a/hoomd-vector/src/cartesian.rs
+++ b/hoomd-vector/src/cartesian.rs
@@ -885,10 +885,10 @@ mod tests {
         assert_eq!(unit_a, [3.0 / 5.0, 0.0, 4.0 / 5.0].into());
 
         let a = Cartesian::from((0.0, 0.0, 0.0));
-        assert!(matches!(a.to_unit(), Err(Error::InvalidMagnitude)));
+        assert!(matches!(a.to_unit(), Err(Error::InvalidVectorMagnitude)));
         assert!(matches!(
             Unit::<Cartesian<3>>::try_from([0.0, 0.0, 0.0]),
-            Err(Error::InvalidMagnitude)
+            Err(Error::InvalidVectorMagnitude)
         ));
     }
 

--- a/hoomd-vector/src/cartesian.rs
+++ b/hoomd-vector/src/cartesian.rs
@@ -393,7 +393,8 @@ impl<const N: usize> Distribution<Cartesian<N>> for StandardUniform {
             clippy::expect_used,
             reason = "This constants chosen for this distribution are valid"
         )]
-        let uniform = Uniform::new_inclusive(-1.0, 1.0).expect("a valid distribution");
+        let uniform = Uniform::new_inclusive(-1.0, 1.0)
+            .expect("hard-coded range should form a valid distribution");
         Cartesian {
             coordinates: array::from_fn(|_| uniform.sample(rng)),
         }
@@ -858,25 +859,29 @@ mod tests {
     #[test]
     fn to_unit() {
         let a = Cartesian::from((2.0, 0.0, 0.0));
-        let (Unit(unit_a), _) = a.to_unit().expect("non-zero vector");
+        let (Unit(unit_a), _) = a
+            .to_unit()
+            .expect("hard-coded vector should have non-zero length");
         assert_eq!(unit_a, [1.0, 0.0, 0.0].into());
 
         let (Unit(unit_a), _) = a.to_unit_unchecked();
         assert_eq!(unit_a, [1.0, 0.0, 0.0].into());
 
-        let Unit(unit_a) =
-            Unit::<Cartesian<3>>::try_from([1.0, 0.0, 0.0]).expect("non-zero vector");
+        let Unit(unit_a) = Unit::<Cartesian<3>>::try_from([1.0, 0.0, 0.0])
+            .expect("hard-coded vector should have non-zero length");
         assert_eq!(unit_a, [1.0, 0.0, 0.0].into());
 
         let a = Cartesian::from((3.0, 0.0, 4.0));
-        let (Unit(unit_a), _) = a.to_unit().expect("non-zero vector");
+        let (Unit(unit_a), _) = a
+            .to_unit()
+            .expect("hard-coded vector should have non-zero length");
         assert_eq!(unit_a, [3.0 / 5.0, 0.0, 4.0 / 5.0].into());
 
         let (Unit(unit_a), _) = a.to_unit_unchecked();
         assert_eq!(unit_a, [3.0 / 5.0, 0.0, 4.0 / 5.0].into());
 
-        let Unit(unit_a) =
-            Unit::<Cartesian<3>>::try_from([3.0, 0.0, 4.0]).expect("non-zero vector");
+        let Unit(unit_a) = Unit::<Cartesian<3>>::try_from([3.0, 0.0, 4.0])
+            .expect("hard-coded vector should have non-zero length");
         assert_eq!(unit_a, [3.0 / 5.0, 0.0, 4.0 / 5.0].into());
 
         let a = Cartesian::from((0.0, 0.0, 0.0));

--- a/hoomd-vector/src/distribution.rs
+++ b/hoomd-vector/src/distribution.rs
@@ -40,7 +40,7 @@ impl<const N: usize> Distribution<Cartesian<N>> for Ball {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Cartesian<N> {
         let r = self.r.get();
 
-        let uniform = Uniform::new_inclusive(-r, r).expect("valid distribution");
+        let uniform = Uniform::new_inclusive(-r, r).expect("r should be a positive real value");
 
         loop {
             let v = Cartesian {
@@ -68,7 +68,8 @@ mod test {
         r => [0.5, 1.0, 12.0])]
     fn ball(r: f64) {
         let ball = Ball {
-            r: r.try_into().expect("valid distribution"),
+            r: r.try_into()
+                .expect("hard-coded constant should be positive"),
         };
         let mut rng = StdRng::seed_from_u64(1);
 

--- a/hoomd-vector/src/lib.rs
+++ b/hoomd-vector/src/lib.rs
@@ -181,12 +181,16 @@ use thiserror::Error;
 #[derive(Error, PartialEq, Debug)]
 pub enum Error {
     /// Attempted converting a value to a vector with a dimension not equal to the value's length.
-    #[error("Source does not match the target vector length.")]
+    #[error("source length does not match the target dimensions")]
     InvalidVectorLength,
 
-    /// Attempted normalizing a vector or quaternion with an invalid magnitude.
-    #[error("Invalid magnitude for normalization.")]
-    InvalidMagnitude,
+    /// Attempted to normalize a vector with an invalid magnitude.
+    #[error("cannot normalize the 0 vector")]
+    InvalidVectorMagnitude,
+
+    /// Attempted to normalize a quaternion with an invalid magnitude.
+    #[error("cannot normalize the 0 quaternion")]
+    InvalidQuaternionMagnitude,
 }
 
 /** Operate on elements of a normed vector space.
@@ -426,13 +430,13 @@ pub trait Vector:
 
     # Errors
 
-    [`Error::InvalidMagnitude`] when `self` is the 0 vector.
+    [`Error::InvalidVectorMagnitude`] when `self` is the 0 vector.
     */
     #[inline]
     fn to_unit(self) -> Result<(Unit<Self>, f64), Error> {
         let norm = self.norm();
         if norm == 0.0 {
-            Err(Error::InvalidMagnitude)
+            Err(Error::InvalidVectorMagnitude)
         } else {
             Ok((Unit(self / norm), norm))
         }

--- a/hoomd-vector/src/quaternion.rs
+++ b/hoomd-vector/src/quaternion.rs
@@ -773,7 +773,7 @@ impl Distribution<Versor> for StandardUniform {
             clippy::expect_used,
             reason = "This constants chosen for this distribution are valid"
         )]
-        let uniform = Uniform::new(-1.0, 1.0).expect("a valid distribution");
+        let uniform = Uniform::new(-1.0, 1.0).expect("hard-coded distribution should be valid");
 
         let (u, v) = loop {
             let u: f64 = uniform.sample(rng);
@@ -901,7 +901,8 @@ mod tests {
             let q = Quaternion::from([5.0, 3.0, -1.0, 1.0]);
 
             assert_relative_eq!(
-                q.to_versor().expect("non-zero quaternion"),
+                q.to_versor()
+                    .expect("hard-coded quatnernion should be non zero"),
                 Versor(Quaternion {
                     scalar: 5.0 / 6.0,
                     vector: [3.0 / 6.0, -1.0 / 6.0, 1.0 / 6.0].into()
@@ -982,7 +983,7 @@ mod tests {
 
         #[rstest(
         theta => [0.0, PI/2.0, 1e-12 * PI, -3.0, 12345.6],
-        axis => [[1.0, 0.0, 0.0].try_into().expect("valid unit vector"), [1.0, -1.0, 1.0].try_into().expect("valid unit vector")],
+        axis => [[1.0, 0.0, 0.0].try_into().expect("hard-coded vector should have non-zero length"), [1.0, -1.0, 1.0].try_into().expect("hard-coded vector should have non-zero length")],
     )]
         fn from_axis_angle(theta: f64, axis: Unit<Cartesian<3>>) {
             let Unit(axis_vector) = axis;
@@ -997,7 +998,9 @@ mod tests {
         theta_2 => [-0.0, -PI/3.0, PI, 2.0 * PI]
     )]
         fn combine_same_axis(theta_1: f64, theta_2: f64) {
-            let axis = [1.0, 0.0, 0.0].try_into().expect("valid unit vector");
+            let axis = [1.0, 0.0, 0.0]
+                .try_into()
+                .expect("hard-coded vector should have non-zero length");
             let Unit(axis_vector) = axis;
 
             let a = Versor::from_axis_angle(axis, theta_1);
@@ -1042,11 +1045,15 @@ mod tests {
         #[test]
         fn rotate() {
             let z_pi_2 = Versor::from_axis_angle(
-                [0.0, 0.0, 1.0].try_into().expect("valid unit vector"),
+                [0.0, 0.0, 1.0]
+                    .try_into()
+                    .expect("hard-coded vector should have non-zero length"),
                 PI / 2.0,
             );
             let y_pi_4 = Versor::from_axis_angle(
-                [0.0, 1.0, 0.0].try_into().expect("valid unit vector"),
+                [0.0, 1.0, 0.0]
+                    .try_into()
+                    .expect("hard-coded vector should have non-zero length"),
                 PI / 4.0,
             );
 
@@ -1056,11 +1063,15 @@ mod tests {
         #[test]
         fn precompute() {
             let z_pi_2 = RotationMatrix::from(Versor::from_axis_angle(
-                [0.0, 0.0, 1.0].try_into().expect("valid unit vector"),
+                [0.0, 0.0, 1.0]
+                    .try_into()
+                    .expect("hard-coded vector should have non-zero length"),
                 PI / 2.0,
             ));
             let y_pi_4 = RotationMatrix::from(Versor::from_axis_angle(
-                [0.0, 1.0, 0.0].try_into().expect("valid unit vector"),
+                [0.0, 1.0, 0.0]
+                    .try_into()
+                    .expect("hard-coded vector should have non-zero length"),
                 PI / 4.0,
             ));
 
@@ -1070,11 +1081,15 @@ mod tests {
         #[test]
         fn combine_different_axis() {
             let a = Versor::from_axis_angle(
-                [1.0, 0.0, 0.0].try_into().expect("valid unit vector"),
+                [1.0, 0.0, 0.0]
+                    .try_into()
+                    .expect("hard-coded vector should have non-zero length"),
                 PI / 4.0,
             );
             let b = Versor::from_axis_angle(
-                [0.0, 0.0, 1.0].try_into().expect("valid unit vector"),
+                [0.0, 0.0, 1.0]
+                    .try_into()
+                    .expect("hard-coded vector should have non-zero length"),
                 PI / 2.0,
             );
 
@@ -1086,7 +1101,9 @@ mod tests {
         #[rstest(theta => [0.0, 1.0, 2.125])]
         fn inverted(theta: f64) {
             let q1 = Versor::from_axis_angle(
-                [1.0, 0.5, -2.0].try_into().expect("valid unit vector"),
+                [1.0, 0.5, -2.0]
+                    .try_into()
+                    .expect("hard-coded vector should have non-zero length"),
                 theta,
             );
             let q2 = q1.inverted();

--- a/hoomd-vector/src/quaternion.rs
+++ b/hoomd-vector/src/quaternion.rs
@@ -918,7 +918,10 @@ mod tests {
             );
 
             let zero = Quaternion::from([0.0, 0.0, 0.0, 0.0]);
-            assert!(matches!(zero.to_versor(), Err(Error::InvalidQuaternionMagnitude)));
+            assert!(matches!(
+                zero.to_versor(),
+                Err(Error::InvalidQuaternionMagnitude)
+            ));
         }
 
         #[test]

--- a/hoomd-vector/src/quaternion.rs
+++ b/hoomd-vector/src/quaternion.rs
@@ -238,13 +238,13 @@ impl Quaternion {
 
     # Errors
 
-    [`Error::InvalidMagnitude`] when `self` is the 0 quaternion.
+    [`Error::InvalidQuaternionMagnitude`] when `self` is the 0 quaternion.
     */
     #[inline]
     pub fn to_versor(self) -> Result<Versor, Error> {
         let mag = self.norm();
         if mag == 0.0 {
-            Err(Error::InvalidMagnitude)
+            Err(Error::InvalidQuaternionMagnitude)
         } else {
             Ok(Versor(self / mag))
         }
@@ -918,7 +918,7 @@ mod tests {
             );
 
             let zero = Quaternion::from([0.0, 0.0, 0.0, 0.0]);
-            assert!(matches!(zero.to_versor(), Err(Error::InvalidMagnitude)));
+            assert!(matches!(zero.to_versor(), Err(Error::InvalidQuaternionMagnitude)));
         }
 
         #[test]


### PR DESCRIPTION
Implement the `Boundary` trait and the `Square` boundary.

* Methods that add or update bodies/sites are now fallible.
* `Sweep` rejects trial moves that leave the boundary.
* `Microstate` is now generic on the vector space `V` via `PhantomData`.

Boundaries are not "walls". They apply only to the positions of the bodies and sites.