### PR TITLE
Add 2D camera controls to the `hoomd_bevy` crate

### DIFF
--- a/.codebook.toml
+++ b/.codebook.toml
@@ -31,6 +31,7 @@ words = [
     "tetronimo",
     "tetronimoes",
     "timestep",
+    "trackpad",
     "versor",
     "webgl",
     "webgpu",

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,10 +11,11 @@ build:
     - mkdir -p "${PATH%%:*}"
     - curl -sSL "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-gnu.tgz" | tar -xvz --directory "${PATH%%:*}"
     # Install mdbook
-    - cargo binstall mdbook@0.4.52 mdbook-katex@0.9.3 mdbook-alerts@0.8.0 --no-confirm --disable-strategies=compile --disable-telemetry -v --install-path "${PATH%%:*}"
+    - cargo binstall mdbook@0.4.52 mdbook-alerts@0.8.0 --no-confirm --disable-strategies=compile --disable-telemetry --install-path "${PATH%%:*}"
+    - curl -sSL "https://github.com/lzanini/mdbook-katex/releases/download/0.9.3-binaries/mdbook-katex-v0.9.3-x86_64-unknown-linux-gnu.tar.gz" | tar -xvz --directory "${PATH%%:*}"
     # Install wasm toolchain
     - rustup target install wasm32-unknown-unknown
-    - cargo binstall wasm-bindgen-cli@0.2.100 --no-confirm --disable-strategies=compile --disable-telemetry -v --install-path "${PATH%%:*}"
+    - cargo binstall wasm-bindgen-cli@0.2.100 --no-confirm --disable-strategies=compile --disable-telemetry --install-path "${PATH%%:*}"
     - curl -sSL "https://github.com/WebAssembly/binaryen/releases/download/version_123/binaryen-version_123-x86_64-linux.tar.gz" | tar -xvz --strip-components 2 --directory "${PATH%%:*}"
     - ls "${PATH%%:*}"
     # Build the WASM examples

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@ version: 2
 build:
   os: "ubuntu-24.04"
   tools:
-    rust: "1.86"
+    rust: "1.89"
   commands:
     # Install cargo binstall
     - mkdir -p "${PATH%%:*}"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,10 +11,10 @@ build:
     - mkdir -p "${PATH%%:*}"
     - curl -sSL "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-gnu.tgz" | tar -xvz --directory "${PATH%%:*}"
     # Install mdbook
-    - cargo binstall mdbook@0.4.52 mdbook-katex@0.9.3 mdbook-alerts@0.8.0 --no-confirm --install-path "${PATH%%:*}"
+    - cargo binstall mdbook@0.4.52 mdbook-katex@0.9.3 mdbook-alerts@0.8.0 --no-confirm --disable-strategies=compile --disable-telemetry -v --install-path "${PATH%%:*}"
     # Install wasm toolchain
     - rustup target install wasm32-unknown-unknown
-    - cargo binstall wasm-bindgen-cli@0.2.100 --no-confirm --install-path "${PATH%%:*}"
+    - cargo binstall wasm-bindgen-cli@0.2.100 --no-confirm --disable-strategies=compile --disable-telemetry -v --install-path "${PATH%%:*}"
     - curl -sSL "https://github.com/WebAssembly/binaryen/releases/download/version_123/binaryen-version_123-x86_64-linux.tar.gz" | tar -xvz --strip-components 2 --directory "${PATH%%:*}"
     - ls "${PATH%%:*}"
     # Build the WASM examples

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,8 +2,11 @@ version: 2
 build:
   os: "ubuntu-24.04"
   tools:
-    rust: "1.89"
+    rust: "1.86"
   commands:
+    # Rust 1.89.0 is needed to build hoomd-rs
+    - rustup install 1.89.0
+    - rustup default 1.89.0
     # Install cargo binstall
     - mkdir -p "${PATH%%:*}"
     - curl -sSL "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-gnu.tgz" | tar -xvz --directory "${PATH%%:*}"

--- a/examples/mc-tutorial/applying-interactions.rs
+++ b/examples/mc-tutorial/applying-interactions.rs
@@ -16,6 +16,7 @@ use hoomd_bevy::{
     AdvanceSet, HoomdBevyPlugin, Settings, Simulation,
     representation::RectangularBoundary,
     representation::disk::{self, Disk},
+    CameraSettings2D, camera_control_2d,
 };
 
 use anyhow::Context;
@@ -169,6 +170,9 @@ fn main() -> anyhow::Result<()> {
             .run_if(resource_changed::<Fill>)
             .after(AdvanceSet),
     );
+
+    app.insert_resource(CameraSettings2D::default());
+    app.add_systems(Update, camera_control_2d);
 
     app.run();
 

--- a/examples/mc-tutorial/applying-interactions.rs
+++ b/examples/mc-tutorial/applying-interactions.rs
@@ -13,10 +13,9 @@ use hoomd_vector::Cartesian;
 // ANCHOR_END: use
 
 use hoomd_bevy::{
-    AdvanceSet, HoomdBevyPlugin, Settings, Simulation,
+    AdvanceSet, HoomdBevyPlugin, InitialCamera, Settings, Simulation,
     representation::RectangularBoundary,
     representation::disk::{self, Disk},
-    CameraSettings2D, camera_control_2d,
 };
 
 use anyhow::Context;
@@ -142,7 +141,7 @@ fn main() -> anyhow::Result<()> {
     let l = simulation.microstate.boundary().0.edge_lengths[1].get() as f32;
     let hoomd_bevy_plugin = HoomdBevyPlugin {
         initial_settings: Settings {
-            viewport_height: l + 1.0,
+            camera: InitialCamera::Orthographic2d(l + 1.0),
             ..default()
         },
         simulation,
@@ -170,9 +169,6 @@ fn main() -> anyhow::Result<()> {
             .run_if(resource_changed::<Fill>)
             .after(AdvanceSet),
     );
-
-    app.insert_resource(CameraSettings2D::default());
-    app.add_systems(Update, camera_control_2d);
 
     app.run();
 

--- a/examples/mc-tutorial/custom-random-walk.rs
+++ b/examples/mc-tutorial/custom-random-walk.rs
@@ -14,6 +14,7 @@ use hoomd_vector::{Cartesian, Vector};
 use hoomd_bevy::{
     AdvanceSet, HoomdBevyPlugin, Settings, Simulation,
     representation::disk::{self, Disk},
+    CameraSettings2D, camera_control_2d,
 };
 
 use anyhow::Context;
@@ -157,6 +158,9 @@ fn main() -> anyhow::Result<()> {
             .run_if(resource_changed::<CustomRandomWalk>)
             .after(AdvanceSet),
     );
+
+    app.insert_resource(CameraSettings2D::default());
+    app.add_systems(Update, camera_control_2d);
 
     app.run();
 

--- a/examples/mc-tutorial/custom-random-walk.rs
+++ b/examples/mc-tutorial/custom-random-walk.rs
@@ -12,9 +12,8 @@ use hoomd_vector::{Cartesian, Vector};
 // ANCHOR_END: use
 
 use hoomd_bevy::{
-    AdvanceSet, HoomdBevyPlugin, Settings, Simulation,
+    AdvanceSet, HoomdBevyPlugin, InitialCamera, Settings, Simulation,
     representation::disk::{self, Disk},
-    CameraSettings2D, camera_control_2d,
 };
 
 use anyhow::Context;
@@ -139,7 +138,7 @@ fn main() -> anyhow::Result<()> {
         CustomRandomWalk::new().context("failed to setup simulation")?;
     let hoomd_bevy_plugin = HoomdBevyPlugin {
         initial_settings: Settings {
-            viewport_height: 110.0,
+            camera: InitialCamera::Orthographic2d(110.0),
             ..default()
         },
         simulation,
@@ -158,9 +157,6 @@ fn main() -> anyhow::Result<()> {
             .run_if(resource_changed::<CustomRandomWalk>)
             .after(AdvanceSet),
     );
-
-    app.insert_resource(CameraSettings2D::default());
-    app.add_systems(Update, camera_control_2d);
 
     app.run();
 

--- a/examples/mc-tutorial/random-walk.rs
+++ b/examples/mc-tutorial/random-walk.rs
@@ -10,6 +10,7 @@ use hoomd_vector::Cartesian;
 use hoomd_bevy::{
     AdvanceSet, HoomdBevyPlugin, Settings, Simulation,
     representation::disk::{self, Disk},
+    CameraSettings2D, camera_control_2d,
 };
 
 use anyhow::Context;
@@ -119,6 +120,9 @@ fn main() -> anyhow::Result<()> {
             .run_if(resource_changed::<RandomWalk>)
             .after(AdvanceSet),
     );
+
+    app.insert_resource(CameraSettings2D::default());
+    app.add_systems(Update, camera_control_2d);
 
     app.run();
 

--- a/examples/mc-tutorial/random-walk.rs
+++ b/examples/mc-tutorial/random-walk.rs
@@ -8,9 +8,8 @@ use hoomd_vector::Cartesian;
 // ANCHOR_END: use
 
 use hoomd_bevy::{
-    AdvanceSet, HoomdBevyPlugin, Settings, Simulation,
+    AdvanceSet, HoomdBevyPlugin, InitialCamera, Settings, Simulation,
     representation::disk::{self, Disk},
-    CameraSettings2D, camera_control_2d,
 };
 
 use anyhow::Context;
@@ -101,7 +100,7 @@ fn main() -> anyhow::Result<()> {
     let simulation = RandomWalk::new().context("failed to setup simulation")?;
     let hoomd_bevy_plugin = HoomdBevyPlugin {
         initial_settings: Settings {
-            viewport_height: 110.0,
+            camera: InitialCamera::Orthographic2d(110.0),
             ..default()
         },
         simulation,
@@ -120,12 +119,6 @@ fn main() -> anyhow::Result<()> {
             .run_if(resource_changed::<RandomWalk>)
             .after(AdvanceSet),
     );
-
-    app.insert_resource(CameraSettings2D {
-        zoom_speed: 0.02,
-        ..default()
-    });
-    app.add_systems(Update, camera_control_2d);
 
     app.run();
 

--- a/examples/mc-tutorial/random-walk.rs
+++ b/examples/mc-tutorial/random-walk.rs
@@ -121,7 +121,10 @@ fn main() -> anyhow::Result<()> {
             .after(AdvanceSet),
     );
 
-    app.insert_resource(CameraSettings2D::default());
+    app.insert_resource(CameraSettings2D {
+        zoom_speed: 0.02,
+        ..default()
+    });
     app.add_systems(Update, camera_control_2d);
 
     app.run();

--- a/examples/mc-tutorial/tetronimoes.rs
+++ b/examples/mc-tutorial/tetronimoes.rs
@@ -18,10 +18,9 @@ use hoomd_vector::{Angle, Cartesian};
 // ANCHOR_END: use
 
 use hoomd_bevy::{
-    AdvanceSet, HoomdBevyPlugin, Settings, Simulation,
+    AdvanceSet, HoomdBevyPlugin, InitialCamera, Settings, Simulation,
     representation::RectangularBoundary,
     representation::disk::{self, Disk},
-    CameraSettings2D, camera_control_2d,
 };
 
 use anyhow::Context;
@@ -236,7 +235,7 @@ fn main() -> anyhow::Result<()> {
     let hoomd_bevy_plugin = HoomdBevyPlugin {
         initial_settings: Settings {
             sps_limit: 64.0,
-            viewport_height: l + 1.0,
+            camera: InitialCamera::Orthographic2d(l + 1.0),
             ..default()
         },
         simulation,
@@ -268,9 +267,6 @@ fn main() -> anyhow::Result<()> {
             .run_if(resource_changed::<Tetronimoes>)
             .after(AdvanceSet),
     );
-
-    app.insert_resource(CameraSettings2D::default());
-    app.add_systems(Update, camera_control_2d);
 
     app.run();
 

--- a/examples/mc-tutorial/tetronimoes.rs
+++ b/examples/mc-tutorial/tetronimoes.rs
@@ -21,6 +21,7 @@ use hoomd_bevy::{
     AdvanceSet, HoomdBevyPlugin, Settings, Simulation,
     representation::RectangularBoundary,
     representation::disk::{self, Disk},
+    CameraSettings2D, camera_control_2d,
 };
 
 use anyhow::Context;
@@ -267,6 +268,9 @@ fn main() -> anyhow::Result<()> {
             .run_if(resource_changed::<Tetronimoes>)
             .after(AdvanceSet),
     );
+
+    app.insert_resource(CameraSettings2D::default());
+    app.add_systems(Update, camera_control_2d);
 
     app.run();
 

--- a/hoomd-bevy/Cargo.toml
+++ b/hoomd-bevy/Cargo.toml
@@ -27,6 +27,9 @@ hoomd-microstate.workspace = true
 hoomd-vector.workspace = true
 web-time = "1.1.0"
 
+# web-sys = "0.3.77"
+# `web_sys::console::log_1(&msg.into());` is useful for println! type debugging in wasm
+
 # Work around failing build: https://github.com/bevyengine/bevy/issues/17699#issuecomment-2862717597
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.3.3", default-features = false, features = ["wasm_js"] }

--- a/hoomd-bevy/src/lib.rs
+++ b/hoomd-bevy/src/lib.rs
@@ -52,7 +52,14 @@ See any one of the many *hoomd-rs* examples that use [`HoomdBevyPlugin`].
 use std::ops::Range;
 
 use anyhow::Context;
-use bevy::{asset::embedded_asset, input::mouse::{AccumulatedMouseMotion, AccumulatedMouseScroll}, prelude::*, time::common_conditions::once_after_delay};
+use bevy::{
+    asset::embedded_asset,
+    input::common_conditions::{input_just_released, input_pressed},
+    input::mouse::MouseWheel,
+    prelude::*,
+    time::common_conditions::once_after_delay,
+    window::PrimaryWindow,
+};
 #[cfg(not(target_arch = "wasm32"))]
 use bevy::{
     render::view::window::screenshot::{Screenshot, save_to_disk},
@@ -156,6 +163,21 @@ pub enum MenuState {
     Settings,
 }
 
+/// Configure the initial camera view and set how the camera will be controlled.
+#[derive(Clone)]
+pub enum InitialCamera {
+    /** Two dimensional top down camera showing the xy plane.
+
+    The single field sets the height of the visible area. The width is set
+    automatically based on the window dimensions.
+
+    Controls:
+    * Left click and drag to pan.
+    * Scroll to zoom.
+    */
+    Orthographic2d(f32),
+}
+
 /// Store parameters that influence how the simulation is executed.
 #[derive(Resource)]
 pub struct Settings {
@@ -165,8 +187,14 @@ pub struct Settings {
     /// Maximum number of steps per second to advance the simulation.
     pub sps_limit: f32,
 
-    /// Initial viewport height.
-    pub viewport_height: f32,
+    /// Initial camera.
+    pub camera: InitialCamera,
+
+    /// Clamp the orthographic camera's scale to this range.
+    pub zoom_range: Range<f32>,
+
+    /// Multiply mouse wheel inputs by this factor when using the orthographic camera.
+    pub zoom_speed: f32,
 }
 
 impl Default for Settings {
@@ -174,7 +202,9 @@ impl Default for Settings {
         Self {
             frame_budget_fraction: 0.9,
             sps_limit: 2048.0,
-            viewport_height: 10.0,
+            camera: InitialCamera::Orthographic2d(10.0),
+            zoom_range: 0.1..10.0,
+            zoom_speed: 0.25,
         }
     }
 }
@@ -184,24 +214,13 @@ impl Default for Settings {
 struct FrameBudget(Duration);
 
 /// Settings used by the camera controls.
-#[derive(Debug, Resource)]
-pub struct CameraSettings2D {
-    /// Clamp the orthographic camera's scale to this range
-    pub zoom_range: Range<f32>,
-    /// Multiply mouse wheel inputs by this factor when using the orthographic camera
-    pub zoom_speed: f32,
-}
+#[derive(Debug, Default, Resource)]
+pub struct CameraControl2d {
+    /// Coordinates clicked in the world frame.
+    world_position: Vec2,
 
-impl Default for CameraSettings2D {
-    fn default() -> Self {
-        CameraSettings2D {
-            // In orthographic projections, we specify camera scale relative to a default value of 1,
-            // in which one unit in world space corresponds to one pixel.
-            zoom_range: 0.1..10.0,
-            // This value was hand-tuned to ensure that zooming in and out feels smooth but not slow.
-            zoom_speed: 0.2,
-        }
-    }
+    /// Track whether the user is dragging the view.
+    dragging: bool,
 }
 
 /// The overlay UI root node.
@@ -703,18 +722,6 @@ F5      : Show/hide debugging information.
         Some(best_frame_time)
     }
 
-    // TODO: How to set 3D cameras? Use a marker type? Or an option in the settings?
-
-    /// Set up the 2D camera.
-    fn setup_camera(mut commands: Commands, viewport_height: f32) {
-        let projection = Projection::Orthographic(OrthographicProjection {
-            scaling_mode: bevy::render::camera::ScalingMode::FixedVertical { viewport_height },
-            ..OrthographicProjection::default_2d()
-        });
-
-        commands.spawn((Camera2d, projection));
-    }
-
     /// Set up the options menu.
     fn setup_options(
         mut commands: Commands,
@@ -800,6 +807,120 @@ F5      : Show/hide debugging information.
         }
     }
 
+    /// Set up the 2D camera.
+    fn setup_camera_2d(mut commands: Commands, viewport_height: f32) {
+        let projection = Projection::Orthographic(OrthographicProjection {
+            scaling_mode: bevy::render::camera::ScalingMode::FixedVertical { viewport_height },
+            ..OrthographicProjection::default_2d()
+        });
+
+        commands.spawn((Camera2d, projection));
+    }
+
+    /** Left click and drag to pan the 2D camera.
+
+    # Panics
+
+    Panics when the 2D camera viewport is invalid.
+    */
+    pub fn camera_pan_control_2d(
+        camera: Single<
+            (&Camera, &GlobalTransform, &mut Transform, &mut Projection),
+            With<Camera2d>,
+        >,
+        mut control: ResMut<CameraControl2d>,
+        buttons: Res<ButtonInput<MouseButton>>,
+        window: Single<&Window, With<PrimaryWindow>>,
+    ) {
+        // Firefox wasm builds do not behave well using AccumulatedMouseMotion. Use
+        // absolute window coordinates and a state machine to provide consistent
+        // panning behavior across all platforms.
+
+        let (camera, global_transform, mut transform, projection) = camera.into_inner();
+
+        let viewport_size = camera
+            .logical_viewport_size()
+            .unwrap_or(Vec2::new(1280.0, 720.0));
+
+        if let Projection::Orthographic(ref mut orthographic) = *projection.into_inner() {
+            if buttons.just_pressed(MouseButton::Left) {
+                if let Some(world_position) = window
+                    .cursor_position()
+                    .and_then(|cursor| camera.viewport_to_world_2d(global_transform, cursor).ok())
+                {
+                    control.world_position = world_position;
+                    control.dragging = true;
+                    return;
+                }
+            }
+
+            if !buttons.pressed(MouseButton::Left) {
+                control.dragging = false;
+                return;
+            }
+
+            if control.dragging
+                && let Some(current_cursor_position) = window.cursor_position()
+            {
+                let pixel_scale = orthographic.area.size() / viewport_size;
+
+                // Pan by placing control.world_position at the cursor position
+                let desired_cursor_position = camera
+                    .world_to_viewport(global_transform, Vec3::from((control.world_position, 0.0)))
+                    .expect("viewport should be valid");
+
+                let offset = (desired_cursor_position - current_cursor_position) * pixel_scale;
+                transform.translation.x += offset.x;
+                transform.translation.y -= offset.y;
+            }
+        }
+    }
+
+    /// Zoom the 2d camera using the mouse wheel or trackpad scroll gesture.
+    pub fn camera_zoom_control_2d(
+        camera: Single<
+            (&Camera, &GlobalTransform, &mut Transform, &mut Projection),
+            With<Camera2d>,
+        >,
+        settings: Res<Settings>,
+        mut scroll: EventReader<MouseWheel>,
+        window: Single<&Window, With<PrimaryWindow>>,
+    ) {
+        let (camera, global_transform, mut transform, projection) = camera.into_inner();
+
+        if let Projection::Orthographic(ref mut orthographic) = *projection.into_inner() {
+            let scroll = scroll.read().map(|e| e.y).fold(0.0, |total, y| total + y);
+
+            // The scroll events distinguish between line (mouse wheel) and pixel
+            // (trackpad) events. However, In wasm builds all major browsers report
+            // only pixel events. Tested on macOS, scrolling with the trackpad gave
+            // consistent values across all browsers and native. However, scrolling
+            // with the mouse wheel gave different scales between native and browser
+            // and from browser to browser (a factor of 100 from the smallest to
+            // the largest). Therefore, the best we can do is check the sign of the
+            // scroll event and act scale the camera in the appropriate direction.
+
+            let delta_zoom = -settings.zoom_speed.copysign(scroll);
+            let new_scale = (orthographic.scale * (1.0 + delta_zoom))
+                .clamp(settings.zoom_range.start, settings.zoom_range.end);
+            let scale_ratio = new_scale / orthographic.scale;
+
+            let world_position_result = window
+                .cursor_position()
+                .and_then(|cursor| camera.viewport_to_world_2d(global_transform, cursor).ok());
+
+            let delta_translation = match world_position_result {
+                None => Vec2::default(),
+                Some(world_position) => {
+                    (world_position - transform.translation.xy()) * (1.0 - scale_ratio)
+                }
+            };
+
+            orthographic.scale = new_scale;
+            transform.translation += Vec3::from((delta_translation, 0.0));
+        }
+    }
+
     /** Build the plugin.
 
     [`HoomdBevyPlugin`] does not implement [`Plugin`] and cannot be used with
@@ -812,10 +933,7 @@ F5      : Show/hide debugging information.
 
         embedded_asset!(app, "logo.png");
 
-        let initial_viewport_height = self.initial_settings.viewport_height;
-        let setup_camera = move |commands: Commands| {
-            Self::setup_camera(commands, initial_viewport_height);
-        };
+        let initial_camera = self.initial_settings.camera.clone();
 
         app.add_plugins(FrameTimeDiagnosticsPlugin::default())
             .insert_resource(ClearColor(Self::CLEAR))
@@ -825,7 +943,6 @@ F5      : Show/hide debugging information.
             .insert_resource(self.simulation)
             .insert_state(PauseState::Running)
             .insert_state(MenuState::None)
-            .add_systems(Startup, setup_camera)
             .add_systems(
                 Startup,
                 (
@@ -866,6 +983,30 @@ F5      : Show/hide debugging information.
                 Update,
                 (Self::keyboard_sps, Self::keyboard_frame_budget).in_set(SettingsMenuInputSet),
             );
+
+        match initial_camera {
+            InitialCamera::Orthographic2d(initial_viewport_height) => {
+                app.add_systems(
+                    Update,
+                    Self::camera_pan_control_2d
+                        .run_if(
+                            input_pressed(MouseButton::Left)
+                                .or(input_just_released(MouseButton::Left)),
+                        )
+                        .in_set(NoMenuInputSet),
+                )
+                .add_systems(
+                    Update,
+                    Self::camera_zoom_control_2d
+                        .run_if(on_event::<MouseWheel>)
+                        .in_set(NoMenuInputSet),
+                )
+                .insert_resource(CameraControl2d::default())
+                .add_systems(Startup, move |commands: Commands| {
+                    Self::setup_camera_2d(commands, initial_viewport_height)
+                });
+            }
+        }
 
         #[cfg(not(target_arch = "wasm32"))]
         app.add_systems(
@@ -913,40 +1054,5 @@ pub fn add_default_plugins(app: &mut App) {
         }));
     } else {
         app.add_plugins(DefaultPlugins);
-    }
-}
-
-
-/// 2D camera controls (adapted from https://bevy.org/examples/camera/projection-zoom/)
-pub fn camera_control_2d(
-    camera: Single<(&Camera, &mut Transform, &mut Projection), With<Camera2d>>,
-    camera_settings: Res<CameraSettings2D>,
-    mouse_wheel_input: Res<AccumulatedMouseScroll>,
-    mouse_motion_input: Res<AccumulatedMouseMotion>,
-    mouse_button_input: Res<ButtonInput<MouseButton>>,
-) {
-    let (camera, mut transform, projection) = camera.into_inner();
-
-    let viewport_size = camera.logical_viewport_size().unwrap_or(Vec2::new(1280.0, 720.0));
-
-    if let Projection::Orthographic(ref mut orthographic) = *projection.into_inner() {
-        let pixel_scale = orthographic.area.size() / viewport_size;
-
-        // Zoom
-        // We want scrolling up to zoom in, decreasing the scale, so we negate the delta.
-        let delta_zoom = -mouse_wheel_input.delta.y * camera_settings.zoom_speed;
-        // When changing scales, logarithmic changes are more intuitive.
-        let multiplicative_zoom = 1. + delta_zoom;
-
-        orthographic.scale = (orthographic.scale * multiplicative_zoom).clamp(
-            camera_settings.zoom_range.start,
-            camera_settings.zoom_range.end,
-        );
-
-        // Pan
-        if mouse_button_input.pressed(MouseButton::Left) {
-            transform.translation.x -= mouse_motion_input.delta.x * pixel_scale.x;
-            transform.translation.y += mouse_motion_input.delta.y * pixel_scale.y;
-        }
     }
 }

--- a/hoomd-bevy/src/lib.rs
+++ b/hoomd-bevy/src/lib.rs
@@ -1003,7 +1003,7 @@ F5      : Show/hide debugging information.
                 )
                 .insert_resource(CameraControl2d::default())
                 .add_systems(Startup, move |commands: Commands| {
-                    Self::setup_camera_2d(commands, initial_viewport_height)
+                    Self::setup_camera_2d(commands, initial_viewport_height);
                 });
             }
         }

--- a/hoomd-bevy/src/lib.rs
+++ b/hoomd-bevy/src/lib.rs
@@ -52,7 +52,7 @@ See any one of the many *hoomd-rs* examples that use [`HoomdBevyPlugin`].
 use std::ops::Range;
 
 use anyhow::Context;
-use bevy::{asset::embedded_asset, prelude::*, time::common_conditions::once_after_delay};
+use bevy::{asset::embedded_asset, input::mouse::{AccumulatedMouseMotion, AccumulatedMouseScroll}, prelude::*, time::common_conditions::once_after_delay};
 #[cfg(not(target_arch = "wasm32"))]
 use bevy::{
     render::view::window::screenshot::{Screenshot, save_to_disk},
@@ -917,5 +917,39 @@ pub fn add_default_plugins(app: &mut App) {
         }));
     } else {
         app.add_plugins(DefaultPlugins);
+    }
+}
+
+
+/// 2D camera controls (adapted from https://bevy.org/examples/camera/projection-zoom/)
+pub fn camera_control_2d(
+    mut query: Query<(&mut Transform, &mut Projection), With<Camera2d>>,
+    camera_settings: Res<CameraSettings2D>,
+    mouse_wheel_input: Res<AccumulatedMouseScroll>,
+    mouse_motion_input: Res<AccumulatedMouseMotion>,
+    mouse_button_input: Res<ButtonInput<MouseButton>>,
+) {
+    let (mut transform, projection) = query.single_mut().unwrap();
+    if let Projection::Orthographic(ref mut orthographic) = *projection.into_inner() {
+        // Zoom
+        // We want scrolling up to zoom in, decreasing the scale, so we negate the delta.
+        let delta_zoom = -mouse_wheel_input.delta.y * camera_settings.zoom_speed;
+        // When changing scales, logarithmic changes are more intuitive.
+        let multiplicative_zoom = 1. + delta_zoom;
+
+        orthographic.scale = (orthographic.scale * multiplicative_zoom).clamp(
+            camera_settings.zoom_range.start,
+            camera_settings.zoom_range.end,
+        );
+
+        // Pan
+        if mouse_button_input.pressed(MouseButton::Left) {
+            transform.translation.x -= mouse_motion_input.delta.x
+                * orthographic.scale
+                * camera_settings.translation_scale_factor;
+            transform.translation.y += mouse_motion_input.delta.y
+                * orthographic.scale
+                * camera_settings.translation_scale_factor;
+        }
     }
 }

--- a/hoomd-bevy/src/lib.rs
+++ b/hoomd-bevy/src/lib.rs
@@ -204,7 +204,7 @@ impl Default for Settings {
             sps_limit: 2048.0,
             camera: InitialCamera::Orthographic2d(10.0),
             zoom_range: 0.1..10.0,
-            zoom_speed: 0.25,
+            zoom_speed: 25.0,
         }
     }
 }
@@ -878,6 +878,7 @@ F5      : Show/hide debugging information.
 
     /// Zoom the 2d camera using the mouse wheel or trackpad scroll gesture.
     pub fn camera_zoom_control_2d(
+        time: Res<Time>,
         camera: Single<
             (&Camera, &GlobalTransform, &mut Transform, &mut Projection),
             With<Camera2d>,
@@ -900,7 +901,8 @@ F5      : Show/hide debugging information.
             // the largest). Therefore, the best we can do is check the sign of the
             // scroll event and act scale the camera in the appropriate direction.
 
-            let delta_zoom = -settings.zoom_speed.copysign(scroll);
+            let zoom_speed = settings.zoom_speed * time.delta_secs();
+            let delta_zoom = -zoom_speed.copysign(scroll);
             let new_scale = (orthographic.scale * (1.0 + delta_zoom))
                 .clamp(settings.zoom_range.start, settings.zoom_range.end);
             let scale_ratio = new_scale / orthographic.scale;

--- a/hoomd-bevy/src/lib.rs
+++ b/hoomd-bevy/src/lib.rs
@@ -49,6 +49,8 @@ See any one of the many *hoomd-rs* examples that use [`HoomdBevyPlugin`].
 * `webgpu` Compile for the WebGPU platform when building for the wasm32 target.
 */
 
+use std::ops::Range;
+
 use anyhow::Context;
 use bevy::{asset::embedded_asset, prelude::*, time::common_conditions::once_after_delay};
 #[cfg(not(target_arch = "wasm32"))]
@@ -180,6 +182,31 @@ impl Default for Settings {
 /// Total time allow to advance simulation per frame.
 #[derive(Resource)]
 struct FrameBudget(Duration);
+
+/// Settings used by the camera controls.
+#[derive(Debug, Resource)]
+pub struct CameraSettings2D {
+    /// Clamp the orthographic camera's scale to this range
+    pub zoom_range: Range<f32>,
+    /// Multiply mouse wheel inputs by this factor when using the orthographic camera
+    pub zoom_speed: f32,
+    /// Multiply mouse motion inputs by this factor when translating the camera
+    pub translation_scale_factor: f32,
+}
+
+impl Default for CameraSettings2D {
+    fn default() -> Self {
+        CameraSettings2D {
+            // In orthographic projections, we specify camera scale relative to a default value of 1,
+            // in which one unit in world space corresponds to one pixel.
+            zoom_range: 0.1..10.0,
+            // This value was hand-tuned to ensure that zooming in and out feels smooth but not slow.
+            zoom_speed: 0.2,
+            // Determined empirically (could be improved)
+            translation_scale_factor: 0.1,
+        }
+    }
+}
 
 /// The overlay UI root node.
 #[derive(Component)]

--- a/hoomd-bevy/src/lib.rs
+++ b/hoomd-bevy/src/lib.rs
@@ -190,8 +190,6 @@ pub struct CameraSettings2D {
     pub zoom_range: Range<f32>,
     /// Multiply mouse wheel inputs by this factor when using the orthographic camera
     pub zoom_speed: f32,
-    /// Multiply mouse motion inputs by this factor when translating the camera
-    pub translation_scale_factor: f32,
 }
 
 impl Default for CameraSettings2D {
@@ -202,8 +200,6 @@ impl Default for CameraSettings2D {
             zoom_range: 0.1..10.0,
             // This value was hand-tuned to ensure that zooming in and out feels smooth but not slow.
             zoom_speed: 0.2,
-            // Determined empirically (could be improved)
-            translation_scale_factor: 0.1,
         }
     }
 }
@@ -923,14 +919,19 @@ pub fn add_default_plugins(app: &mut App) {
 
 /// 2D camera controls (adapted from https://bevy.org/examples/camera/projection-zoom/)
 pub fn camera_control_2d(
-    mut query: Query<(&mut Transform, &mut Projection), With<Camera2d>>,
+    camera: Single<(&Camera, &mut Transform, &mut Projection), With<Camera2d>>,
     camera_settings: Res<CameraSettings2D>,
     mouse_wheel_input: Res<AccumulatedMouseScroll>,
     mouse_motion_input: Res<AccumulatedMouseMotion>,
     mouse_button_input: Res<ButtonInput<MouseButton>>,
 ) {
-    let (mut transform, projection) = query.single_mut().unwrap();
+    let (camera, mut transform, projection) = camera.into_inner();
+
+    let viewport_size = camera.logical_viewport_size().unwrap_or(Vec2::new(1280.0, 720.0));
+
     if let Projection::Orthographic(ref mut orthographic) = *projection.into_inner() {
+        let pixel_scale = orthographic.area.size() / viewport_size;
+
         // Zoom
         // We want scrolling up to zoom in, decreasing the scale, so we negate the delta.
         let delta_zoom = -mouse_wheel_input.delta.y * camera_settings.zoom_speed;
@@ -944,12 +945,8 @@ pub fn camera_control_2d(
 
         // Pan
         if mouse_button_input.pressed(MouseButton::Left) {
-            transform.translation.x -= mouse_motion_input.delta.x
-                * orthographic.scale
-                * camera_settings.translation_scale_factor;
-            transform.translation.y += mouse_motion_input.delta.y
-                * orthographic.scale
-                * camera_settings.translation_scale_factor;
+            transform.translation.x -= mouse_motion_input.delta.x * pixel_scale.x;
+            transform.translation.y += mouse_motion_input.delta.y * pixel_scale.y;
         }
     }
 }

--- a/hoomd-bevy/src/lib.rs
+++ b/hoomd-bevy/src/lib.rs
@@ -82,6 +82,9 @@ pub const PRIMARY_COLOR: Color = Color::srgb(249.0 / 255.0, 203.0 / 255.0, 136.0
 /// The default color for the boundary representation.
 pub const BOUNDARY_COLOR: Color = Color::srgb(0.0, 0.0, 0.0);
 
+/// Camera zoom speed multiplier
+const CAMERA_ZOOM_SPEED: f32 = 50.0;
+
 /** The model, parameters, and microstate they act on.
 
 A [`Simulation`] type stores the microstate, all model actors, and any
@@ -193,8 +196,8 @@ pub struct Settings {
     /// Clamp the orthographic camera's scale to this range.
     pub zoom_range: Range<f32>,
 
-    /// Multiply mouse wheel inputs by this factor when using the orthographic camera.
-    pub zoom_speed: f32,
+    /// Camera sensitivity.
+    pub camera_sensitivity: f32,
 }
 
 impl Default for Settings {
@@ -204,7 +207,7 @@ impl Default for Settings {
             sps_limit: 2048.0,
             camera: InitialCamera::Orthographic2d(10.0),
             zoom_range: 0.1..10.0,
-            zoom_speed: 25.0,
+            camera_sensitivity: 0.5,
         }
     }
 }
@@ -432,7 +435,8 @@ where
         help_text.push_str("q       : Quit.\n");
 
         help_text.push_str(
-            "<space> : Pause the simulation.
+            "=       : Reset the camera.
+<space> : Pause the simulation.
 <right>: Advance one step (while paused).
 shift-F1: Show/hide the user interface.
 F5      : Show/hide debugging information.
@@ -817,13 +821,33 @@ F5      : Show/hide debugging information.
         commands.spawn((Camera2d, projection));
     }
 
+    /** Keyboard controls for the 2d camera.
+
+    * `=` resets the camera to the default.
+    */
+    fn camera_keyboard_control_2d(
+        keys: Res<ButtonInput<KeyCode>>,
+        camera: Single<(&mut Transform, &mut Projection), With<Camera2d>>,
+        mut control: ResMut<CameraControl2d>,
+    ) {
+        let (mut transform, projection) = camera.into_inner();
+
+        if keys.just_pressed(KeyCode::Equal) {
+            if let Projection::Orthographic(ref mut orthographic) = *projection.into_inner() {
+                orthographic.scale = 1.0;
+            }
+            control.dragging = false;
+            transform.translation = Vec3::default();
+        }
+    }
+
     /** Left click and drag to pan the 2D camera.
 
     # Panics
 
     Panics when the 2D camera viewport is invalid.
     */
-    pub fn camera_pan_control_2d(
+    fn camera_mouse_pan_control_2d(
         camera: Single<
             (&Camera, &GlobalTransform, &mut Transform, &mut Projection),
             With<Camera2d>,
@@ -877,7 +901,7 @@ F5      : Show/hide debugging information.
     }
 
     /// Zoom the 2d camera using the mouse wheel or trackpad scroll gesture.
-    pub fn camera_zoom_control_2d(
+    fn camera_mouse_zoom_control_2d(
         time: Res<Time>,
         camera: Single<
             (&Camera, &GlobalTransform, &mut Transform, &mut Projection),
@@ -901,7 +925,7 @@ F5      : Show/hide debugging information.
             // the largest). Therefore, the best we can do is check the sign of the
             // scroll event and act scale the camera in the appropriate direction.
 
-            let zoom_speed = settings.zoom_speed * time.delta_secs();
+            let zoom_speed = settings.camera_sensitivity * CAMERA_ZOOM_SPEED * time.delta_secs();
             let delta_zoom = -zoom_speed.copysign(scroll);
             let new_scale = (orthographic.scale * (1.0 + delta_zoom))
                 .clamp(settings.zoom_range.start, settings.zoom_range.end);
@@ -930,6 +954,7 @@ F5      : Show/hide debugging information.
     `build` to take ownership of the `simulation` field and create the appropriate
     Bevy [`Resource`].
     */
+    #[expect(clippy::too_many_lines, reason = "Bevy functions are very verbose.")]
     pub fn build(self, app: &mut App) {
         representation::disk::build(app);
 
@@ -990,7 +1015,7 @@ F5      : Show/hide debugging information.
             InitialCamera::Orthographic2d(initial_viewport_height) => {
                 app.add_systems(
                     Update,
-                    Self::camera_pan_control_2d
+                    Self::camera_mouse_pan_control_2d
                         .run_if(
                             input_pressed(MouseButton::Left)
                                 .or(input_just_released(MouseButton::Left)),
@@ -999,9 +1024,13 @@ F5      : Show/hide debugging information.
                 )
                 .add_systems(
                     Update,
-                    Self::camera_zoom_control_2d
+                    Self::camera_mouse_zoom_control_2d
                         .run_if(on_event::<MouseWheel>)
                         .in_set(NoMenuInputSet),
+                )
+                .add_systems(
+                    Update,
+                    Self::camera_keyboard_control_2d.in_set(NoMenuInputSet),
                 )
                 .insert_resource(CameraControl2d::default())
                 .add_systems(Startup, move |commands: Commands| {


### PR DESCRIPTION
I've created a new resource and system for controlling a camera with an orthographic projection in 2D space. I have then added these assets to the tutorials.

Currently, the new resource and system are provided as a public struct and function, and have to be manually added to a new Bevy app. If we want to make this process automatic, we'll need to have a way to specify to the Hoomd Bevy plugin constructor that the app is 2D, since these camera controls only work in 2D.

Feedback/suggestions welcome!