### PR TITLE
Format documentation examples.

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -3,8 +3,6 @@ edition = "2024"
 style_edition = "2024"
 hex_literal_case = "Lower"
 imports_granularity = "Crate"
-
-# Will implement on a separate PR
-# format_code_in_doc_comments = true
-# doc_comment_code_block_width = 80
-# normalize_comments = true
+format_code_in_doc_comments = true
+doc_comment_code_block_width = 80
+normalize_comments = true

--- a/doc/src/developer-tools.md
+++ b/doc/src/developer-tools.md
@@ -1,6 +1,31 @@
 # Developer Tools
 
-## Spell checking
+## prek
+
+Run
+```shell
+prek run --all-files
+```
+to perform a number of style checks and fixes.
+
+## Code formatting
+
+Run
+```shell
+cargo +nightly-2025-09-17 fmt --check
+```
+to automatically format the code. Use the shown Rust nightly version to obtain
+the same results as the CI checks.
+
+## Code Linting
+
+Run
+```shell
+cargo clippy --all-targets --all-features
+```
+to ensure that the code follows established best practices.
+
+## Spell Checking
 
 Use [codebook] to check for spelling errors in arguments, variable names,
 comments, etc... *hoomd-rs* includes a codebook dictionary file exempting
@@ -8,7 +33,9 @@ words commonly used throughout the repository.
 
 [codebook]: https://github.com/blopker/codebook
 
-## mdBook
+## Build the documentation
+
+### mdBook
 
 This documentation is built with [mdBook] using the following plugins:
 * [mdbook-alerts]
@@ -29,7 +56,7 @@ $ cd doc
 $ mdbook serve --open
 ```
 
-## rustdoc
+### rustdoc
 
 To build the API documentation from source and open it in your browser, execute:
 ```shell

--- a/hoomd-bevy/src/lib.rs
+++ b/hoomd-bevy/src/lib.rs
@@ -103,14 +103,14 @@ const CAMERA_ZOOM_SPEED: f32 = 50.0;
 /// A menu to control common settings (steps per second limit, camera speed, etc.)
 ///
 /// The caller must:
-/// Provide type that implements [`Simulation`].
-/// Add a `sync` `Update` system that populates (and removes) entities for
-/// rendering. See [`representation`] for helper code.
+/// * Provide type that implements [`Simulation`].
+/// * Add a `sync` `Update` system that populates (and removes) entities for
+///   rendering. See [`representation`] for helper code.
 ///
 /// The caller may optionally:
-/// Add UI to the upper right corner of the screen.
-/// Implement custom controls.
-/// Add lines to the [`HelpText`] entity.
+/// * Add UI to the upper right corner of the screen.
+/// * Implement custom controls.
+/// * Add lines to the [`HelpText`] entity.
 ///
 /// To keep individual example scripts short and understandable, `hoomd-bevy` should
 /// implement as much common code as possible.
@@ -156,8 +156,8 @@ pub enum InitialCamera {
     /// automatically based on the window dimensions.
     ///
     /// Controls:
-    /// Left click and drag to pan.
-    /// Scroll to zoom.
+    /// * Left click and drag to pan.
+    /// * Scroll to zoom.
     Orthographic2d(f32),
 }
 

--- a/hoomd-bevy/src/lib.rs
+++ b/hoomd-bevy/src/lib.rs
@@ -24,30 +24,29 @@
     reason = "Bevy operates with f32 values."
 )]
 
-/*! Connect *hoomd-rs* simulations with the Bevy game engine.
-
-Use [`HoomdBevyPlugin`] to create visual, interactive simulations. Add the
-plugin to a Bevy `App` and it will step the simulation up to a configurable
-limit number of steps per second. To display geometry on the screen, add one
-more more `setup` methods from [`representation`] to the `Startup` schedule.
-Then add a `sync` method to the `Update` schedule that synchronizes the entire
-microstate (using the helper methods from [`representation`]).
-
-# Examples
-
-See any one of the many *hoomd-rs* examples that use [`HoomdBevyPlugin`].
-
-# Embedded assets.
-
-`hoomd-bevy` provides the following assets:
-
-* `embedded://hoomd_bevy/logo.png` - The HOOMD logo (512 x 512).
-
-# Feature flags
-
-* `doc-example` Make examples suitable for display in a web browser.
-* `webgpu` Compile for the WebGPU platform when building for the wasm32 target.
-*/
+//! Connect *hoomd-rs* simulations with the Bevy game engine.
+//!
+//! Use [`HoomdBevyPlugin`] to create visual, interactive simulations. Add the
+//! plugin to a Bevy `App` and it will step the simulation up to a configurable
+//! limit number of steps per second. To display geometry on the screen, add one
+//! more more `setup` methods from [`representation`] to the `Startup` schedule.
+//! Then add a `sync` method to the `Update` schedule that synchronizes the entire
+//! microstate (using the helper methods from [`representation`]).
+//!
+//! # Examples
+//!
+//! See any one of the many *hoomd-rs* examples that use [`HoomdBevyPlugin`].
+//!
+//! # Embedded assets.
+//!
+//! `hoomd-bevy` provides the following assets:
+//!
+//! `embedded://hoomd_bevy/logo.png` - The HOOMD logo (512 x 512).
+//!
+//! # Feature flags
+//!
+//! `doc-example` Make examples suitable for display in a web browser.
+//! `webgpu` Compile for the WebGPU platform when building for the wasm32 target.
 
 use std::ops::Range;
 
@@ -91,37 +90,36 @@ pub const BOUNDARY_COLOR: Color = Color::srgb(0.0, 0.0, 0.0);
 /// Camera zoom speed multiplier
 const CAMERA_ZOOM_SPEED: f32 = 50.0;
 
-/** Interface *hoomd-rs* simulations with the Bevy game engine.
-
-[`HoomdBevyPlugin`] is used by all the *hoomd-rs* examples that create
-interactive graphical displays of simulations. Specifically, it implements:
-
-* Camera controls (2D and 3D separately).
-* Simulation step and frame pacing, with a limited number of steps per second.
-* Pause and advance by single step controls.
-* A help screen describing common controls (examples can add lines if needed).
-* Key bindings to hide the UI and take screenshots.
-* A menu to control common settings (steps per second limit, camera speed, etc.)
-
-The caller must:
-* Provide type that implements [`Simulation`].
-* Add a `sync` `Update` system that populates (and removes) entities for
-  rendering. See [`representation`] for helper code.
-
-The caller may optionally:
-* Add UI to the upper right corner of the screen.
-* Implement custom controls.
-* Add lines to the [`HelpText`] entity.
-
-To keep individual example scripts short and understandable, `hoomd-bevy` should
-implement as much common code as possible.
-
-# Examples
-
-See any one of the many *hoomd-rs* examples that use [`HoomdBevyPlugin`].
-
-[`Simulation`]: hoomd_simulation::Simulation
-*/
+/// Interface *hoomd-rs* simulations with the Bevy game engine.
+///
+/// [`HoomdBevyPlugin`] is used by all the *hoomd-rs* examples that create
+/// interactive graphical displays of simulations. Specifically, it implements:
+///
+/// Camera controls (2D and 3D separately).
+/// Simulation step and frame pacing, with a limited number of steps per second.
+/// Pause and advance by single step controls.
+/// A help screen describing common controls (examples can add lines if needed).
+/// Key bindings to hide the UI and take screenshots.
+/// A menu to control common settings (steps per second limit, camera speed, etc.)
+///
+/// The caller must:
+/// Provide type that implements [`Simulation`].
+/// Add a `sync` `Update` system that populates (and removes) entities for
+/// rendering. See [`representation`] for helper code.
+///
+/// The caller may optionally:
+/// Add UI to the upper right corner of the screen.
+/// Implement custom controls.
+/// Add lines to the [`HelpText`] entity.
+///
+/// To keep individual example scripts short and understandable, `hoomd-bevy` should
+/// implement as much common code as possible.
+///
+/// # Examples
+///
+/// See any one of the many *hoomd-rs* examples that use [`HoomdBevyPlugin`].
+///
+/// [`Simulation`]: hoomd_simulation::Simulation
 pub struct HoomdBevyPlugin<S> {
     /// Configuration to use at application start (may be changed later).
     pub initial_settings: Settings,
@@ -152,15 +150,14 @@ pub enum MenuState {
 /// Configure the initial camera view and set how the camera will be controlled.
 #[derive(Clone)]
 pub enum InitialCamera {
-    /** Two dimensional top down camera showing the xy plane.
-
-    The single field sets the height of the visible area. The width is set
-    automatically based on the window dimensions.
-
-    Controls:
-    * Left click and drag to pan.
-    * Scroll to zoom.
-    */
+    /// Two dimensional top down camera showing the xy plane.
+    ///
+    /// The single field sets the height of the visible area. The width is set
+    /// automatically based on the window dimensions.
+    ///
+    /// Controls:
+    /// Left click and drag to pan.
+    /// Scroll to zoom.
     Orthographic2d(f32),
 }
 
@@ -225,12 +222,11 @@ struct PauseText;
 #[derive(Component)]
 struct HelpTextContainer;
 
-/** Mark the help text entity.
-
-[`HoomdBevyPlugin`] populates the help text with instructions for common
-controls. Callers may add lines to the text node to show example-specific
-information when ? is pressed.
-*/
+/// Mark the help text entity.
+///
+/// [`HoomdBevyPlugin`] populates the help text with instructions for common
+/// controls. Callers may add lines to the text node to show example-specific
+/// information when ? is pressed.
 #[derive(Component)]
 pub struct HelpText;
 
@@ -254,29 +250,25 @@ struct FrameBudgetText;
 #[derive(Component)]
 struct MenuRoot;
 
-/** Systems that run to advance the simulation.
-
-Callers should use this to execute the sync step after the simulation is advanced:
-`app.add_systems(Update, sync_simulation.run_if(resource_changed::<MySimulation>).after(AdvanceSet));`
-*/
+/// Systems that run to advance the simulation.
+///
+/// Callers should use this to execute the sync step after the simulation is advanced:
+/// `app.add_systems(Update, sync_simulation.run_if(resource_changed::<MySimulation>).after(AdvanceSet));`
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AdvanceSet;
 
-/** Systems that always run to process input.
-
-Callers can optionally add input handling systems to this set. It is processed
-after [`AdvanceSet`] to reduce the latency between input and result.
-*/
+/// Systems that always run to process input.
+///
+/// Callers can optionally add input handling systems to this set. It is processed
+/// after [`AdvanceSet`] to reduce the latency between input and result.
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AlwaysInputSet;
 
-/** Systems that run to process input only when there is no menu displayed.
- */
+/// Systems that run to process input only when there is no menu displayed.
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct NoMenuInputSet;
 
-/** Systems that run to process input in the settings menu.
- */
+/// Systems that run to process input in the settings menu.
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SettingsMenuInputSet;
 
@@ -287,10 +279,9 @@ where
     /// Bevy diagnostic that counts the number of steps executed per second.
     pub const SPS: DiagnosticPath = DiagnosticPath::const_new("sps");
 
-    /** Z index at which the help text is displayed.
-
-    Use this should you ever need to display an overlay above the help screen.
-    */
+    /// Z index at which the help text is displayed.
+    ///
+    /// Use this should you ever need to display an overlay above the help screen.
     pub const HELP_OVERLAY_ZINDEX: i32 = i32::MAX - 32;
 
     /// Clear the window to this color before rendering each frame.
@@ -662,11 +653,10 @@ F5      : Show/hide debugging information.
         }
     }
 
-    /** Set the time budgeted to advancing the simulation each frame.
-
-    Derive this time from the current monitor refresh rate and the
-    `frame_budget_fraction` settings.
-    */
+    /// Set the time budgeted to advancing the simulation each frame.
+    ///
+    /// Derive this time from the current monitor refresh rate and the
+    /// `frame_budget_fraction` settings.
     #[cfg(not(target_arch = "wasm32"))]
     fn set_frame_budget(
         winit: NonSend<WinitWindows>,
@@ -804,10 +794,9 @@ F5      : Show/hide debugging information.
         commands.spawn((Camera2d, projection));
     }
 
-    /** Keyboard controls for the 2d camera.
-
-    * `=` resets the camera to the default.
-    */
+    /// Keyboard controls for the 2d camera.
+    ///
+    /// `=` resets the camera to the default.
     fn camera_keyboard_control_2d(
         keys: Res<ButtonInput<KeyCode>>,
         camera: Single<(&mut Transform, &mut Projection), With<Camera2d>>,
@@ -824,12 +813,11 @@ F5      : Show/hide debugging information.
         }
     }
 
-    /** Left click and drag to pan the 2D camera.
-
-    # Panics
-
-    Panics when the 2D camera viewport is invalid.
-    */
+    /// Left click and drag to pan the 2D camera.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the 2D camera viewport is invalid.
     fn camera_mouse_pan_control_2d(
         camera: Single<
             (&Camera, &GlobalTransform, &mut Transform, &mut Projection),
@@ -930,13 +918,12 @@ F5      : Show/hide debugging information.
         }
     }
 
-    /** Build the plugin.
-
-    [`HoomdBevyPlugin`] does not implement [`Plugin`] and cannot be used with
-    `add_plugins` so that the `build` method can consume `self`. This allows
-    `build` to take ownership of the `simulation` field and create the appropriate
-    Bevy [`Resource`].
-    */
+    /// Build the plugin.
+    ///
+    /// [`HoomdBevyPlugin`] does not implement [`Plugin`] and cannot be used with
+    /// `add_plugins` so that the `build` method can consume `self`. This allows
+    /// `build` to take ownership of the `simulation` field and create the appropriate
+    /// Bevy [`Resource`].
     #[expect(clippy::too_many_lines, reason = "Bevy functions are very verbose.")]
     pub fn build(self, app: &mut App) {
         representation::disk::build(app);
@@ -1051,12 +1038,11 @@ F5      : Show/hide debugging information.
     }
 }
 
-/** Construct the default plugins.
-
-This helper adds Bevy's `DefaultPlugins` by default. When the
-`doc-example` feature is enabled, it adds a modified set of plugins
-for the web.
-*/
+/// Construct the default plugins.
+///
+/// This helper adds Bevy's `DefaultPlugins` by default. When the
+/// `doc-example` feature is enabled, it adds a modified set of plugins
+/// for the web.
 pub fn add_default_plugins(app: &mut App) {
     if cfg!(feature = "doc-example") {
         app.add_plugins(DefaultPlugins.set(WindowPlugin {

--- a/hoomd-bevy/src/representation.rs
+++ b/hoomd-bevy/src/representation.rs
@@ -1,18 +1,17 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Graphical elements that depict the simulation microstate.
-
-The `representation` module contains types that you can use to visually represent
-your sites, bodies, or calculated properties of the simulation state. Each type
-has implementation dependent details, although most include a `setup` method
-that you need to add to the `Startup` schedule and helper methods that you can call
-in the `Update` schedule to synchronize the state.
-
-Most of the types in `representation` are opaque primitives intended to
-represent sites or bodies. Some, such as those ending in `Boundary` are thin
-outlines intended to represent the simulation boundaries.
- */
+//! Graphical elements that depict the simulation microstate.
+//!
+//! The `representation` module contains types that you can use to visually represent
+//! your sites, bodies, or calculated properties of the simulation state. Each type
+//! has implementation dependent details, although most include a `setup` method
+//! that you need to add to the `Startup` schedule and helper methods that you can call
+//! in the `Update` schedule to synchronize the state.
+//!
+//! Most of the types in `representation` are opaque primitives intended to
+//! represent sites or bodies. Some, such as those ending in `Boundary` are thin
+//! outlines intended to represent the simulation boundaries.
 
 pub mod disk;
 pub mod ellipse;

--- a/hoomd-bevy/src/representation/disk.rs
+++ b/hoomd-bevy/src/representation/disk.rs
@@ -1,11 +1,10 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! An outlined circle.
-
-The [`Disk`] representation is a circle of pixels with a configurable
-outline color and an optional texture map.
-*/
+//! An outlined circle.
+//!
+//! The [`Disk`] representation is a circle of pixels with a configurable
+//! outline color and an optional texture map.
 
 use bevy::{
     asset::embedded_asset,
@@ -37,21 +36,20 @@ use crate::PRIMARY_COLOR;
 /// Location of the shader implementation
 const SHADER_ASSET_PATH: &str = "embedded://hoomd_bevy/representation/disk.wgsl";
 
-/** Represent an entity with a 2D disk in the xy plane.
-
-The base representation has a diameter of 1.0. Provide a non-unit diameter
-in [`sync`](Self::sync) to render disks of different sizes. Nominally, the z
-coordinate of the disks should be set to 0. Choose a different value to control
-the back to front draw order.
-
-All disks of the same type must have the same material. To display disks with
-different color pallets, outline widths, or textures, call `setup` and `sync`
-multiple types of disks with different marker types.
-
-To use:
-* Add [`setup`](Self::setup) to the `Startup` schedule.
-* Call [`sync`](Self::sync) in an `Update` schedule that runs after `AdvanceSet`.
-*/
+/// Represent an entity with a 2D disk in the xy plane.
+///
+/// The base representation has a diameter of 1.0. Provide a non-unit diameter
+/// in [`sync`](Self::sync) to render disks of different sizes. Nominally, the z
+/// coordinate of the disks should be set to 0. Choose a different value to control
+/// the back to front draw order.
+///
+/// All disks of the same type must have the same material. To display disks with
+/// different color pallets, outline widths, or textures, call `setup` and `sync`
+/// multiple types of disks with different marker types.
+///
+/// To use:
+/// Add [`setup`](Self::setup) to the `Startup` schedule.
+/// Call [`sync`](Self::sync) in an `Update` schedule that runs after `AdvanceSet`.
 #[derive(Component)]
 pub struct Disk<T> {
     /// Mark the type of the disk.
@@ -84,8 +82,7 @@ pub(crate) fn build(app: &mut App) {
 }
 
 impl<T: Send + Sync + 'static> Disk<T> {
-    /** Create assets to render disks.
-     */
+    /// Create assets to render disks.
     pub fn setup(
         material: In<MaterialParameters>,
         mut commands: Commands,
@@ -184,27 +181,26 @@ impl Default for MaterialParameters {
     }
 }
 
-/** Control how disks are rendered.
-
-Disks are always opaque and alpha in any texture or background color is ignored.
-
-By default [`Material`] is initialized with only one background
-color. Color the instances differently by setting more than one color
-with [`set_background_colors`]. The color of each disk is given by
-`background_colors[tag % len(background_colors)]` so you may set fewer colors
-than there are disks. [`sync`] assigns `tag` values in increasing order to each
-primitive.
-
-The `background_color` tints the texture by multiplication. With a `None`
-texture (the default), `background_color` sets the exact color of the disk.
-
-Set the initial material by piping `MaterialParameters` into [`Disk::setup`].
-After it is initialized, change the material during execution via the `material`
-field in`ResMut<disk::Representation<A>>`.
-
-[`sync`]: Disk::sync
-[`set_background_colors`]: Material::set_background_colors
-*/
+/// Control how disks are rendered.
+///
+/// Disks are always opaque and alpha in any texture or background color is ignored.
+///
+/// By default [`Material`] is initialized with only one background
+/// color. Color the instances differently by setting more than one color
+/// with [`set_background_colors`]. The color of each disk is given by
+/// `background_colors[tag % len(background_colors)]` so you may set fewer colors
+/// than there are disks. [`sync`] assigns `tag` values in increasing order to each
+/// primitive.
+///
+/// The `background_color` tints the texture by multiplication. With a `None`
+/// texture (the default), `background_color` sets the exact color of the disk.
+///
+/// Set the initial material by piping `MaterialParameters` into [`Disk::setup`].
+/// After it is initialized, change the material during execution via the `material`
+/// field in`ResMut<disk::Representation<A>>`.
+///
+/// [`sync`]: Disk::sync
+/// [`set_background_colors`]: Material::set_background_colors
 #[derive(Asset, TypePath, AsBindGroup, Debug, Clone)]
 pub struct Material {
     /// Color applied to the outline.
@@ -241,16 +237,15 @@ pub struct Material {
 }
 
 impl Material {
-    /** Set new background colors.
-
-    # Panics
-
-    WebGL2 builds (identified by the `wasm32` target without the `webgpu`
-    feature) support only 1024 background colors.
-
-    Desktop target builds or `wasm32` target builds with `webgpu` support
-    a much larger number of colors and will not panic.
-    */
+    /// Set new background colors.
+    ///
+    /// # Panics
+    ///
+    /// WebGL2 builds (identified by the `wasm32` target without the `webgpu`
+    /// feature) support only 1024 background colors.
+    ///
+    /// Desktop target builds or `wasm32` target builds with `webgpu` support
+    /// a much larger number of colors and will not panic.
     pub fn set_background_colors(
         &mut self,
         mut buffers: ResMut<Assets<ShaderStorageBuffer>>,

--- a/hoomd-bevy/src/representation/disk.rs
+++ b/hoomd-bevy/src/representation/disk.rs
@@ -48,8 +48,8 @@ const SHADER_ASSET_PATH: &str = "embedded://hoomd_bevy/representation/disk.wgsl"
 /// multiple types of disks with different marker types.
 ///
 /// To use:
-/// Add [`setup`](Self::setup) to the `Startup` schedule.
-/// Call [`sync`](Self::sync) in an `Update` schedule that runs after `AdvanceSet`.
+/// * Add [`setup`](Self::setup) to the `Startup` schedule.
+/// * Call [`sync`](Self::sync) in an `Update` schedule that runs after `AdvanceSet`.
 #[derive(Component)]
 pub struct Disk<T> {
     /// Mark the type of the disk.

--- a/hoomd-bevy/src/representation/ellipse.rs
+++ b/hoomd-bevy/src/representation/ellipse.rs
@@ -48,8 +48,8 @@ const SHADER_ASSET_PATH: &str = "embedded://hoomd_bevy/representation/ellipse.wg
 /// types of ellipses with different marker types.
 ///
 /// To use:
-/// Add [`setup`](Self::setup) to the `Startup` schedule.
-/// Call [`sync`](Self::sync) in an `Update` schedule that runs after `AdvanceSet`.
+/// * Add [`setup`](Self::setup) to the `Startup` schedule.
+/// * Call [`sync`](Self::sync) in an `Update` schedule that runs after `AdvanceSet`.
 #[derive(Component)]
 pub struct Ellipse<T> {
     /// Mark the type of the disk.

--- a/hoomd-bevy/src/representation/ellipse.rs
+++ b/hoomd-bevy/src/representation/ellipse.rs
@@ -1,11 +1,10 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! An outlined ellipse.
-
-The [`Ellipse`] representation is a ellipse of pixels with a configurable
-outline color. Each ellipse can have a different aspect ratio.
-*/
+//! An outlined ellipse.
+//!
+//! The [`Ellipse`] representation is a ellipse of pixels with a configurable
+//! outline color. Each ellipse can have a different aspect ratio.
 
 use bevy::{
     asset::embedded_asset,
@@ -37,21 +36,20 @@ use crate::PRIMARY_COLOR;
 /// Location of the shader implementation
 const SHADER_ASSET_PATH: &str = "embedded://hoomd_bevy/representation/ellipse.wgsl";
 
-/** Represent an entity with a 2D ellipse in the xy plane.
-
-The base representation has semi-axes (0.5, 0.5). Provide per-item axes
-in [`sync`](Self::sync) to render ellipses of different sizes and aspect ratios.
-Nominally, the z coordinate of the ellipses should be set to 0. Choose a different
-value to control the back to front draw order.
-
-All ellipses of the same type must have the same material. To display disks with
-different color pallets or outline widths, call `setup` and `sync` multiple
-types of ellipses with different marker types.
-
-To use:
-* Add [`setup`](Self::setup) to the `Startup` schedule.
-* Call [`sync`](Self::sync) in an `Update` schedule that runs after `AdvanceSet`.
-*/
+/// Represent an entity with a 2D ellipse in the xy plane.
+///
+/// The base representation has semi-axes (0.5, 0.5). Provide per-item axes
+/// in [`sync`](Self::sync) to render ellipses of different sizes and aspect ratios.
+/// Nominally, the z coordinate of the ellipses should be set to 0. Choose a different
+/// value to control the back to front draw order.
+///
+/// All ellipses of the same type must have the same material. To display disks with
+/// different color pallets or outline widths, call `setup` and `sync` multiple
+/// types of ellipses with different marker types.
+///
+/// To use:
+/// Add [`setup`](Self::setup) to the `Startup` schedule.
+/// Call [`sync`](Self::sync) in an `Update` schedule that runs after `AdvanceSet`.
 #[derive(Component)]
 pub struct Ellipse<T> {
     /// Mark the type of the disk.
@@ -84,8 +82,7 @@ pub(crate) fn build(app: &mut App) {
 }
 
 impl<T: Send + Sync + 'static> Ellipse<T> {
-    /** Create assets to render disks.
-     */
+    /// Create assets to render disks.
     pub fn setup(
         material: In<MaterialParameters>,
         mut commands: Commands,
@@ -176,27 +173,26 @@ impl Default for MaterialParameters {
     }
 }
 
-/** Control how ellipses are rendered.
-
-Ellipses are always opaque and alpha in any background color is ignored.
-
-By default [`Material`] is initialized with only one background
-color. Color the instances differently by setting more than one color
-with [`set_background_colors`]. The color of each disk is given by
-`background_colors[tag % len(background_colors)]` so you may set fewer colors
-than there are disks. [`sync`] assigns `tag` values in increasing order to each
-primitive.
-
-The `background_color` tints the texture by multiplication. With a `None`
-texture (the default), `background_color` sets the exact color of the disk.
-
-Set the initial material by piping `MaterialParameters` into [`Ellipse::setup`].
-After it is initialized, change the material during execution via the `material`
-field in`ResMut<ellipse::Representation<A>>`.
-
-[`sync`]: Ellipse::sync
-[`set_background_colors`]: Material::set_background_colors
-*/
+/// Control how ellipses are rendered.
+///
+/// Ellipses are always opaque and alpha in any background color is ignored.
+///
+/// By default [`Material`] is initialized with only one background
+/// color. Color the instances differently by setting more than one color
+/// with [`set_background_colors`]. The color of each disk is given by
+/// `background_colors[tag % len(background_colors)]` so you may set fewer colors
+/// than there are disks. [`sync`] assigns `tag` values in increasing order to each
+/// primitive.
+///
+/// The `background_color` tints the texture by multiplication. With a `None`
+/// texture (the default), `background_color` sets the exact color of the disk.
+///
+/// Set the initial material by piping `MaterialParameters` into [`Ellipse::setup`].
+/// After it is initialized, change the material during execution via the `material`
+/// field in`ResMut<ellipse::Representation<A>>`.
+///
+/// [`sync`]: Ellipse::sync
+/// [`set_background_colors`]: Material::set_background_colors
 #[derive(Asset, TypePath, AsBindGroup, Debug, Clone)]
 pub struct Material {
     /// Color applied to the outline.
@@ -224,16 +220,15 @@ pub struct Material {
 }
 
 impl Material {
-    /** Set new background colors.
-
-    # Panics
-
-    WebGL2 builds (identified by the `wasm32` target without the `webgpu`
-    feature) support only 1024 background colors.
-
-    Desktop target builds or `wasm32` target builds with `webgpu` support
-    a much larger number of colors and will not panic.
-    */
+    /// Set new background colors.
+    ///
+    /// # Panics
+    ///
+    /// WebGL2 builds (identified by the `wasm32` target without the `webgpu`
+    /// feature) support only 1024 background colors.
+    ///
+    /// Desktop target builds or `wasm32` target builds with `webgpu` support
+    /// a much larger number of colors and will not panic.
     pub fn set_background_colors(
         &mut self,
         mut buffers: ResMut<Assets<ShaderStorageBuffer>>,

--- a/hoomd-bevy/src/representation/rectangular_boundary.rs
+++ b/hoomd-bevy/src/representation/rectangular_boundary.rs
@@ -1,27 +1,25 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement `RectangularBoundary`.
- */
+//! Implement `RectangularBoundary`.
 
 use bevy::prelude::*;
 
 use crate::BOUNDARY_COLOR;
 
-/** Represent an simulation boundary with a thin lined rectangle.
-
-The lines are a fixed thickness in world coordinates. A default
-[`RectangularBoundary`] has:
-* `width`: 1.0
-* `height`: 1.0
-* `thickness`: 0.1
-* `color`: [`BOUNDARY_COLOR`](crate::BOUNDARY_COLOR)
-* `z`: 1.0
-
-To use:
-* Add [`setup`](Self::setup) to the `Startup` schedule.
-* (if needed) Call [`sync`](Self::sync) in an `Update` schedule that runs after `AdvanceSet`.
-*/
+/// Represent an simulation boundary with a thin lined rectangle.
+///
+/// The lines are a fixed thickness in world coordinates. A default
+/// [`RectangularBoundary`] has:
+/// `width`: 1.0
+/// `height`: 1.0
+/// `thickness`: 0.1
+/// `color`: [`BOUNDARY_COLOR`](crate::BOUNDARY_COLOR)
+/// `z`: 1.0
+///
+/// To use:
+/// Add [`setup`](Self::setup) to the `Startup` schedule.
+/// (if needed) Call [`sync`](Self::sync) in an `Update` schedule that runs after `AdvanceSet`.
 #[derive(Component)]
 pub struct RectangularBoundary {
     /// Extent of the rectangle's open space in the x direction.
@@ -53,8 +51,7 @@ impl Default for RectangularBoundary {
 }
 
 impl RectangularBoundary {
-    /** Create entities that render rectangular boundaries.
-     */
+    /// Create entities that render rectangular boundaries.
     pub fn setup(
         rectangular_boundary: In<Self>,
         mut commands: Commands,

--- a/hoomd-bevy/src/representation/rectangular_boundary.rs
+++ b/hoomd-bevy/src/representation/rectangular_boundary.rs
@@ -18,8 +18,8 @@ use crate::BOUNDARY_COLOR;
 /// `z`: 1.0
 ///
 /// To use:
-/// Add [`setup`](Self::setup) to the `Startup` schedule.
-/// (if needed) Call [`sync`](Self::sync) in an `Update` schedule that runs after `AdvanceSet`.
+/// * Add [`setup`](Self::setup) to the `Startup` schedule.
+/// * (if needed) Call [`sync`](Self::sync) in an `Update` schedule that runs after `AdvanceSet`.
 #[derive(Component)]
 pub struct RectangularBoundary {
     /// Extent of the rectangle's open space in the x direction.

--- a/hoomd-geometry/benches/overlaps.rs
+++ b/hoomd-geometry/benches/overlaps.rs
@@ -7,7 +7,7 @@
 )]
 #![expect(clippy::unwrap_used, reason = "benches can use unwrap where needed")]
 
-/*! Benchmark overlaps */
+//! Benchmark overlaps
 
 use divan::{self, Bencher, black_box, counter::ItemsCount};
 use hoomd_geometry::{

--- a/hoomd-geometry/src/convex.rs
+++ b/hoomd-geometry/src/convex.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement `Convex`.
- */
+//! Implement `Convex`.
 
 use crate::{
     BoundingSphereRadius, IntersectsAt, SupportMapping,
@@ -11,31 +10,52 @@ use crate::{
 };
 use hoomd_vector::{Cartesian, Rotate, Rotation, RotationMatrix};
 
-/** A newtype that checks for intersections using [`xenocollide`](crate::xenocollide).
-
-Use [`Convex`] to check for intersections between two convex shapes (possibly
-with different types).
-
-# Example
-
-Test if a circle overlaps with a rounded rectangle:
-```
-use hoomd_geometry::{Convex, IntersectsAt, shape::{Circle, Rectangle, Sphero}};
-use hoomd_vector::{Cartesian, Angle};
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let circle = Convex(Circle { radius:  0.5.try_into()? });
-let rectangle = Rectangle { edge_lengths: [3.0.try_into()?, 2.0.try_into()?] };
-let rounded_rectangle = Convex(Sphero { shape: rectangle, rounding_radius: 0.5.try_into()? });
-
-assert!(rounded_rectangle.intersects_at(&circle, &[2.4, 0.0].into(), &Angle::default()));
-assert!(!rounded_rectangle.intersects_at(&circle, &[0.0, 2.4].into(), &Angle::default()));
-assert!(circle.intersects_at(&rounded_rectangle, &[0.0, 2.4].into(), &Angle::from(PI / 2.0)));
-# Ok(())
-# }
-```
-*/
+/// A newtype that checks for intersections using [`xenocollide`](crate::xenocollide).
+///
+/// Use [`Convex`] to check for intersections between two convex shapes (possibly
+/// with different types).
+///
+/// # Example
+///
+/// Test if a circle overlaps with a rounded rectangle:
+/// ```
+/// use hoomd_geometry::{
+///     Convex, IntersectsAt,
+///     shape::{Circle, Rectangle, Sphero},
+/// };
+/// use hoomd_vector::{Angle, Cartesian};
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let circle = Convex(Circle {
+///     radius: 0.5.try_into()?,
+/// });
+/// let rectangle = Rectangle {
+///     edge_lengths: [3.0.try_into()?, 2.0.try_into()?],
+/// };
+/// let rounded_rectangle = Convex(Sphero {
+///     shape: rectangle,
+///     rounding_radius: 0.5.try_into()?,
+/// });
+///
+/// assert!(rounded_rectangle.intersects_at(
+///     &circle,
+///     &[2.4, 0.0].into(),
+///     &Angle::default()
+/// ));
+/// assert!(!rounded_rectangle.intersects_at(
+///     &circle,
+///     &[0.0, 2.4].into(),
+///     &Angle::default()
+/// ));
+/// assert!(circle.intersects_at(
+///     &rounded_rectangle,
+///     &[0.0, 2.4].into(),
+///     &Angle::from(PI / 2.0)
+/// ));
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 pub struct Convex<S>(pub S);
 

--- a/hoomd-geometry/src/lib.rs
+++ b/hoomd-geometry/src/lib.rs
@@ -8,95 +8,113 @@
     html_logo_url = "https://hoomd-blue.readthedocs.io/en/latest/_static/hoomdblue-logo-favicon.svg"
 )]
 
-/*! General, performant computational geometry code.
-
-`hoomd_geometry` implements common operations for widely-used geometric
-primitives, with additional functionality to accommodate hard-particle Monte
-Carlo simulations.
-
-## Geometric Primitives
-
-The [`Hypersphere`][shape::Hypersphere] demonstrates the design philosophy of
-`hoomd_geometry`. The struct contains a single radius value, and immediately
-provides access to a variety of methods. Hyperspheres are well defined in
-arbitrary dimension, and therefore the implementation is parameterized with a
-const generic `N` representing the embedding dimension:
-```
-use hoomd_geometry::{ Volume, shape::Hypersphere };
-use approx::assert_relative_eq;
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-const N: usize = 3;
-let s = Hypersphere::<N>::with_radius(1.0.try_into()?);
-let volume = s.volume();
-assert_relative_eq!(volume, (4.0 / 3.0 * PI));
-# Ok(())
-# }
-```
-
-## Traits
-[`Volume`] provides a notion of the amount of space a primitive
-occupies, and indicates the N-hypervolume of a given struct. For a
-[`Rectangle`][shape::Rectangle], for example, [`Volume`] returns the area in the
-plane, and for a [`Sphere`][shape::Sphere] returns the three-dimensional volume.
-
-[`IntersectsAt`] determines if there is an intersection between two shapes,
-where the second shape is placed in the coordinate system of the first.
-This is the most efficient way to test for intersections in Monte Carlo
-simulations as only the positions and orientations of the sites need to be
-modified.
-
-[`IsPointInside`] checks if a point is inside or outside a shape.
-
-Many shapes implement the `Distribution` trait from **rand** to randomly sample
-interior points.
-
-## Intersection Tests
-
-For non-orientable shapes, or for bodies who have special intersection
-tests for particular orientations, and inherent method `intersects` can be
-implemented as well:
-```
-use hoomd_geometry::{Convex, IntersectsAt, shape::Sphere};
-use hoomd_vector::Versor;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let s0 = Sphere {radius: 1.0.try_into()?};
-let s1 = Sphere {radius: 1.0.try_into()?};
-
-let q_id = Versor::default();
-
-assert_eq!(s0.intersects_at(&s1, &[1.9, 0.0, 0.0].into(), &q_id), true);
-assert_eq!(s0.intersects_at(&s1, &[2.1, 0.0, 0.0].into(), &q_id), false);
-# Ok(())
-# }
-```
-
-Any pair of shapes (with possibly different types) that both implement the
-[`SupportMapping`] trait can be tested for overlaps through the  [`Convex`]
-newtype. [`IntersectsAt`] uses the [`xenocollide`] algorithm, provided for
-2d and 3d shapes, to test for intersections between [`Convex`] shapes:
-```
-use hoomd_geometry::{Convex, IntersectsAt, shape::{Cuboid, Sphere}};
-use hoomd_vector::Versor;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let sphere = Convex(Sphere {radius: 1.0.try_into()?});
-let cuboid = Convex(Cuboid { edge_lengths: [2.0.try_into()?, 2.0.try_into()?, 2.0.try_into()?] });
-
-assert_eq!(
-    sphere.intersects_at(&cuboid, &[1.9, 0.0, 0.0].into(), &Versor::default()),
-    true
-);
-assert_eq!(
-    sphere.intersects_at(&cuboid, &[2.1, 0.0, 0.0].into(), &Versor::default()),
-    false
-);
-# Ok(())
-# }
-```
-*/
+//! General, performant computational geometry code.
+//!
+//! `hoomd_geometry` implements common operations for widely-used geometric
+//! primitives, with additional functionality to accommodate hard-particle Monte
+//! Carlo simulations.
+//!
+//! ## Geometric Primitives
+//!
+//! The [`Hypersphere`][shape::Hypersphere] demonstrates the design philosophy of
+//! `hoomd_geometry`. The struct contains a single radius value, and immediately
+//! provides access to a variety of methods. Hyperspheres are well defined in
+//! arbitrary dimension, and therefore the implementation is parameterized with a
+//! const generic `N` representing the embedding dimension:
+//! ```
+//! use approx::assert_relative_eq;
+//! use hoomd_geometry::{Volume, shape::Hypersphere};
+//! use std::f64::consts::PI;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! const N: usize = 3;
+//! let s = Hypersphere::<N>::with_radius(1.0.try_into()?);
+//! let volume = s.volume();
+//! assert_relative_eq!(volume, (4.0 / 3.0 * PI));
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Traits
+//! [`Volume`] provides a notion of the amount of space a primitive
+//! occupies, and indicates the N-hypervolume of a given struct. For a
+//! [`Rectangle`][shape::Rectangle], for example, [`Volume`] returns the area in the
+//! plane, and for a [`Sphere`][shape::Sphere] returns the three-dimensional volume.
+//!
+//! [`IntersectsAt`] determines if there is an intersection between two shapes,
+//! where the second shape is placed in the coordinate system of the first.
+//! This is the most efficient way to test for intersections in Monte Carlo
+//! simulations as only the positions and orientations of the sites need to be
+//! modified.
+//!
+//! [`IsPointInside`] checks if a point is inside or outside a shape.
+//!
+//! Many shapes implement the `Distribution` trait from **rand** to randomly sample
+//! interior points.
+//!
+//! ## Intersection Tests
+//!
+//! For non-orientable shapes, or for bodies who have special intersection
+//! tests for particular orientations, and inherent method `intersects` can be
+//! implemented as well:
+//! ```
+//! use hoomd_geometry::{Convex, IntersectsAt, shape::Sphere};
+//! use hoomd_vector::Versor;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let s0 = Sphere {
+//!     radius: 1.0.try_into()?,
+//! };
+//! let s1 = Sphere {
+//!     radius: 1.0.try_into()?,
+//! };
+//!
+//! let q_id = Versor::default();
+//!
+//! assert_eq!(s0.intersects_at(&s1, &[1.9, 0.0, 0.0].into(), &q_id), true);
+//! assert_eq!(s0.intersects_at(&s1, &[2.1, 0.0, 0.0].into(), &q_id), false);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Any pair of shapes (with possibly different types) that both implement the
+//! [`SupportMapping`] trait can be tested for overlaps through the  [`Convex`]
+//! newtype. [`IntersectsAt`] uses the [`xenocollide`] algorithm, provided for
+//! 2d and 3d shapes, to test for intersections between [`Convex`] shapes:
+//! ```
+//! use hoomd_geometry::{
+//!     Convex, IntersectsAt,
+//!     shape::{Cuboid, Sphere},
+//! };
+//! use hoomd_vector::Versor;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let sphere = Convex(Sphere {
+//!     radius: 1.0.try_into()?,
+//! });
+//! let cuboid = Convex(Cuboid {
+//!     edge_lengths: [2.0.try_into()?, 2.0.try_into()?, 2.0.try_into()?],
+//! });
+//!
+//! assert_eq!(
+//!     sphere.intersects_at(
+//!         &cuboid,
+//!         &[1.9, 0.0, 0.0].into(),
+//!         &Versor::default()
+//!     ),
+//!     true
+//! );
+//! assert_eq!(
+//!     sphere.intersects_at(
+//!         &cuboid,
+//!         &[2.1, 0.0, 0.0].into(),
+//!         &Versor::default()
+//!     ),
+//!     false
+//! );
+//! # Ok(())
+//! # }
+//! ```
 
 use hoomd_utility::valid::PositiveReal;
 use hoomd_vector::InnerProduct;
@@ -108,141 +126,159 @@ pub use convex::Convex;
 pub mod shape;
 pub mod xenocollide;
 
-/** The N-hypervolume of a geometry. In 2D, this is area and in 3D this is Volume.
-
-# Example
-
-```
-use hoomd_geometry::{Volume, shape::Hypersphere};
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-const N: usize = 3;
-let s = Hypersphere::<N>::with_radius(1.0.try_into()?);
-let volume = s.volume();
-# Ok(())
-# }
-```
-
-*/
+/// The N-hypervolume of a geometry. In 2D, this is area and in 3D this is Volume.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_geometry::{Volume, shape::Hypersphere};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// const N: usize = 3;
+/// let s = Hypersphere::<N>::with_radius(1.0.try_into()?);
+/// let volume = s.volume();
+/// # Ok(())
+/// # }
+/// ```
+///
 pub trait Volume {
     /// The N-hypervolume of a geometry.
     #[must_use]
     fn volume(&self) -> f64;
 }
 
-/** Find the point on a shape that is the furthest in a given direction.
-
-# Example
-
-```
-use hoomd_geometry::{shape::Cuboid, SupportMapping};
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let cuboid = Cuboid { edge_lengths: [3.0.try_into()?, 2.0.try_into()?] };
-
-let upper_right = cuboid.support_mapping(&[1.0, 1.0].into());
-let lower_right = cuboid.support_mapping(&[1.0, -1.0].into());
-
-assert_eq!(upper_right, [1.5, 1.0].into());
-assert_eq!(lower_right, [1.5, -1.0].into());
-# Ok(())
-# }
-```
-*/
+/// Find the point on a shape that is the furthest in a given direction.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_geometry::{SupportMapping, shape::Cuboid};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let cuboid = Cuboid {
+///     edge_lengths: [3.0.try_into()?, 2.0.try_into()?],
+/// };
+///
+/// let upper_right = cuboid.support_mapping(&[1.0, 1.0].into());
+/// let lower_right = cuboid.support_mapping(&[1.0, -1.0].into());
+///
+/// assert_eq!(upper_right, [1.5, 1.0].into());
+/// assert_eq!(lower_right, [1.5, -1.0].into());
+/// # Ok(())
+/// # }
+/// ```
 pub trait SupportMapping<V> {
     /// Return the furthest extent of a shape in the direction of `n`.
     fn support_mapping(&self, n: &V) -> V;
 }
 
-/** Test whether two shapes share any points in space.
-
-# Examples
-
-Some shapes implement [`IntersectsAt`] directly:
-```
-use hoomd_geometry::{Convex, IntersectsAt, shape::Sphere};
-use hoomd_vector::Versor;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let s0 = Sphere {radius: 1.0.try_into()?};
-let s1 = Sphere {radius: 1.0.try_into()?};
-
-let q_id = Versor::default();
-
-assert_eq!(s0.intersects_at(&s1, &[1.9, 0.0, 0.0].into(), &q_id), true);
-assert_eq!(s0.intersects_at(&s1, &[2.1, 0.0, 0.0].into(), &q_id), false);
-# Ok(())
-# }
-```
-
-Others must be wrapped in [`Convex`]:
-```
-use hoomd_geometry::{Convex, IntersectsAt, shape::{Cuboid, Sphere}};
-use hoomd_vector::Versor;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let sphere = Convex(Sphere {radius: 1.0.try_into()?});
-let cuboid = Convex(Cuboid { edge_lengths: [2.0.try_into()?, 2.0.try_into()?, 2.0.try_into()?] });
-
-assert_eq!(
-    sphere.intersects_at(&cuboid, &[1.9, 0.0, 0.0].into(), &Versor::default()),
-    true
-);
-assert_eq!(
-    sphere.intersects_at(&cuboid, &[2.1, 0.0, 0.0].into(), &Versor::default()),
-    false
-);
-# Ok(())
-# }
-```
-*/
+/// Test whether two shapes share any points in space.
+///
+/// # Examples
+///
+/// Some shapes implement [`IntersectsAt`] directly:
+/// ```
+/// use hoomd_geometry::{Convex, IntersectsAt, shape::Sphere};
+/// use hoomd_vector::Versor;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let s0 = Sphere {
+///     radius: 1.0.try_into()?,
+/// };
+/// let s1 = Sphere {
+///     radius: 1.0.try_into()?,
+/// };
+///
+/// let q_id = Versor::default();
+///
+/// assert_eq!(s0.intersects_at(&s1, &[1.9, 0.0, 0.0].into(), &q_id), true);
+/// assert_eq!(s0.intersects_at(&s1, &[2.1, 0.0, 0.0].into(), &q_id), false);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Others must be wrapped in [`Convex`]:
+/// ```
+/// use hoomd_geometry::{
+///     Convex, IntersectsAt,
+///     shape::{Cuboid, Sphere},
+/// };
+/// use hoomd_vector::Versor;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let sphere = Convex(Sphere {
+///     radius: 1.0.try_into()?,
+/// });
+/// let cuboid = Convex(Cuboid {
+///     edge_lengths: [2.0.try_into()?, 2.0.try_into()?, 2.0.try_into()?],
+/// });
+///
+/// assert_eq!(
+///     sphere.intersects_at(
+///         &cuboid,
+///         &[1.9, 0.0, 0.0].into(),
+///         &Versor::default()
+///     ),
+///     true
+/// );
+/// assert_eq!(
+///     sphere.intersects_at(
+///         &cuboid,
+///         &[2.1, 0.0, 0.0].into(),
+///         &Versor::default()
+///     ),
+///     false
+/// );
+/// # Ok(())
+/// # }
+/// ```
 pub trait IntersectsAt<S, V, R> {
-    /** Test whether the set of points in one shape intersects with the set of another.
-
-    Each shape (`self` and `other`) remain unmodified in their own local
-    coordinate systems. The intersection test is performed in the local
-    coordinate system of `self`. The vector `v_ij` points from the local
-    origin of `self` to the local origin of `other`. Similarly, `o_ij` is the
-    orientation of `other` in the local coordinate system of `self`.
-
-    # See Also
-
-    Call [`pair_system_to_local`] to compute `v_ij` and `o_ij` from the
-    system frame positions and orientations of two shapes.
-
-    [`pair_system_to_local`]: hoomd_vector::pair_system_to_local
-    */
+    /// Test whether the set of points in one shape intersects with the set of another.
+    ///
+    /// Each shape (`self` and `other`) remain unmodified in their own local
+    /// coordinate systems. The intersection test is performed in the local
+    /// coordinate system of `self`. The vector `v_ij` points from the local
+    /// origin of `self` to the local origin of `other`. Similarly, `o_ij` is the
+    /// orientation of `other` in the local coordinate system of `self`.
+    ///
+    /// # See Also
+    ///
+    /// Call [`pair_system_to_local`] to compute `v_ij` and `o_ij` from the
+    /// system frame positions and orientations of two shapes.
+    ///
+    /// [`pair_system_to_local`]: hoomd_vector::pair_system_to_local
     fn intersects_at(&self, other: &S, v_ij: &V, o_ij: &R) -> bool;
 
-    /** Approximate the amount of overlap between two shapes.
-
-    Move `other` in along `v_ij` until the shapes no longer overlap. Return the
-    *approximate* distance needed to move `other` (which is 0 if the shapes are
-    already separated). This is *not* the exact minimum separation distance and
-    the method does *not* solve for an optimal direction.
-
-    `resolution` sets the size of the steps between distances in the
-    approximation.
-
-    If `v_ij` has 0 norm, move `other` along the `V::default_unit()`.
-
-    ```
-    use hoomd_geometry::{Convex, IntersectsAt, shape::Cuboid};
-    use hoomd_vector::Versor;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let cuboid = Convex(Cuboid::with_equal_edges(2.0.try_into()?));
-
-    let d = cuboid.approximate_separation_distance(&cuboid,
-        &[1.8, 0.0, 0.0].into(),
-        &Versor::default(),
-        0.01.try_into()?);
-
-    assert!(d >= 0.2);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Approximate the amount of overlap between two shapes.
+    ///
+    /// Move `other` in along `v_ij` until the shapes no longer overlap. Return the
+    /// approximate* distance needed to move `other` (which is 0 if the shapes are
+    /// already separated). This is *not* the exact minimum separation distance and
+    /// the method does *not* solve for an optimal direction.
+    ///
+    /// `resolution` sets the size of the steps between distances in the
+    /// approximation.
+    ///
+    /// If `v_ij` has 0 norm, move `other` along the `V::default_unit()`.
+    ///
+    /// ```
+    /// use hoomd_geometry::{Convex, IntersectsAt, shape::Cuboid};
+    /// use hoomd_vector::Versor;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let cuboid = Convex(Cuboid::with_equal_edges(2.0.try_into()?));
+    ///
+    /// let d = cuboid.approximate_separation_distance(
+    ///     &cuboid,
+    ///     &[1.8, 0.0, 0.0].into(),
+    ///     &Versor::default(),
+    ///     0.01.try_into()?,
+    /// );
+    ///
+    /// assert!(d >= 0.2);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn approximate_separation_distance(
         &self,
@@ -266,49 +302,51 @@ pub trait IntersectsAt<S, V, R> {
     }
 }
 
-/** Radius of an N-dimensional hypersphere that bounds a shape.
-
-The hypersphere has the same local origin as the shape `self`.
-
-Some [`IntersectsAt`] tests use the bounding sphere radius as a first pass
-before calling a more expensive intersection test. To improve performance,
-the bounding sphere should be as tightly fitting as possible.
-
-# Example
-
-```
-use hoomd_geometry::{BoundingSphereRadius, shape::Cuboid};
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let cuboid = Cuboid { edge_lengths: [6.0.try_into()?, 8.0.try_into()?] };
-let bounding_radius = cuboid.bounding_sphere_radius();
-
-assert_eq!(bounding_radius.get(), 5.0);
-# Ok(())
-# }
-```
-*/
+/// Radius of an N-dimensional hypersphere that bounds a shape.
+///
+/// The hypersphere has the same local origin as the shape `self`.
+///
+/// Some [`IntersectsAt`] tests use the bounding sphere radius as a first pass
+/// before calling a more expensive intersection test. To improve performance,
+/// the bounding sphere should be as tightly fitting as possible.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_geometry::{BoundingSphereRadius, shape::Cuboid};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let cuboid = Cuboid {
+///     edge_lengths: [6.0.try_into()?, 8.0.try_into()?],
+/// };
+/// let bounding_radius = cuboid.bounding_sphere_radius();
+///
+/// assert_eq!(bounding_radius.get(), 5.0);
+/// # Ok(())
+/// # }
+/// ```
 pub trait BoundingSphereRadius {
     /// Get the bounding radius.
     fn bounding_sphere_radius(&self) -> PositiveReal;
 }
 
-/** Test whether a point is inside or outside a shape.
-
-# Example
-
-```
-use hoomd_geometry::{IsPointInside, shape::Cuboid};
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let cuboid = Cuboid { edge_lengths: [6.0.try_into()?, 8.0.try_into()?] };
-
-assert!(cuboid.is_point_inside(&[2.5, -3.5].into()));
-assert!(!cuboid.is_point_inside(&[4.0, -3.5].into()));
-# Ok(())
-# }
-```
-*/
+/// Test whether a point is inside or outside a shape.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_geometry::{IsPointInside, shape::Cuboid};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let cuboid = Cuboid {
+///     edge_lengths: [6.0.try_into()?, 8.0.try_into()?],
+/// };
+///
+/// assert!(cuboid.is_point_inside(&[2.5, -3.5].into()));
+/// assert!(!cuboid.is_point_inside(&[4.0, -3.5].into()));
+/// # Ok(())
+/// # }
+/// ```
 pub trait IsPointInside<V> {
     /// Check if a point is inside the shape.
     fn is_point_inside(&self, point: &V) -> bool;

--- a/hoomd-geometry/src/lib.rs
+++ b/hoomd-geometry/src/lib.rs
@@ -71,8 +71,8 @@
 //!
 //! let q_id = Versor::default();
 //!
-//! assert_eq!(s0.intersects_at(&s1, &[1.9, 0.0, 0.0].into(), &q_id), true);
-//! assert_eq!(s0.intersects_at(&s1, &[2.1, 0.0, 0.0].into(), &q_id), false);
+//! assert!(s0.intersects_at(&s1, &[1.9, 0.0, 0.0].into(), &q_id));
+//! assert!(!s0.intersects_at(&s1, &[2.1, 0.0, 0.0].into(), &q_id));
 //! # Ok(())
 //! # }
 //! ```
@@ -96,21 +96,19 @@
 //!     edge_lengths: [2.0.try_into()?, 2.0.try_into()?, 2.0.try_into()?],
 //! });
 //!
-//! assert_eq!(
+//! assert!(
 //!     sphere.intersects_at(
 //!         &cuboid,
 //!         &[1.9, 0.0, 0.0].into(),
 //!         &Versor::default()
-//!     ),
-//!     true
+//!     )
 //! );
-//! assert_eq!(
-//!     sphere.intersects_at(
+//! assert!(
+//!     !sphere.intersects_at(
 //!         &cuboid,
 //!         &[2.1, 0.0, 0.0].into(),
 //!         &Versor::default()
-//!     ),
-//!     false
+//!     )
 //! );
 //! # Ok(())
 //! # }
@@ -140,7 +138,6 @@ pub mod xenocollide;
 /// # Ok(())
 /// # }
 /// ```
-///
 pub trait Volume {
     /// The N-hypervolume of a geometry.
     #[must_use]
@@ -191,8 +188,8 @@ pub trait SupportMapping<V> {
 ///
 /// let q_id = Versor::default();
 ///
-/// assert_eq!(s0.intersects_at(&s1, &[1.9, 0.0, 0.0].into(), &q_id), true);
-/// assert_eq!(s0.intersects_at(&s1, &[2.1, 0.0, 0.0].into(), &q_id), false);
+/// assert!(s0.intersects_at(&s1, &[1.9, 0.0, 0.0].into(), &q_id));
+/// assert!(!s0.intersects_at(&s1, &[2.1, 0.0, 0.0].into(), &q_id));
 /// # Ok(())
 /// # }
 /// ```
@@ -213,21 +210,19 @@ pub trait SupportMapping<V> {
 ///     edge_lengths: [2.0.try_into()?, 2.0.try_into()?, 2.0.try_into()?],
 /// });
 ///
-/// assert_eq!(
+/// assert!(
 ///     sphere.intersects_at(
 ///         &cuboid,
 ///         &[1.9, 0.0, 0.0].into(),
 ///         &Versor::default()
-///     ),
-///     true
+///     )
 /// );
-/// assert_eq!(
-///     sphere.intersects_at(
+/// assert!(
+///     !sphere.intersects_at(
 ///         &cuboid,
 ///         &[2.1, 0.0, 0.0].into(),
 ///         &Versor::default()
-///     ),
-///     false
+///     )
 /// );
 /// # Ok(())
 /// # }

--- a/hoomd-geometry/src/lib.rs
+++ b/hoomd-geometry/src/lib.rs
@@ -96,20 +96,16 @@
 //!     edge_lengths: [2.0.try_into()?, 2.0.try_into()?, 2.0.try_into()?],
 //! });
 //!
-//! assert!(
-//!     sphere.intersects_at(
-//!         &cuboid,
-//!         &[1.9, 0.0, 0.0].into(),
-//!         &Versor::default()
-//!     )
-//! );
-//! assert!(
-//!     !sphere.intersects_at(
-//!         &cuboid,
-//!         &[2.1, 0.0, 0.0].into(),
-//!         &Versor::default()
-//!     )
-//! );
+//! assert!(sphere.intersects_at(
+//!     &cuboid,
+//!     &[1.9, 0.0, 0.0].into(),
+//!     &Versor::default()
+//! ));
+//! assert!(!sphere.intersects_at(
+//!     &cuboid,
+//!     &[2.1, 0.0, 0.0].into(),
+//!     &Versor::default()
+//! ));
 //! # Ok(())
 //! # }
 //! ```
@@ -210,20 +206,16 @@ pub trait SupportMapping<V> {
 ///     edge_lengths: [2.0.try_into()?, 2.0.try_into()?, 2.0.try_into()?],
 /// });
 ///
-/// assert!(
-///     sphere.intersects_at(
-///         &cuboid,
-///         &[1.9, 0.0, 0.0].into(),
-///         &Versor::default()
-///     )
-/// );
-/// assert!(
-///     !sphere.intersects_at(
-///         &cuboid,
-///         &[2.1, 0.0, 0.0].into(),
-///         &Versor::default()
-///     )
-/// );
+/// assert!(sphere.intersects_at(
+///     &cuboid,
+///     &[1.9, 0.0, 0.0].into(),
+///     &Versor::default()
+/// ));
+/// assert!(!sphere.intersects_at(
+///     &cuboid,
+///     &[2.1, 0.0, 0.0].into(),
+///     &Versor::default()
+/// ));
 /// # Ok(())
 /// # }
 /// ```

--- a/hoomd-geometry/src/shape.rs
+++ b/hoomd-geometry/src/shape.rs
@@ -1,16 +1,15 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Geometric representations of common shapes in N-dimensional space.
-
-Geometric primitives defined in this package are designed to be lightweight
-representations of geometry, independent of a global reference. This design
-makes struct suitible for use with simulation code, and ensures shapes are
-constructible from minimal information.
-
-For shapes with parameterizable dimension, a `const N: usize` generic parameter
-encodes the dimensionality.
-*/
+//! Geometric representations of common shapes in N-dimensional space.
+//!
+//! Geometric primitives defined in this package are designed to be lightweight
+//! representations of geometry, independent of a global reference. This design
+//! makes struct suitible for use with simulation code, and ensures shapes are
+//! constructible from minimal information.
+//!
+//! For shapes with parameterizable dimension, a `const N: usize` generic parameter
+//! encodes the dimensionality.
 
 mod capsule;
 pub use capsule::Capsule;

--- a/hoomd-geometry/src/shape/capsule.rs
+++ b/hoomd-geometry/src/shape/capsule.rs
@@ -48,23 +48,21 @@ use hoomd_vector::{Cartesian, InnerProduct};
 ///     height: 8.0.try_into()?,
 /// });
 ///
-/// assert!(
-///     capsule.intersects_at(
-///         &capsule,
-///         &[1.75, 0.0].into(),
-///         &Angle::identity()
-///     )
-/// );
-/// assert!(
-///     !capsule.intersects_at(&capsule, &[4.0, 2.0].into(), &Angle::identity()),
-/// );
-/// assert!(
-///     capsule.intersects_at(
-///         &capsule,
-///         &[4.0, -2.0].into(),
-///         &Angle::from(PI / 2.0)
-///     )
-/// );
+/// assert!(capsule.intersects_at(
+///     &capsule,
+///     &[1.75, 0.0].into(),
+///     &Angle::identity()
+/// ));
+/// assert!(!capsule.intersects_at(
+///     &capsule,
+///     &[4.0, 2.0].into(),
+///     &Angle::identity()
+/// ),);
+/// assert!(capsule.intersects_at(
+///     &capsule,
+///     &[4.0, -2.0].into(),
+///     &Angle::from(PI / 2.0)
+/// ));
 /// # Ok(())
 /// # }
 /// ```

--- a/hoomd-geometry/src/shape/capsule.rs
+++ b/hoomd-geometry/src/shape/capsule.rs
@@ -48,25 +48,22 @@ use hoomd_vector::{Cartesian, InnerProduct};
 ///     height: 8.0.try_into()?,
 /// });
 ///
-/// assert_eq!(
+/// assert!(
 ///     capsule.intersects_at(
 ///         &capsule,
 ///         &[1.75, 0.0].into(),
 ///         &Angle::identity()
-///     ),
-///     true
+///     )
 /// );
-/// assert_eq!(
-///     capsule.intersects_at(&capsule, &[4.0, 2.0].into(), &Angle::identity()),
-///     false
+/// assert!(
+///     !capsule.intersects_at(&capsule, &[4.0, 2.0].into(), &Angle::identity()),
 /// );
-/// assert_eq!(
+/// assert!(
 ///     capsule.intersects_at(
 ///         &capsule,
 ///         &[4.0, -2.0].into(),
 ///         &Angle::from(PI / 2.0)
-///     ),
-///     true
+///     )
 /// );
 /// # Ok(())
 /// # }

--- a/hoomd-geometry/src/shape/capsule.rs
+++ b/hoomd-geometry/src/shape/capsule.rs
@@ -1,54 +1,76 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement [`Capsule`] */
+//! Implement [`Capsule`]
 
 use super::sphere::sphere_volume_prefactor;
 use crate::{BoundingSphereRadius, SupportMapping, Volume};
 use hoomd_utility::valid::PositiveReal;
 use hoomd_vector::{Cartesian, InnerProduct};
 
-/** All points less than or equal to a distance `r` from a line segment of length `h`.
-
-This line is oriented along the `[0 0 ... 1]` direction, and has extents `+h/2`,
-`-h/2` along that axis.
-
-# Examples
-
-Construction and basic methods:
-```
-use hoomd_geometry::{BoundingSphereRadius, shape::Capsule, Volume};
-use hoomd_vector::Cartesian;
-use approx::assert_relative_eq;
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let capsule = Capsule::<2> { radius: 1.0.try_into()?, height: 8.0.try_into()? };
-let bounding_radius = capsule.bounding_sphere_radius();
-let volume = capsule.volume();
-
-assert_eq!(bounding_radius.get(), 5.0);
-assert_relative_eq!(volume, 16.0 + PI);
-# Ok(())
-# }
-```
-
-Intersection test:
-```
-use hoomd_geometry::{Convex, IntersectsAt, shape::Capsule};
-use hoomd_vector::{Angle, Cartesian, Rotation};
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let capsule = Convex(Capsule::<2> { radius: 1.0.try_into()?, height: 8.0.try_into()? });
-
-assert_eq!(capsule.intersects_at(&capsule, &[1.75, 0.0].into(), &Angle::identity()), true);
-assert_eq!(capsule.intersects_at(&capsule, &[4.0, 2.0].into(), &Angle::identity()), false);
-assert_eq!(capsule.intersects_at(&capsule, &[4.0, -2.0].into(), &Angle::from(PI / 2.0)), true);
-# Ok(())
-# }
-```
-*/
+/// All points less than or equal to a distance `r` from a line segment of length `h`.
+///
+/// This line is oriented along the `[0 0 ... 1]` direction, and has extents `+h/2`,
+/// `-h/2` along that axis.
+///
+/// # Examples
+///
+/// Construction and basic methods:
+/// ```
+/// use approx::assert_relative_eq;
+/// use hoomd_geometry::{BoundingSphereRadius, Volume, shape::Capsule};
+/// use hoomd_vector::Cartesian;
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let capsule = Capsule::<2> {
+///     radius: 1.0.try_into()?,
+///     height: 8.0.try_into()?,
+/// };
+/// let bounding_radius = capsule.bounding_sphere_radius();
+/// let volume = capsule.volume();
+///
+/// assert_eq!(bounding_radius.get(), 5.0);
+/// assert_relative_eq!(volume, 16.0 + PI);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Intersection test:
+/// ```
+/// use hoomd_geometry::{Convex, IntersectsAt, shape::Capsule};
+/// use hoomd_vector::{Angle, Cartesian, Rotation};
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let capsule = Convex(Capsule::<2> {
+///     radius: 1.0.try_into()?,
+///     height: 8.0.try_into()?,
+/// });
+///
+/// assert_eq!(
+///     capsule.intersects_at(
+///         &capsule,
+///         &[1.75, 0.0].into(),
+///         &Angle::identity()
+///     ),
+///     true
+/// );
+/// assert_eq!(
+///     capsule.intersects_at(&capsule, &[4.0, 2.0].into(), &Angle::identity()),
+///     false
+/// );
+/// assert_eq!(
+///     capsule.intersects_at(
+///         &capsule,
+///         &[4.0, -2.0].into(),
+///         &Angle::from(PI / 2.0)
+///     ),
+///     true
+/// );
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Capsule<const N: usize> {
     /// Radius of of points that are considered enclosed in the shape.

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -46,21 +46,19 @@ use hoomd_vector::{Cartesian, InnerProduct};
 /// ])?;
 /// let rectangle = Convex(rectangle);
 ///
-/// assert_eq!(
-///     rectangle.intersects_at(
+/// assert!(
+///     !rectangle.intersects_at(
 ///         &rectangle,
 ///         &[0.0, 2.1].into(),
 ///         &Angle::default()
-///     ),
-///     false
+///     )
 /// );
-/// assert_eq!(
+/// assert!(
 ///     rectangle.intersects_at(
 ///         &rectangle,
 ///         &[0.0, 2.1].into(),
 ///         &Angle::from(PI / 2.0)
-///     ),
-///     true
+///     )
 /// );
 /// # Ok(())
 /// # }
@@ -93,10 +91,11 @@ pub type ConvexPolygon = ConvexPolytope<2>;
 
 /// A faceted convex body in three dimensions.
 ///
+/// # Example
+/// 
 /// ```
 /// use hoomd_geometry::shape::{ConvexPolyhedron, Simplex3};
 /// # fn main() -> Result<(), hoomd_geometry::Error> {
-/// Create a regular tetrahedron from its vertices
 /// let poly = ConvexPolyhedron::with_vertices(
 /// vec![
 /// [1.0, 1.0, 1.0].into(),

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -46,20 +46,16 @@ use hoomd_vector::{Cartesian, InnerProduct};
 /// ])?;
 /// let rectangle = Convex(rectangle);
 ///
-/// assert!(
-///     !rectangle.intersects_at(
-///         &rectangle,
-///         &[0.0, 2.1].into(),
-///         &Angle::default()
-///     )
-/// );
-/// assert!(
-///     rectangle.intersects_at(
-///         &rectangle,
-///         &[0.0, 2.1].into(),
-///         &Angle::from(PI / 2.0)
-///     )
-/// );
+/// assert!(!rectangle.intersects_at(
+///     &rectangle,
+///     &[0.0, 2.1].into(),
+///     &Angle::default()
+/// ));
+/// assert!(rectangle.intersects_at(
+///     &rectangle,
+///     &[0.0, 2.1].into(),
+///     &Angle::from(PI / 2.0)
+/// ));
 /// # Ok(())
 /// # }
 /// ```
@@ -92,18 +88,16 @@ pub type ConvexPolygon = ConvexPolytope<2>;
 /// A faceted convex body in three dimensions.
 ///
 /// # Example
-/// 
+///
 /// ```
 /// use hoomd_geometry::shape::{ConvexPolyhedron, Simplex3};
 /// # fn main() -> Result<(), hoomd_geometry::Error> {
-/// let poly = ConvexPolyhedron::with_vertices(
-/// vec![
-/// [1.0, 1.0, 1.0].into(),
-/// [1.0, -1.0, -1.0].into(),
-/// [-1.0, 1.0, -1.0].into(),
-/// [-1.0, -1.0, 1.0].into(),
-/// ]
-/// )?;
+/// let poly = ConvexPolyhedron::with_vertices(vec![
+///     [1.0, 1.0, 1.0].into(),
+///     [1.0, -1.0, -1.0].into(),
+///     [-1.0, 1.0, -1.0].into(),
+///     [-1.0, -1.0, 1.0].into(),
+/// ])?;
 ///
 /// assert_eq!(poly.vertices(), Simplex3::default().vertices());
 /// # Ok(())

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -1,58 +1,70 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! N-Dimensional generalization of a convex polyhedron. */
+//! N-Dimensional generalization of a convex polyhedron.
 
 use crate::{BoundingSphereRadius, Error, SupportMapping};
 use hoomd_utility::valid::PositiveReal;
 use hoomd_vector::{Cartesian, InnerProduct};
 
-/** A faceted solid defined by the convex hull of its vertices.
-
-# Examples
-
-Construction and basic methods:
-```
-use hoomd_geometry::{BoundingSphereRadius, shape::{ConvexPolyhedron}};
-use approx::assert_relative_eq;
-
-# fn main() -> Result<(), hoomd_geometry::Error> {
-let tetrahedron = ConvexPolyhedron::with_vertices(
-    vec![
-        [1.0, 1.0, 1.0].into(),
-        [1.0, -1.0, -1.0].into(),
-        [-1.0, 1.0, -1.0].into(),
-        [-1.0, -1.0, 1.0].into(),
-    ]
-)?;
-
-let bounding_radius = tetrahedron.bounding_sphere_radius();
-
-assert_relative_eq!(bounding_radius.get(), 3.0_f64.sqrt());
-# Ok(())
-# }
-```
-
-Intersection tests:
-```
-use hoomd_geometry::{Convex, IntersectsAt, shape::ConvexPolygon};
-use hoomd_vector::{Cartesian, Angle};
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), hoomd_geometry::Error> {
-let rectangle = ConvexPolygon::with_vertices(
-    [[-2.0, -1.0].into(),
-     [2.0, -1.0].into(),
-     [2.0, 1.0].into(),
-     [-2.0, 1.0].into()])?;
-let rectangle = Convex(rectangle);
-
-assert_eq!(rectangle.intersects_at(&rectangle, &[0.0, 2.1].into(), &Angle::default()), false);
-assert_eq!(rectangle.intersects_at(&rectangle, &[0.0, 2.1].into(), &Angle::from(PI / 2.0)), true);
-# Ok(())
-# }
-```
-*/
+/// A faceted solid defined by the convex hull of its vertices.
+///
+/// # Examples
+///
+/// Construction and basic methods:
+/// ```
+/// use approx::assert_relative_eq;
+/// use hoomd_geometry::{BoundingSphereRadius, shape::ConvexPolyhedron};
+///
+/// # fn main() -> Result<(), hoomd_geometry::Error> {
+/// let tetrahedron = ConvexPolyhedron::with_vertices(vec![
+///     [1.0, 1.0, 1.0].into(),
+///     [1.0, -1.0, -1.0].into(),
+///     [-1.0, 1.0, -1.0].into(),
+///     [-1.0, -1.0, 1.0].into(),
+/// ])?;
+///
+/// let bounding_radius = tetrahedron.bounding_sphere_radius();
+///
+/// assert_relative_eq!(bounding_radius.get(), 3.0_f64.sqrt());
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Intersection tests:
+/// ```
+/// use hoomd_geometry::{Convex, IntersectsAt, shape::ConvexPolygon};
+/// use hoomd_vector::{Angle, Cartesian};
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), hoomd_geometry::Error> {
+/// let rectangle = ConvexPolygon::with_vertices([
+///     [-2.0, -1.0].into(),
+///     [2.0, -1.0].into(),
+///     [2.0, 1.0].into(),
+///     [-2.0, 1.0].into(),
+/// ])?;
+/// let rectangle = Convex(rectangle);
+///
+/// assert_eq!(
+///     rectangle.intersects_at(
+///         &rectangle,
+///         &[0.0, 2.1].into(),
+///         &Angle::default()
+///     ),
+///     false
+/// );
+/// assert_eq!(
+///     rectangle.intersects_at(
+///         &rectangle,
+///         &[0.0, 2.1].into(),
+///         &Angle::from(PI / 2.0)
+///     ),
+///     true
+/// );
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 pub struct ConvexPolytope<const N: usize> {
     /// The vertices of the shape.
@@ -61,57 +73,54 @@ pub struct ConvexPolytope<const N: usize> {
     pub(crate) bounding_radius: f64,
 }
 
-/**A faceted convex body in two dimensions.
-
-```rust
-
-use hoomd_geometry::shape::ConvexPolygon;
-
-# fn main() -> Result<(), hoomd_geometry::Error> {
-let hexagon = ConvexPolygon::regular(6);
-let square = ConvexPolygon::with_vertices(
-    [[-1.0, -1.0].into(),
-     [1.0, -1.0].into(),
-     [1.0, 1.0].into(),
-     [-1.0, 1.0].into()])?;
-# Ok(())
-# }
-```
-*/
+/// A faceted convex body in two dimensions.
+///
+/// ```rust
+/// use hoomd_geometry::shape::ConvexPolygon;
+///
+/// # fn main() -> Result<(), hoomd_geometry::Error> {
+/// let hexagon = ConvexPolygon::regular(6);
+/// let square = ConvexPolygon::with_vertices([
+///     [-1.0, -1.0].into(),
+///     [1.0, -1.0].into(),
+///     [1.0, 1.0].into(),
+///     [-1.0, 1.0].into(),
+/// ])?;
+/// # Ok(())
+/// # }
+/// ```
 pub type ConvexPolygon = ConvexPolytope<2>;
 
-/**A faceted convex body in three dimensions.
-
-```
-use hoomd_geometry::shape::{ConvexPolyhedron, Simplex3};
-# fn main() -> Result<(), hoomd_geometry::Error> {
-// Create a regular tetrahedron from its vertices
-let poly = ConvexPolyhedron::with_vertices(
-    vec![
-        [1.0, 1.0, 1.0].into(),
-        [1.0, -1.0, -1.0].into(),
-        [-1.0, 1.0, -1.0].into(),
-        [-1.0, -1.0, 1.0].into(),
-    ]
-)?;
-
-assert_eq!(poly.vertices(), Simplex3::default().vertices());
-# Ok(())
-# }
-```
-*/
+/// A faceted convex body in three dimensions.
+///
+/// ```
+/// use hoomd_geometry::shape::{ConvexPolyhedron, Simplex3};
+/// # fn main() -> Result<(), hoomd_geometry::Error> {
+/// Create a regular tetrahedron from its vertices
+/// let poly = ConvexPolyhedron::with_vertices(
+/// vec![
+/// [1.0, 1.0, 1.0].into(),
+/// [1.0, -1.0, -1.0].into(),
+/// [-1.0, 1.0, -1.0].into(),
+/// [-1.0, -1.0, 1.0].into(),
+/// ]
+/// )?;
+///
+/// assert_eq!(poly.vertices(), Simplex3::default().vertices());
+/// # Ok(())
+/// # }
+/// ```
 pub type ConvexPolyhedron = ConvexPolytope<3>;
 
 impl ConvexPolytope<2> {
-    /** Create a regular *n*-gon with *n* vertices and circumradius one.
-
-    # Example
-    ```
-    use hoomd_geometry::shape::ConvexPolytope;
-
-    let equilateral_triangle = ConvexPolytope::regular(3);
-    ```
-    */
+    /// Create a regular *n*-gon with *n* vertices and circumradius one.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_geometry::shape::ConvexPolytope;
+    ///
+    /// let equilateral_triangle = ConvexPolytope::regular(3);
+    /// ```
     #[inline]
     #[must_use]
     pub fn regular(n: usize) -> ConvexPolytope<2> {
@@ -128,27 +137,24 @@ impl ConvexPolytope<2> {
 }
 
 impl<const N: usize> ConvexPolytope<N> {
-    /** Create an `N`-polytope with the given vertices.
-
-    # Example
-    ```
-    use hoomd_geometry::shape::ConvexPolytope;
-
-    # fn main() -> Result<(), hoomd_geometry::Error> {
-    let equilateral_triangle = ConvexPolytope::with_vertices(
-        vec![
-            [1.0, 0.0].into(),
-            [0.5, f64::sqrt(3.0)/2.0].into(),
-            [-0.5, f64::sqrt(3.0)/2.0].into(),
-       ]
-    )?;
-    # Ok(())
-    # }
-    ```
-    # Errors
-
-    * `[Error::DegeneratePolytope]` when no vertices are provided.
-    */
+    /// Create an `N`-polytope with the given vertices.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_geometry::shape::ConvexPolytope;
+    ///
+    /// # fn main() -> Result<(), hoomd_geometry::Error> {
+    /// let equilateral_triangle = ConvexPolytope::with_vertices(vec![
+    ///     [1.0, 0.0].into(),
+    ///     [0.5, f64::sqrt(3.0) / 2.0].into(),
+    ///     [-0.5, f64::sqrt(3.0) / 2.0].into(),
+    /// ])?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    /// # Errors
+    ///
+    /// `[Error::DegeneratePolytope]` when no vertices are provided.
     #[inline]
     pub fn with_vertices<I>(vertices: I) -> Result<ConvexPolytope<N>, Error>
     where

--- a/hoomd-geometry/src/shape/cuboid.rs
+++ b/hoomd-geometry/src/shape/cuboid.rs
@@ -59,9 +59,7 @@ use std::{array, ops::Mul};
 ///     edge_lengths: [1.0.try_into()?, 1.0.try_into()?, 9.0.try_into()?],
 /// };
 ///
-/// assert!(
-///     unit_cube.intersects_aligned(&rectangular_prism, &[1.0; 3].into())
-/// );
+/// assert!(unit_cube.intersects_aligned(&rectangular_prism, &[1.0; 3].into()));
 /// assert!(
 ///     !unit_cube.intersects_aligned(&rectangular_prism, &[1.1; 3].into())
 /// );
@@ -81,16 +79,16 @@ use std::{array, ops::Mul};
 ///     edge_lengths: [1.0.try_into()?; 2],
 /// });
 ///
-/// assert!(
-///     !square.intersects_at(&square, &[1.1, 0.0].into(), &Angle::default())
-/// );
-/// assert!(
-///     square.intersects_at(
-///         &square,
-///         &[1.1, 0.0].into(),
-///         &Angle::from(PI / 4.0)
-///     )
-/// );
+/// assert!(!square.intersects_at(
+///     &square,
+///     &[1.1, 0.0].into(),
+///     &Angle::default()
+/// ));
+/// assert!(square.intersects_at(
+///     &square,
+///     &[1.1, 0.0].into(),
+///     &Angle::from(PI / 4.0)
+/// ));
 /// # Ok(())
 /// # }
 /// ```
@@ -129,20 +127,16 @@ pub struct Cuboid<const N: usize> {
 /// };
 /// let rectangle = Convex(rectangle);
 ///
-/// assert!(
-///     !rectangle.intersects_at(
-///         &rectangle,
-///         &[0.0, 2.1].into(),
-///         &Angle::default()
-///     )
-/// );
-/// assert!(
-///     rectangle.intersects_at(
-///         &rectangle,
-///         &[0.0, 2.1].into(),
-///         &Angle::from(PI / 2.0)
-///     )
-/// );
+/// assert!(!rectangle.intersects_at(
+///     &rectangle,
+///     &[0.0, 2.1].into(),
+///     &Angle::default()
+/// ));
+/// assert!(rectangle.intersects_at(
+///     &rectangle,
+///     &[0.0, 2.1].into(),
+///     &Angle::from(PI / 2.0)
+/// ));
 /// # Ok(())
 /// # }
 /// ```
@@ -206,9 +200,7 @@ impl<const N: usize> Cuboid<N> {
     ///     edge_lengths: [1.0.try_into()?, 1.0.try_into()?, 9.0.try_into()?],
     /// };
     ///
-    /// assert!(
-    ///     unit_cube.intersects_aligned(&rectangular_prism, &[1.0; 3].into())
-    /// );
+    /// assert!(unit_cube.intersects_aligned(&rectangular_prism, &[1.0; 3].into()));
     /// assert!(
     ///     !unit_cube.intersects_aligned(&rectangular_prism, &[1.1; 3].into())
     /// );

--- a/hoomd-geometry/src/shape/cuboid.rs
+++ b/hoomd-geometry/src/shape/cuboid.rs
@@ -59,13 +59,11 @@ use std::{array, ops::Mul};
 ///     edge_lengths: [1.0.try_into()?, 1.0.try_into()?, 9.0.try_into()?],
 /// };
 ///
-/// assert_eq!(
-///     unit_cube.intersects_aligned(&rectangular_prism, &[1.0; 3].into()),
-///     true
+/// assert!(
+///     unit_cube.intersects_aligned(&rectangular_prism, &[1.0; 3].into())
 /// );
-/// assert_eq!(
-///     unit_cube.intersects_aligned(&rectangular_prism, &[1.1; 3].into()),
-///     false
+/// assert!(
+///     !unit_cube.intersects_aligned(&rectangular_prism, &[1.1; 3].into())
 /// );
 /// # Ok(())
 /// # }
@@ -83,17 +81,15 @@ use std::{array, ops::Mul};
 ///     edge_lengths: [1.0.try_into()?; 2],
 /// });
 ///
-/// assert_eq!(
-///     square.intersects_at(&square, &[1.1, 0.0].into(), &Angle::default()),
-///     false
+/// assert!(
+///     !square.intersects_at(&square, &[1.1, 0.0].into(), &Angle::default())
 /// );
-/// assert_eq!(
+/// assert!(
 ///     square.intersects_at(
 ///         &square,
 ///         &[1.1, 0.0].into(),
 ///         &Angle::from(PI / 4.0)
-///     ),
-///     true
+///     )
 /// );
 /// # Ok(())
 /// # }
@@ -133,21 +129,19 @@ pub struct Cuboid<const N: usize> {
 /// };
 /// let rectangle = Convex(rectangle);
 ///
-/// assert_eq!(
-///     rectangle.intersects_at(
+/// assert!(
+///     !rectangle.intersects_at(
 ///         &rectangle,
 ///         &[0.0, 2.1].into(),
 ///         &Angle::default()
-///     ),
-///     false
+///     )
 /// );
-/// assert_eq!(
+/// assert!(
 ///     rectangle.intersects_at(
 ///         &rectangle,
 ///         &[0.0, 2.1].into(),
 ///         &Angle::from(PI / 2.0)
-///     ),
-///     true
+///     )
 /// );
 /// # Ok(())
 /// # }
@@ -212,13 +206,11 @@ impl<const N: usize> Cuboid<N> {
     ///     edge_lengths: [1.0.try_into()?, 1.0.try_into()?, 9.0.try_into()?],
     /// };
     ///
-    /// assert_eq!(
-    ///     unit_cube.intersects_aligned(&rectangular_prism, &[1.0; 3].into()),
-    ///     true
+    /// assert!(
+    ///     unit_cube.intersects_aligned(&rectangular_prism, &[1.0; 3].into())
     /// );
-    /// assert_eq!(
-    ///     unit_cube.intersects_aligned(&rectangular_prism, &[1.1; 3].into()),
-    ///     false
+    /// assert!(
+    ///     !unit_cube.intersects_aligned(&rectangular_prism, &[1.1; 3].into())
     /// );
     /// # Ok(())
     /// # }

--- a/hoomd-geometry/src/shape/cuboid.rs
+++ b/hoomd-geometry/src/shape/cuboid.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement [`Cuboid`] */
+//! Implement [`Cuboid`]
 
 use crate::{BoundingSphereRadius, IsPointInside, SupportMapping, Volume};
 use hoomd_utility::valid::PositiveReal;
@@ -14,104 +14,144 @@ use rand::{
 };
 use std::{array, ops::Mul};
 
-/** A shape with with all perpendicular angles made from axis-aligned edges.
-
-A [`Cuboid`] is the N-dimensional analog of a rectangle, and is defined by
-its edge lengths. Each perpendicular edge of the cuboid is aligned along the
-corresponding Cartesian axis. The Cuboid is placed with its centroid at the
-origin.
-
-# Example
-
-Construction and basic methods:
-```
-use hoomd_geometry::shape::Cuboid;
-use hoomd_geometry::Volume;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let unit_cube = Cuboid {edge_lengths: [1.0.try_into()?; 3]};
-assert_eq!(unit_cube.volume(), 1.0);
-
-let min_extents = unit_cube.minimal_extents();
-let max_extents = unit_cube.maximal_extents();
-assert_eq!(min_extents, [-0.5; 3]);
-assert_eq!(max_extents, [0.5; 3]);
-
-let rectangular_prism = Cuboid {edge_lengths: [1.0.try_into()?, 1.0.try_into()?, 9.0.try_into()?]};
-
-assert_eq!(rectangular_prism.volume(), 9.0);
-# Ok(())
-# }
-```
-
-Perform a fast AABB intersection tests:
-```
-use hoomd_geometry::shape::Cuboid;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let unit_cube = Cuboid {edge_lengths: [1.0.try_into()?; 3]};
-let rectangular_prism = Cuboid {edge_lengths: [1.0.try_into()?, 1.0.try_into()?, 9.0.try_into()?]};
-
-assert_eq!(unit_cube.intersects_aligned(&rectangular_prism, &[1.0; 3].into()), true);
-assert_eq!(unit_cube.intersects_aligned(&rectangular_prism, &[1.1; 3].into()), false);
-# Ok(())
-# }
-```
-
-Wrap with [`Convex`](crate::Convex) to check intersections of oriented cuboids:
-
-```
-use hoomd_geometry::{Convex, IntersectsAt, shape::Rectangle};
-use hoomd_vector::Angle;
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let square = Convex(Rectangle {edge_lengths: [1.0.try_into()?; 2]});
-
-assert_eq!(square.intersects_at(&square, &[1.1, 0.0].into(), &Angle::default()), false);
-assert_eq!(square.intersects_at(&square, &[1.1, 0.0].into(), &Angle::from(PI / 4.0)), true);
-# Ok(())
-# }
-```
-*/
+/// A shape with with all perpendicular angles made from axis-aligned edges.
+///
+/// A [`Cuboid`] is the N-dimensional analog of a rectangle, and is defined by
+/// its edge lengths. Each perpendicular edge of the cuboid is aligned along the
+/// corresponding Cartesian axis. The Cuboid is placed with its centroid at the
+/// origin.
+///
+/// # Example
+///
+/// Construction and basic methods:
+/// ```
+/// use hoomd_geometry::{Volume, shape::Cuboid};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let unit_cube = Cuboid {
+///     edge_lengths: [1.0.try_into()?; 3],
+/// };
+/// assert_eq!(unit_cube.volume(), 1.0);
+///
+/// let min_extents = unit_cube.minimal_extents();
+/// let max_extents = unit_cube.maximal_extents();
+/// assert_eq!(min_extents, [-0.5; 3]);
+/// assert_eq!(max_extents, [0.5; 3]);
+///
+/// let rectangular_prism = Cuboid {
+///     edge_lengths: [1.0.try_into()?, 1.0.try_into()?, 9.0.try_into()?],
+/// };
+///
+/// assert_eq!(rectangular_prism.volume(), 9.0);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Perform a fast AABB intersection tests:
+/// ```
+/// use hoomd_geometry::shape::Cuboid;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let unit_cube = Cuboid {
+///     edge_lengths: [1.0.try_into()?; 3],
+/// };
+/// let rectangular_prism = Cuboid {
+///     edge_lengths: [1.0.try_into()?, 1.0.try_into()?, 9.0.try_into()?],
+/// };
+///
+/// assert_eq!(
+///     unit_cube.intersects_aligned(&rectangular_prism, &[1.0; 3].into()),
+///     true
+/// );
+/// assert_eq!(
+///     unit_cube.intersects_aligned(&rectangular_prism, &[1.1; 3].into()),
+///     false
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Wrap with [`Convex`](crate::Convex) to check intersections of oriented cuboids:
+///
+/// ```
+/// use hoomd_geometry::{Convex, IntersectsAt, shape::Rectangle};
+/// use hoomd_vector::Angle;
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let square = Convex(Rectangle {
+///     edge_lengths: [1.0.try_into()?; 2],
+/// });
+///
+/// assert_eq!(
+///     square.intersects_at(&square, &[1.1, 0.0].into(), &Angle::default()),
+///     false
+/// );
+/// assert_eq!(
+///     square.intersects_at(
+///         &square,
+///         &[1.1, 0.0].into(),
+///         &Angle::from(PI / 4.0)
+///     ),
+///     true
+/// );
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Cuboid<const N: usize> {
     /// The lengths of each edge of the cuboid.
     pub edge_lengths: [PositiveReal; N],
 }
 
-/** An axis-aligned rectangle.
-
-# Examples
-
-Basic construction and methods:
-```
-use hoomd_geometry::shape::Rectangle;
-use hoomd_geometry::Volume;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let rectangle = Rectangle {edge_lengths: [2.0.try_into()?, 4.0.try_into()?]};
-assert_eq!(rectangle.volume(), 8.0);
-# Ok(())
-# }
-```
-
-Intersection tests:
-```
-use hoomd_geometry::{Convex, IntersectsAt, shape::Rectangle};
-use hoomd_vector::{Cartesian, Angle};
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let rectangle = Rectangle { edge_lengths: [4.0.try_into()?, 2.0.try_into()?] };
-let rectangle = Convex(rectangle);
-
-assert_eq!(rectangle.intersects_at(&rectangle, &[0.0, 2.1].into(), &Angle::default()), false);
-assert_eq!(rectangle.intersects_at(&rectangle, &[0.0, 2.1].into(), &Angle::from(PI / 2.0)), true);
-# Ok(())
-# }
-```
-*/
+/// An axis-aligned rectangle.
+///
+/// # Examples
+///
+/// Basic construction and methods:
+/// ```
+/// use hoomd_geometry::{Volume, shape::Rectangle};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let rectangle = Rectangle {
+///     edge_lengths: [2.0.try_into()?, 4.0.try_into()?],
+/// };
+/// assert_eq!(rectangle.volume(), 8.0);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Intersection tests:
+/// ```
+/// use hoomd_geometry::{Convex, IntersectsAt, shape::Rectangle};
+/// use hoomd_vector::{Angle, Cartesian};
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let rectangle = Rectangle {
+///     edge_lengths: [4.0.try_into()?, 2.0.try_into()?],
+/// };
+/// let rectangle = Convex(rectangle);
+///
+/// assert_eq!(
+///     rectangle.intersects_at(
+///         &rectangle,
+///         &[0.0, 2.1].into(),
+///         &Angle::default()
+///     ),
+///     false
+/// );
+/// assert_eq!(
+///     rectangle.intersects_at(
+///         &rectangle,
+///         &[0.0, 2.1].into(),
+///         &Angle::from(PI / 2.0)
+///     ),
+///     true
+/// );
+/// # Ok(())
+/// # }
+/// ```
 pub type Rectangle = Cuboid<2>;
 
 impl Cuboid<3> {
@@ -136,17 +176,16 @@ impl Cuboid<3> {
 }
 
 impl<const N: usize> Cuboid<N> {
-    /** Construct a cuboid with all edge lengths equal.
-
-    # Example
-    ```
-    use hoomd_geometry::shape::Rectangle;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let square = Rectangle::with_equal_edges(10.0.try_into()?);
-    # Ok(())
-    # }
-    */
+    /// Construct a cuboid with all edge lengths equal.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_geometry::shape::Rectangle;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let square = Rectangle::with_equal_edges(10.0.try_into()?);
+    /// # Ok(())
+    /// # }
     #[inline]
     #[must_use]
     pub fn with_equal_edges(l: PositiveReal) -> Self {
@@ -155,26 +194,35 @@ impl<const N: usize> Cuboid<N> {
         }
     }
 
-    /** Test for intersections between two *axis-aligned* cuboids.
-
-    This test is much faster than a general oriented cuboid (OBB) intersection, which
-    can be achieved by wrapping with the [`Convex`](crate::Convex) newtype.
-
-    # Example
-
-    ```
-    use hoomd_geometry::shape::Cuboid;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let unit_cube = Cuboid {edge_lengths: [1.0.try_into()?; 3]};
-    let rectangular_prism = Cuboid {edge_lengths: [1.0.try_into()?, 1.0.try_into()?, 9.0.try_into()?]};
-
-    assert_eq!(unit_cube.intersects_aligned(&rectangular_prism, &[1.0; 3].into()), true);
-    assert_eq!(unit_cube.intersects_aligned(&rectangular_prism, &[1.1; 3].into()), false);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Test for intersections between two *axis-aligned* cuboids.
+    ///
+    /// This test is much faster than a general oriented cuboid (OBB) intersection, which
+    /// can be achieved by wrapping with the [`Convex`](crate::Convex) newtype.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_geometry::shape::Cuboid;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let unit_cube = Cuboid {
+    ///     edge_lengths: [1.0.try_into()?; 3],
+    /// };
+    /// let rectangular_prism = Cuboid {
+    ///     edge_lengths: [1.0.try_into()?, 1.0.try_into()?, 9.0.try_into()?],
+    /// };
+    ///
+    /// assert_eq!(
+    ///     unit_cube.intersects_aligned(&rectangular_prism, &[1.0; 3].into()),
+    ///     true
+    /// );
+    /// assert_eq!(
+    ///     unit_cube.intersects_aligned(&rectangular_prism, &[1.1; 3].into()),
+    ///     false
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     #[inline]
     pub fn intersects_aligned(&self, other: &Cuboid<N>, v_ij: &Cartesian<N>) -> bool {
@@ -230,75 +278,78 @@ impl<const N: usize> SupportMapping<Cartesian<N>> for Cuboid<N> {
 impl<const N: usize> Cuboid<N> {
     #[inline]
     #[must_use]
-    /** Determine the maximal extents of the cuboid along each Cartesian axis.
-
-    # Example
-
-    ```
-    use hoomd_geometry::shape::Cuboid;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let unit_cube = Cuboid {edge_lengths: [1.0.try_into()?; 3]};
-
-    let max_extents = unit_cube.maximal_extents();
-    assert_eq!(max_extents, [0.5; 3]);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Determine the maximal extents of the cuboid along each Cartesian axis.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_geometry::shape::Cuboid;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let unit_cube = Cuboid {
+    ///     edge_lengths: [1.0.try_into()?; 3],
+    /// };
+    ///
+    /// let max_extents = unit_cube.maximal_extents();
+    /// assert_eq!(max_extents, [0.5; 3]);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn maximal_extents(&self) -> [f64; N] {
         array::from_fn(|i| self.edge_lengths[i].get() / 2.0)
     }
 
     #[inline]
     #[must_use]
-    /** Determine the minimal extents of the cuboid along each Cartesian axis.
-
-    # Example
-
-    ```
-    use hoomd_geometry::shape::Cuboid;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let unit_cube = Cuboid {edge_lengths: [1.0.try_into()?; 3]};
-
-    let min_extents = unit_cube.minimal_extents();
-    assert_eq!(min_extents, [-0.5; 3]);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Determine the minimal extents of the cuboid along each Cartesian axis.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_geometry::shape::Cuboid;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let unit_cube = Cuboid {
+    ///     edge_lengths: [1.0.try_into()?; 3],
+    /// };
+    ///
+    /// let min_extents = unit_cube.minimal_extents();
+    /// assert_eq!(min_extents, [-0.5; 3]);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn minimal_extents(&self) -> [f64; N] {
         array::from_fn(|i| -self.edge_lengths[i].get() / 2.0)
     }
 }
 
 impl<const N: usize> IsPointInside<Cartesian<N>> for Cuboid<N> {
-    /** Check if a cartesian vector is inside a cuboid.
-
-    By conventions typically used in periodic boundary conditions, points
-    exactly at the minimal extent are inside the shape but points exactly
-    on the maximal extent are not:
-    ```math
-    -\frac{L_x}{2} \le x \lt \frac{L_x}{2}
-    ```
-    ```math
-    -\frac{L_y}{2} \le y \lt \frac{L_y}{2}
-    ```
-    ... and so on
-
-    ```
-    use hoomd_geometry::{IsPointInside, shape::Cuboid};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let cuboid = Cuboid { edge_lengths: [6.0.try_into()?, 8.0.try_into()?] };
-
-    assert!(cuboid.is_point_inside(&[2.5, -3.5].into()));
-    assert!(!cuboid.is_point_inside(&[4.0, -3.5].into()));
-    # Ok(())
-    # }
-    ```
-    */
+    /// Check if a cartesian vector is inside a cuboid.
+    ///
+    /// By conventions typically used in periodic boundary conditions, points
+    /// exactly at the minimal extent are inside the shape but points exactly
+    /// on the maximal extent are not:
+    /// ```math
+    /// -\frac{L_x}{2} \le x \lt \frac{L_x}{2}
+    /// ```
+    /// ```math
+    /// -\frac{L_y}{2} \le y \lt \frac{L_y}{2}
+    /// ```
+    /// ... and so on
+    ///
+    /// ```
+    /// use hoomd_geometry::{IsPointInside, shape::Cuboid};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let cuboid = Cuboid {
+    ///     edge_lengths: [6.0.try_into()?, 8.0.try_into()?],
+    /// };
+    ///
+    /// assert!(cuboid.is_point_inside(&[2.5, -3.5].into()));
+    /// assert!(!cuboid.is_point_inside(&[4.0, -3.5].into()));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn is_point_inside(&self, point: &Cartesian<N>) -> bool {
         point
@@ -309,25 +360,26 @@ impl<const N: usize> IsPointInside<Cartesian<N>> for Cuboid<N> {
 }
 
 impl<const N: usize> Distribution<Cartesian<N>> for Cuboid<N> {
-    /** Generate points uniformly distributed in the cuboid.
-
-    # Example
-
-    ```
-    use rand::{SeedableRng, rngs::StdRng, distr::Distribution};
-
-    use hoomd_geometry::{IsPointInside, shape::Cuboid};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let cuboid = Cuboid { edge_lengths: [6.0.try_into()?, 8.0.try_into()?] };
-    let mut rng = StdRng::seed_from_u64(1);
-
-    let point = cuboid.sample(&mut rng);
-    assert!(cuboid.is_point_inside(&point));
-    # Ok(())
-    # }
-    ```
-    */
+    /// Generate points uniformly distributed in the cuboid.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rand::{SeedableRng, distr::Distribution, rngs::StdRng};
+    ///
+    /// use hoomd_geometry::{IsPointInside, shape::Cuboid};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let cuboid = Cuboid {
+    ///     edge_lengths: [6.0.try_into()?, 8.0.try_into()?],
+    /// };
+    /// let mut rng = StdRng::seed_from_u64(1);
+    ///
+    /// let point = cuboid.sample(&mut rng);
+    /// assert!(cuboid.is_point_inside(&point));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Cartesian<N> {
         let minimal_extents = self.minimal_extents();

--- a/hoomd-geometry/src/shape/cylinder.rs
+++ b/hoomd-geometry/src/shape/cylinder.rs
@@ -1,28 +1,30 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement [`Cylinder`] */
+//! Implement [`Cylinder`]
 
 use super::Circle;
 use crate::Volume;
 use hoomd_utility::valid::PositiveReal;
 
-/** A circle with normal `[0 0 1]` swept by `h/2` in the `+z` and `-z` directions.
-
-# Example
-
-[`Cylinder`] implements the [`Volume`] trait, which is equivalent to $π r^2 h$
-```
-use hoomd_geometry::{shape::Cylinder, Volume};
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let cyl = Cylinder {radius: 2.0.try_into()?, height: 3.0.try_into()?};
-assert_eq!(cyl.volume(), PI * (2.0 * 2.0) * 3.0);
-# Ok(())
-# }
-```
-*/
+/// A circle with normal `[0 0 1]` swept by `h/2` in the `+z` and `-z` directions.
+///
+/// # Example
+///
+/// [`Cylinder`] implements the [`Volume`] trait, which is equivalent to $π r^2 h$
+/// ```
+/// use hoomd_geometry::{Volume, shape::Cylinder};
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let cyl = Cylinder {
+///     radius: 2.0.try_into()?,
+///     height: 3.0.try_into()?,
+/// };
+/// assert_eq!(cyl.volume(), PI * (2.0 * 2.0) * 3.0);
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Cylinder {
     /// Radius of the [`Cylinder`]

--- a/hoomd-geometry/src/shape/cylinder.rs
+++ b/hoomd-geometry/src/shape/cylinder.rs
@@ -11,7 +11,8 @@ use hoomd_utility::valid::PositiveReal;
 ///
 /// # Example
 ///
-/// [`Cylinder`] implements the [`Volume`] trait, which is equivalent to $π r^2 h$
+/// [`Cylinder`] implements the [`Volume`] trait, which is equivalent to
+/// $` \pi r^2 h `$.
 /// ```
 /// use hoomd_geometry::{Volume, shape::Cylinder};
 /// use std::f64::consts::PI;

--- a/hoomd-geometry/src/shape/hyperellipsoid.rs
+++ b/hoomd-geometry/src/shape/hyperellipsoid.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement [`Hyperellipsoid`]. */
+//! Implement [`Hyperellipsoid`].
 
 use super::sphere::sphere_volume_prefactor;
 use crate::{BoundingSphereRadius, IntersectsAt, SupportMapping, Volume};
@@ -130,142 +130,152 @@ impl SquareMatrix<2> {
     }
 }
 
-/** The geometry resulting from an Hypersphere that is scaled along the Cartesian axes.
-
-See [`Ellipse`] and [`Ellipsoid`] for special cases in 2 and 3 dimensions.
-
-# Examples
-
-Basic construction and methods:
-```
-use hoomd_geometry::{BoundingSphereRadius,
-    shape::Hyperellipsoid,
-    Volume};
-use std::f64::consts::PI;
-use approx::assert_relative_eq;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let ellipse = Hyperellipsoid { semi_axes: [1.0.try_into()?, 2.0.try_into()?] };
-let bounding_radius = ellipse.bounding_sphere_radius();
-let volume = ellipse.volume();
-
-assert_eq!(bounding_radius.get(), 2.0);
-assert_relative_eq!(volume, PI * 1.0 * 2.0);
-
-let sphere = Hyperellipsoid {semi_axes: [2.0.try_into()?, 2.0.try_into()?, 2.0.try_into()?]};
-let bounding_radius = sphere.bounding_sphere_radius();
-let volume = sphere.volume();
-
-assert_eq!(bounding_radius.get(), 2.0);
-assert_eq!(volume, 4.0 / 3.0 * PI * 2.0_f64.powi(3));
-# Ok(())
-# }
-```
-*/
+/// The geometry resulting from an Hypersphere that is scaled along the Cartesian axes.
+///
+/// See [`Ellipse`] and [`Ellipsoid`] for special cases in 2 and 3 dimensions.
+///
+/// # Examples
+///
+/// Basic construction and methods:
+/// ```
+/// use approx::assert_relative_eq;
+/// use hoomd_geometry::{BoundingSphereRadius, Volume, shape::Hyperellipsoid};
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let ellipse = Hyperellipsoid {
+///     semi_axes: [1.0.try_into()?, 2.0.try_into()?],
+/// };
+/// let bounding_radius = ellipse.bounding_sphere_radius();
+/// let volume = ellipse.volume();
+///
+/// assert_eq!(bounding_radius.get(), 2.0);
+/// assert_relative_eq!(volume, PI * 1.0 * 2.0);
+///
+/// let sphere = Hyperellipsoid {
+///     semi_axes: [2.0.try_into()?, 2.0.try_into()?, 2.0.try_into()?],
+/// };
+/// let bounding_radius = sphere.bounding_sphere_radius();
+/// let volume = sphere.volume();
+///
+/// assert_eq!(bounding_radius.get(), 2.0);
+/// assert_eq!(volume, 4.0 / 3.0 * PI * 2.0_f64.powi(3));
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Hyperellipsoid<const N: usize> {
     /// The principle semi-axes of the [`Hyperellipsoid`] along each cartesian direction.
     pub semi_axes: [PositiveReal; N],
 }
 
-/** A circle scaled along the x and y axes.
-
-# Examples
-
-Basic construction and methods:
-```
-use hoomd_geometry::{BoundingSphereRadius,
-    shape::Ellipse,
-    Volume};
-use std::f64::consts::PI;
-use approx::assert_relative_eq;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let ellipse = Ellipse { semi_axes: [1.0.try_into()?, 2.0.try_into()?] };
-let bounding_radius = ellipse.bounding_sphere_radius();
-let volume = ellipse.volume();
-
-assert_eq!(bounding_radius.get(), 2.0);
-assert_relative_eq!(volume, PI * 1.0 * 2.0);
-# Ok(())
-# }
-```
-
-Rapid ellipse-ellipse intersection testing is possible with hoomd-geometry. This check
-is based on a result from algebraic geometry, with the precise approach documented
-within the code:
-```
-use hoomd_geometry::{IntersectsAt, shape::Ellipse};
-use hoomd_vector::Angle;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let long_ellipse = Ellipse {semi_axes: [0.5.try_into()?, 3.0.try_into()?]};
-let round_ellipse = Ellipse {semi_axes: [1.0.try_into()?, 2.0.try_into()?]};
-
-let v_ij = [0.0, long_ellipse.semi_axes[1].get() + round_ellipse.semi_axes[1].get() - 0.1].into();
-
-assert_eq!(
-    long_ellipse.intersects_at(&round_ellipse, &v_ij, &Angle::from(0.0)),
-    true
-);
-# Ok(())
-# }
-```
-*/
+/// A circle scaled along the x and y axes.
+///
+/// # Examples
+///
+/// Basic construction and methods:
+/// ```
+/// use approx::assert_relative_eq;
+/// use hoomd_geometry::{BoundingSphereRadius, Volume, shape::Ellipse};
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let ellipse = Ellipse {
+///     semi_axes: [1.0.try_into()?, 2.0.try_into()?],
+/// };
+/// let bounding_radius = ellipse.bounding_sphere_radius();
+/// let volume = ellipse.volume();
+///
+/// assert_eq!(bounding_radius.get(), 2.0);
+/// assert_relative_eq!(volume, PI * 1.0 * 2.0);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Rapid ellipse-ellipse intersection testing is possible with hoomd-geometry. This check
+/// is based on a result from algebraic geometry, with the precise approach documented
+/// within the code:
+/// ```
+/// use hoomd_geometry::{IntersectsAt, shape::Ellipse};
+/// use hoomd_vector::Angle;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let long_ellipse = Ellipse {
+///     semi_axes: [0.5.try_into()?, 3.0.try_into()?],
+/// };
+/// let round_ellipse = Ellipse {
+///     semi_axes: [1.0.try_into()?, 2.0.try_into()?],
+/// };
+///
+/// let v_ij = [
+///     0.0,
+///     long_ellipse.semi_axes[1].get() + round_ellipse.semi_axes[1].get()
+///         - 0.1,
+/// ]
+/// .into();
+///
+/// assert_eq!(
+///     long_ellipse.intersects_at(&round_ellipse, &v_ij, &Angle::from(0.0)),
+///     true
+/// );
+/// # Ok(())
+/// # }
+/// ```
 pub type Ellipse = Hyperellipsoid<2>;
 
-/**A sphere scaled along the x, y, and z axes.
-
-# Examples
-
-Basic construction and methods:
-```
-use hoomd_geometry::{BoundingSphereRadius,
-    shape::Ellipsoid,
-    Volume};
-use std::f64::consts::PI;
-use approx::assert_relative_eq;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let sphere = Ellipsoid { semi_axes: [2.0.try_into()?, 2.0.try_into()?, 2.0.try_into()?] };
-let bounding_radius = sphere.bounding_sphere_radius();
-let volume = sphere.volume();
-
-assert_eq!(bounding_radius.get(), 2.0);
-assert_eq!(volume, 4.0 / 3.0 * PI * 2.0_f64.powi(3));
-# Ok(())
-# }
-```
-
-Test for intersections using [`Convex`](crate::Convex):
-```
-use hoomd_geometry::{Convex, IntersectsAt, shape::Ellipsoid};
-use hoomd_vector::Versor;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let ellipsoid = Convex(Ellipsoid { semi_axes: [1.0.try_into()?, 2.0.try_into()?, 3.0.try_into()?] });
-let q = Versor::default();
-
-assert_eq!(
-    ellipsoid.intersects_at(&ellipsoid, &[0.9, 0.0, 0.0].into(), &q),
-    true
-);
-assert_eq!(
-    ellipsoid.intersects_at(&ellipsoid, &[1.1, 0.0, 0.0].into(), &q),
-    true
-);
-assert_eq!(
-    ellipsoid.intersects_at(&ellipsoid, &[0.0, 1.9, 0.0].into(), &q),
-    true
-);
-assert_eq!(
-    ellipsoid.intersects_at(&ellipsoid, &[0.0, 2.1, 0.0].into(), &q),
-    true
-);
-# Ok(())
-# }
-```
-*/
+/// A sphere scaled along the x, y, and z axes.
+///
+/// # Examples
+///
+/// Basic construction and methods:
+/// ```
+/// use approx::assert_relative_eq;
+/// use hoomd_geometry::{BoundingSphereRadius, Volume, shape::Ellipsoid};
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let sphere = Ellipsoid {
+///     semi_axes: [2.0.try_into()?, 2.0.try_into()?, 2.0.try_into()?],
+/// };
+/// let bounding_radius = sphere.bounding_sphere_radius();
+/// let volume = sphere.volume();
+///
+/// assert_eq!(bounding_radius.get(), 2.0);
+/// assert_eq!(volume, 4.0 / 3.0 * PI * 2.0_f64.powi(3));
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Test for intersections using [`Convex`](crate::Convex):
+/// ```
+/// use hoomd_geometry::{Convex, IntersectsAt, shape::Ellipsoid};
+/// use hoomd_vector::Versor;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let ellipsoid = Convex(Ellipsoid {
+///     semi_axes: [1.0.try_into()?, 2.0.try_into()?, 3.0.try_into()?],
+/// });
+/// let q = Versor::default();
+///
+/// assert_eq!(
+///     ellipsoid.intersects_at(&ellipsoid, &[0.9, 0.0, 0.0].into(), &q),
+///     true
+/// );
+/// assert_eq!(
+///     ellipsoid.intersects_at(&ellipsoid, &[1.1, 0.0, 0.0].into(), &q),
+///     true
+/// );
+/// assert_eq!(
+///     ellipsoid.intersects_at(&ellipsoid, &[0.0, 1.9, 0.0].into(), &q),
+///     true
+/// );
+/// assert_eq!(
+///     ellipsoid.intersects_at(&ellipsoid, &[0.0, 2.1, 0.0].into(), &q),
+///     true
+/// );
+/// # Ok(())
+/// # }
+/// ```
 pub type Ellipsoid = Hyperellipsoid<3>;
 
 impl<const N: usize> SupportMapping<Cartesian<N>> for Hyperellipsoid<N> {
@@ -301,10 +311,9 @@ impl<const N: usize> Volume for Hyperellipsoid<N> {
 
 /// The inverse of the Golden ratio, used for a golden section solver
 const _INV_PHI: f64 = 0.618_033_988_749_894_9_f64;
-/** Precision within which ellipsoids are considered to be overlapping.
-
-This is 1000x more precise than HOOMD-Blue.
-*/
+/// Precision within which ellipsoids are considered to be overlapping.
+///
+/// This is 1000x more precise than HOOMD-Blue.
 const _ELLIPSOID_OVERLAP_PRECISION: f64 = 1e-9;
 /// Max bound of the root search for an ellipsoid characteristic polynomial.
 const _ELLIPSOID_K_MAX_BOUND: f64 = 1.0 - _ELLIPSOID_OVERLAP_PRECISION;
@@ -318,54 +327,51 @@ where
 {
     #[inline]
     fn intersects_at(&self, other: &Hyperellipsoid<2>, v_ij: &Cartesian<2>, o_ij: &R) -> bool {
-        /*
-
-        This approach is derived from "A Robust Computational Test for Overlap of Two
-        Arbitrary-dimensional Ellipsoids in Fault-Detection of Kalman Filters".
-        Rather than generalize over dimension (which results in significant performance
-        losses, even with efficient linear algebra libraries), we choose to implement
-        the special case of ellipses in 2d. This derivation is far from rigorous, but
-        aims to inform how the method actually works.
-
-        We begin with Remark 1 from the above paper. In essence, we are defininig a
-        convex, one dimensional function K(λ) that represents the intersection of our
-        two ellipsoids, which is also a conic section. If this intersection function has
-        any real roots (in the domain (0, 1)), our ellipsoids must intersect. To compute
-        this function, we represent our ellipsoids as matrixes $A$ and $B$. $K(λ)$ is...
-
-        $$
-            K(λ) = 1 - v^T @ (1/(1-λ) B^-1 + 1/λ A^-1)^-1
-        $$
-
-        The "natural" matrix form of an ellipse is $diag(1/axes_i**2)$. However, we must
-        transform one of our matrixes for the intersection calculation. We choose B, as
-        it simplifies our future calculations. With R as the rotation matrix of o_ij:
-
-        $$
-            B = (R^-1).T @ diag(1/axes_B**2) @ R^-1
-        $$
-        The inverse of a rotation matrix is its transpose, so this simplifies. However,
-        because we actually desire A_inverse and B_inverse (and A and B are diagonal),
-        we can simplify further:
-        $$
-            A^-1 = diag(axes_A**2)
-            B^-1 = R @ diag(axes_B**2) @ R^T
-        $$
-
-        Both these results can be cached and reused for evaluation of [`k_lambda`].
-        Note that our equation is really of the quadratic form $K(λ)=1 - v.T @ M @ v$,
-        with $M = (1/(1-λ) B^-1 + 1/λ A^-1)^-1$. This final inversion makes evaluating
-        K(λ) in this form undesirable in the general case, but in 2D we have a simple
-        closed form for the inverse.
-
-        Recall that our ellipsoids do not overlap if there is a real root of Κ(λ) on
-        (0, 1). Rather than searching for such a root, we can instead query for a
-        negative element in the codomain. Our function is extremely well behaved
-        (numerical instability notwithstanding), so we can use a simple golden section
-        search for such an element. In most cases, we can exit within a single iteration
-        although the method converges linearly in general. If the search does NOT find a
-        negative element in the codomain, the ellipsoids intersect (within a tolerance).
-        */
+        // This approach is derived from "A Robust Computational Test for Overlap of Two
+        // Arbitrary-dimensional Ellipsoids in Fault-Detection of Kalman Filters".
+        // Rather than generalize over dimension (which results in significant performance
+        // losses, even with efficient linear algebra libraries), we choose to implement
+        // the special case of ellipses in 2d. This derivation is far from rigorous, but
+        // aims to inform how the method actually works.
+        //
+        // We begin with Remark 1 from the above paper. In essence, we are defininig a
+        // convex, one dimensional function K(λ) that represents the intersection of our
+        // two ellipsoids, which is also a conic section. If this intersection function has
+        // any real roots (in the domain (0, 1)), our ellipsoids must intersect. To compute
+        // this function, we represent our ellipsoids as matrixes $A$ and $B$. $K(λ)$ is...
+        //
+        // $$
+        // K(λ) = 1 - v^T @ (1/(1-λ) B^-1 + 1/λ A^-1)^-1
+        // $$
+        //
+        // The "natural" matrix form of an ellipse is $diag(1/axes_i**2)$. However, we must
+        // transform one of our matrixes for the intersection calculation. We choose B, as
+        // it simplifies our future calculations. With R as the rotation matrix of o_ij:
+        //
+        // $$
+        // B = (R^-1).T @ diag(1/axes_B**2) @ R^-1
+        // $$
+        // The inverse of a rotation matrix is its transpose, so this simplifies. However,
+        // because we actually desire A_inverse and B_inverse (and A and B are diagonal),
+        // we can simplify further:
+        // $$
+        // A^-1 = diag(axes_A**2)
+        // B^-1 = R @ diag(axes_B**2) @ R^T
+        // $$
+        //
+        // Both these results can be cached and reused for evaluation of [`k_lambda`].
+        // Note that our equation is really of the quadratic form $K(λ)=1 - v.T @ M @ v$,
+        // with $M = (1/(1-λ) B^-1 + 1/λ A^-1)^-1$. This final inversion makes evaluating
+        // K(λ) in this form undesirable in the general case, but in 2D we have a simple
+        // closed form for the inverse.
+        //
+        // Recall that our ellipsoids do not overlap if there is a real root of Κ(λ) on
+        // (0, 1). Rather than searching for such a root, we can instead query for a
+        // negative element in the codomain. Our function is extremely well behaved
+        // (numerical instability notwithstanding), so we can use a simple golden section
+        // search for such an element. In most cases, we can exit within a single iteration
+        // although the method converges linearly in general. If the search does NOT find a
+        // negative element in the codomain, the ellipsoids intersect (within a tolerance).
         let a_inv = other.semi_axes.map(|x| x.get().powi(2));
 
         let rot = RotationMatrix::<2>::from(*o_ij);

--- a/hoomd-geometry/src/shape/hyperellipsoid.rs
+++ b/hoomd-geometry/src/shape/hyperellipsoid.rs
@@ -130,7 +130,7 @@ impl SquareMatrix<2> {
     }
 }
 
-/// The geometry resulting from an Hypersphere that is scaled along the Cartesian axes.
+/// The geometry resulting from an Hypersphere that is scaled along each Cartesian axes.
 ///
 /// See [`Ellipse`] and [`Ellipsoid`] for special cases in 2 and 3 dimensions.
 ///

--- a/hoomd-geometry/src/shape/simplex3.rs
+++ b/hoomd-geometry/src/shape/simplex3.rs
@@ -1,9 +1,8 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! A tetrahedron in three dimensions. This struct should be viewed as a prototype for
-more complex geometries in addition to its standalone functionality.
-*/
+//! A tetrahedron in three dimensions. This struct should be viewed as a prototype for
+//! more complex geometries in addition to its standalone functionality.
 use std::{array, fmt};
 
 use hoomd_vector::{Cartesian, Cross, InnerProduct, Rotate, RotationMatrix};
@@ -11,65 +10,63 @@ use itertools::Itertools;
 
 use crate::{IntersectsAt, SupportMapping, Volume};
 
-/** The hull of any 4 noncoplanar points in three dimensions.
-
-# Example
-
-A [`Simplex3`], or equivalently a (nonuniform) tetrahedron, is the simplest faceted
-three-dimensional geometry. Because a simplex has an intrinsice idea of its position in
-space (defined by its barycenter), this struct provides implementations for spatial
-translation and a center of mass.
-
-```rust
-use hoomd_geometry::shape::Simplex3;
-use hoomd_geometry::{Volume, IntersectsAt};
-use hoomd_vector::{Cartesian, Rotation, Versor};
-
-// A uniform tetrahedron with edge length 2*sqrt(2), centered at the origin
-// Vertices are defined by 3-length positive-signed permutations of [1,-1]
-let tet = Simplex3::default();
-
-assert_eq!(tet.vertices()[0], [1.0; 3].into());
-assert_eq!(tet.centroid(), [0.0; 3].into());
-
-// The tetrahedron's volume can be rapidly calculated. The default tetrahedron has V=8/3
-assert_eq!(tet.volume(), 8.0 / 3.0);
-
-// Edge vectors are also provided, in the order [[1,0], [2,0], [3,0], [2,1], [3,1]]
-assert_eq!(tet.get_edge_vectors()[0], tet.vertices()[1]-tet.vertices()[0]);
-
-```
-
-[`Simplex3`] instances support a fast intersection detection algorithm
-
-```rust
-# use hoomd_geometry::{shape::Simplex3, IntersectsAt};
-# use hoomd_vector::{Cartesian, Rotation, Versor};
-# let tet = Simplex3::default();
-let other_tet = Simplex3::default();
-let displacement = [2.0, 2.0, 0.0].into();
-let q_ij = Versor::identity();
-
-// Exactly align the tips of two tetrahedra
-assert_eq!(tet.intersects_at(&other_tet, &displacement, &q_ij), true);
-
-// Translate the tetrahedra slightly further apart, separating them
-assert_eq!(tet.intersects_at(&other_tet, &[2.001, 2.0, 0.0].into(), &q_ij), false);
-```
-
-Although generally advised, Simplex3 tetrahedra are not required to be convex
-```rust
-# use hoomd_geometry::{shape::Simplex3, Volume};
-# use hoomd_vector::Cartesian;
-let planar_tetrahedron = Simplex3::from(
-    [[0.0;3], [0.0;3], [1.0,0.0,0.0], [0.0,1.0,0.0]].map(Cartesian::from)
-);
-
-assert_eq!(planar_tetrahedron.volume(), 0.0);
-assert_eq!(planar_tetrahedron.centroid(), [1.0, 1.0, 0.0].into()); // Lies in the xy plane
-```
-
-*/
+/// The hull of any 4 noncoplanar points in three dimensions.
+///
+/// # Example
+///
+/// A [`Simplex3`], or equivalently a (nonuniform) tetrahedron, is the simplest faceted
+/// three-dimensional geometry. Because a simplex has an intrinsice idea of its position in
+/// space (defined by its barycenter), this struct provides implementations for spatial
+/// translation and a center of mass.
+///
+/// ```rust
+/// use hoomd_geometry::shape::Simplex3;
+/// use hoomd_geometry::{Volume, IntersectsAt};
+/// use hoomd_vector::{Cartesian, Rotation, Versor};
+///
+/// A uniform tetrahedron with edge length 2*sqrt(2), centered at the origin
+/// Vertices are defined by 3-length positive-signed permutations of [1,-1]
+/// let tet = Simplex3::default();
+///
+/// assert_eq!(tet.vertices()[0], [1.0; 3].into());
+/// assert_eq!(tet.centroid(), [0.0; 3].into());
+///
+/// The tetrahedron's volume can be rapidly calculated. The default tetrahedron has V=8/3
+/// assert_eq!(tet.volume(), 8.0 / 3.0);
+///
+/// Edge vectors are also provided, in the order [[1,0], [2,0], [3,0], [2,1], [3,1]]
+/// assert_eq!(tet.get_edge_vectors()[0], tet.vertices()[1]-tet.vertices()[0]);
+/// ```
+///
+/// [`Simplex3`] instances support a fast intersection detection algorithm
+///
+/// ```rust
+/// # use hoomd_geometry::{shape::Simplex3, IntersectsAt};
+/// # use hoomd_vector::{Cartesian, Rotation, Versor};
+/// # let tet = Simplex3::default();
+/// let other_tet = Simplex3::default();
+/// let displacement = [2.0, 2.0, 0.0].into();
+/// let q_ij = Versor::identity();
+///
+/// Exactly align the tips of two tetrahedra
+/// assert_eq!(tet.intersects_at(&other_tet, &displacement, &q_ij), true);
+///
+/// Translate the tetrahedra slightly further apart, separating them
+/// assert_eq!(tet.intersects_at(&other_tet, &[2.001, 2.0, 0.0].into(), &q_ij), false);
+/// ```
+///
+/// Although generally advised, Simplex3 tetrahedra are not required to be convex
+/// ```rust
+/// # use hoomd_geometry::{shape::Simplex3, Volume};
+/// # use hoomd_vector::Cartesian;
+/// let planar_tetrahedron = Simplex3::from(
+/// [[0.0;3], [0.0;3], [1.0,0.0,0.0], [0.0,1.0,0.0]].map(Cartesian::from)
+/// );
+///
+/// assert_eq!(planar_tetrahedron.volume(), 0.0);
+/// assert_eq!(planar_tetrahedron.centroid(), [1.0, 1.0, 0.0].into()); // Lies in the xy plane
+/// ```
+///
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Simplex3 {
     /// Vertices of the simplex
@@ -311,14 +308,11 @@ impl<R: Rotate<Cartesian<3>> + Copy> IntersectsAt<Simplex3, Cartesian<3>, R> for
 where
     RotationMatrix<3>: From<R>,
 {
-    /**
-
-    Original C code of algorithm:
-    <https://web.archive.org/web/20030907000716/http://www.acm.org/jgt/papers/GanovelliPonchioRocchini02/tet_a_tet.html>
-
-    Recent Clojure reimplementation that orients shapes:
-    <https://gist.github.com/postspectacular/9021724>
-    */
+    /// Original C code of algorithm:
+    /// <https://web.archive.org/web/20030907000716/http://www.acm.org/jgt/papers/GanovelliPonchioRocchini02/tet_a_tet.html>
+    ///
+    /// Recent Clojure reimplementation that orients shapes:
+    /// <https://gist.github.com/postspectacular/9021724>
     #[inline]
     fn intersects_at(&self, other: &Simplex3, v_ij: &Cartesian<3>, o_ij: &R) -> bool {
         let r = RotationMatrix::from(*o_ij);

--- a/hoomd-geometry/src/shape/simplex3.rs
+++ b/hoomd-geometry/src/shape/simplex3.rs
@@ -23,8 +23,7 @@ use crate::{IntersectsAt, SupportMapping, Volume};
 /// Vertices are defined by 3-length positive-signed permutations of [1,-1]
 ///
 /// ```rust
-/// use hoomd_geometry::shape::Simplex3;
-/// use hoomd_geometry::{Volume, IntersectsAt};
+/// use hoomd_geometry::{IntersectsAt, Volume, shape::Simplex3};
 /// use hoomd_vector::{Cartesian, Rotation, Versor};
 ///
 /// let tet = Simplex3::default();
@@ -34,7 +33,10 @@ use crate::{IntersectsAt, SupportMapping, Volume};
 ///
 /// assert_eq!(tet.volume(), 8.0 / 3.0);
 ///
-/// assert_eq!(tet.get_edge_vectors()[0], tet.vertices()[1]-tet.vertices()[0]);
+/// assert_eq!(
+///     tet.get_edge_vectors()[0],
+///     tet.vertices()[1] - tet.vertices()[0]
+/// );
 /// ```
 ///
 /// [`Simplex3`] instances support a fast intersection detection algorithm:
@@ -57,7 +59,8 @@ use crate::{IntersectsAt, SupportMapping, Volume};
 /// # use hoomd_geometry::{shape::Simplex3, Volume};
 /// # use hoomd_vector::Cartesian;
 /// let planar_tetrahedron = Simplex3::from(
-/// [[0.0;3], [0.0;3], [1.0,0.0,0.0], [0.0,1.0,0.0]].map(Cartesian::from)
+///     [[0.0; 3], [0.0; 3], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
+///         .map(Cartesian::from),
 /// );
 ///
 /// assert_eq!(planar_tetrahedron.volume(), 0.0);

--- a/hoomd-geometry/src/shape/simplex3.rs
+++ b/hoomd-geometry/src/shape/simplex3.rs
@@ -12,33 +12,32 @@ use crate::{IntersectsAt, SupportMapping, Volume};
 
 /// The hull of any 4 noncoplanar points in three dimensions.
 ///
-/// # Example
+/// # Examples
 ///
 /// A [`Simplex3`], or equivalently a (nonuniform) tetrahedron, is the simplest faceted
-/// three-dimensional geometry. Because a simplex has an intrinsice idea of its position in
+/// three-dimensional geometry. Because a simplex has an intrinsic idea of its position in
 /// space (defined by its barycenter), this struct provides implementations for spatial
 /// translation and a center of mass.
+///
+/// A uniform tetrahedron with edge length 2*sqrt(2), centered at the origin
+/// Vertices are defined by 3-length positive-signed permutations of [1,-1]
 ///
 /// ```rust
 /// use hoomd_geometry::shape::Simplex3;
 /// use hoomd_geometry::{Volume, IntersectsAt};
 /// use hoomd_vector::{Cartesian, Rotation, Versor};
 ///
-/// A uniform tetrahedron with edge length 2*sqrt(2), centered at the origin
-/// Vertices are defined by 3-length positive-signed permutations of [1,-1]
 /// let tet = Simplex3::default();
 ///
 /// assert_eq!(tet.vertices()[0], [1.0; 3].into());
 /// assert_eq!(tet.centroid(), [0.0; 3].into());
 ///
-/// The tetrahedron's volume can be rapidly calculated. The default tetrahedron has V=8/3
 /// assert_eq!(tet.volume(), 8.0 / 3.0);
 ///
-/// Edge vectors are also provided, in the order [[1,0], [2,0], [3,0], [2,1], [3,1]]
 /// assert_eq!(tet.get_edge_vectors()[0], tet.vertices()[1]-tet.vertices()[0]);
 /// ```
 ///
-/// [`Simplex3`] instances support a fast intersection detection algorithm
+/// [`Simplex3`] instances support a fast intersection detection algorithm:
 ///
 /// ```rust
 /// # use hoomd_geometry::{shape::Simplex3, IntersectsAt};
@@ -48,14 +47,12 @@ use crate::{IntersectsAt, SupportMapping, Volume};
 /// let displacement = [2.0, 2.0, 0.0].into();
 /// let q_ij = Versor::identity();
 ///
-/// Exactly align the tips of two tetrahedra
-/// assert_eq!(tet.intersects_at(&other_tet, &displacement, &q_ij), true);
+/// assert!(tet.intersects_at(&other_tet, &displacement, &q_ij));
 ///
-/// Translate the tetrahedra slightly further apart, separating them
-/// assert_eq!(tet.intersects_at(&other_tet, &[2.001, 2.0, 0.0].into(), &q_ij), false);
+/// assert!(!tet.intersects_at(&other_tet, &[2.001, 2.0, 0.0].into(), &q_ij));
 /// ```
 ///
-/// Although generally advised, Simplex3 tetrahedra are not required to be convex
+/// Although generally advised, Simplex3 tetrahedra are not required to be convex:
 /// ```rust
 /// # use hoomd_geometry::{shape::Simplex3, Volume};
 /// # use hoomd_vector::Cartesian;
@@ -64,9 +61,8 @@ use crate::{IntersectsAt, SupportMapping, Volume};
 /// );
 ///
 /// assert_eq!(planar_tetrahedron.volume(), 0.0);
-/// assert_eq!(planar_tetrahedron.centroid(), [1.0, 1.0, 0.0].into()); // Lies in the xy plane
+/// assert_eq!(planar_tetrahedron.centroid(), [1.0, 1.0, 0.0].into());
 /// ```
-///
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Simplex3 {
     /// Vertices of the simplex

--- a/hoomd-geometry/src/shape/sphere.rs
+++ b/hoomd-geometry/src/shape/sphere.rs
@@ -63,20 +63,16 @@ pub(crate) fn sphere_volume_prefactor(n: usize) -> f64 {
 ///
 /// let unit_sphere = Hypersphere::<3>::default();
 ///
-/// assert!(
-///     !unit_sphere.intersects_at(
-///         &unit_sphere,
-///         &Cartesian::from([2.1, 0.0, 0.0]),
-///         &Versor::default()
-///     )
-/// );
-/// assert!(
-///     unit_sphere.intersects_at(
-///         &unit_sphere,
-///         &Cartesian::from([0.0, 1.9, 0.0]),
-///         &Versor::default()
-///     )
-/// );
+/// assert!(!unit_sphere.intersects_at(
+///     &unit_sphere,
+///     &Cartesian::from([2.1, 0.0, 0.0]),
+///     &Versor::default()
+/// ));
+/// assert!(unit_sphere.intersects_at(
+///     &unit_sphere,
+///     &Cartesian::from([0.0, 1.9, 0.0]),
+///     &Versor::default()
+/// ));
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Hypersphere<const N: usize> {
@@ -170,20 +166,16 @@ pub type Circle = Hypersphere<2>;
 ///
 /// let unit_sphere = Sphere::default();
 ///
-/// assert!(
-///     !unit_sphere.intersects_at(
-///         &unit_sphere,
-///         &Cartesian::from([2.1, 0.0, 0.0]),
-///         &Versor::default()
-///     )
-/// );
-/// assert!(
-///     unit_sphere.intersects_at(
-///         &unit_sphere,
-///         &Cartesian::from([0.0, 1.9, 0.0]),
-///         &Versor::default()
-///     )
-/// );
+/// assert!(!unit_sphere.intersects_at(
+///     &unit_sphere,
+///     &Cartesian::from([2.1, 0.0, 0.0]),
+///     &Versor::default()
+/// ));
+/// assert!(unit_sphere.intersects_at(
+///     &unit_sphere,
+///     &Cartesian::from([0.0, 1.9, 0.0]),
+///     &Versor::default()
+/// ));
 /// ```
 pub type Sphere = Hypersphere<3>;
 

--- a/hoomd-geometry/src/shape/sphere.rs
+++ b/hoomd-geometry/src/shape/sphere.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement [`Hypersphere`] */
+//! Implement [`Hypersphere`]
 use crate::{BoundingSphereRadius, IntersectsAt, IsPointInside, SupportMapping, Volume};
 use hoomd_utility::valid::PositiveReal;
 use hoomd_vector::{Cartesian, InnerProduct, Rotate, distribution::Ball};
@@ -34,134 +34,161 @@ pub(crate) fn sphere_volume_prefactor(n: usize) -> f64 {
     }
 }
 
-/** All points within a given `radius` from the origin.
-
-# Examples
-
-Basic construction and methods:
-```
-use hoomd_geometry::{shape::Hypersphere, SupportMapping, Volume};
-use hoomd_vector::Cartesian;
-use std::f64::consts::PI;
-
-let unit_sphere = Hypersphere::<3>::default();
-let volume = unit_sphere.volume();
-
-assert_eq!(unit_sphere.radius.get(), 1.0);
-assert_eq!(volume, 4.0 * PI / 3.0);
-
-assert_eq!(
-    unit_sphere.support_mapping(&Cartesian::from([1.0; 3])),
-    [1.0 / f64::sqrt(3.0); 3].into()
-)
-```
-
-Test for intersections:
-```
-use hoomd_geometry::{IntersectsAt, shape::Hypersphere};
-use hoomd_vector::{Cartesian, Versor};
-
-let unit_sphere = Hypersphere::<3>::default();
-
-assert_eq!(
-    unit_sphere.intersects_at(&unit_sphere, &Cartesian::from([2.1, 0.0, 0.0]), &Versor::default()),
-    false
-);
-assert_eq!(
-    unit_sphere.intersects_at(&unit_sphere, &Cartesian::from([0.0, 1.9, 0.0]), &Versor::default()),
-    true
-);
-```
-*/
+/// All points within a given `radius` from the origin.
+///
+/// # Examples
+///
+/// Basic construction and methods:
+/// ```
+/// use hoomd_geometry::{SupportMapping, Volume, shape::Hypersphere};
+/// use hoomd_vector::Cartesian;
+/// use std::f64::consts::PI;
+///
+/// let unit_sphere = Hypersphere::<3>::default();
+/// let volume = unit_sphere.volume();
+///
+/// assert_eq!(unit_sphere.radius.get(), 1.0);
+/// assert_eq!(volume, 4.0 * PI / 3.0);
+///
+/// assert_eq!(
+///     unit_sphere.support_mapping(&Cartesian::from([1.0; 3])),
+///     [1.0 / f64::sqrt(3.0); 3].into()
+/// )
+/// ```
+///
+/// Test for intersections:
+/// ```
+/// use hoomd_geometry::{IntersectsAt, shape::Hypersphere};
+/// use hoomd_vector::{Cartesian, Versor};
+///
+/// let unit_sphere = Hypersphere::<3>::default();
+///
+/// assert_eq!(
+///     unit_sphere.intersects_at(
+///         &unit_sphere,
+///         &Cartesian::from([2.1, 0.0, 0.0]),
+///         &Versor::default()
+///     ),
+///     false
+/// );
+/// assert_eq!(
+///     unit_sphere.intersects_at(
+///         &unit_sphere,
+///         &Cartesian::from([0.0, 1.9, 0.0]),
+///         &Versor::default()
+///     ),
+///     true
+/// );
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Hypersphere<const N: usize> {
     /// Radius of the sphere
     pub radius: PositiveReal,
 }
 
-/** A circle in two dimensions.
-
-# Examples
-
-Basic construction and methods:
-```
-use hoomd_geometry::{shape::Circle, Volume};
-use hoomd_vector::Cartesian;
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let circle = Circle { radius: 2.0.try_into()? };
-let volume = circle.volume();
-
-assert_eq!(volume, PI * 4.0);
-# Ok(())
-# }
-```
-
-Test for intersections:
-```
-use hoomd_geometry::{IntersectsAt, shape::Circle};
-use hoomd_vector::{Cartesian, Angle};
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let circle = Circle { radius: 1.0.try_into()? };
-
-assert_eq!(
-    circle.intersects_at(&circle, &Cartesian::from([2.1, 0.0]), &Angle::default()),
-    false
-);
-assert_eq!(
-    circle.intersects_at(&circle, &Cartesian::from([0.0, 1.9]), &Angle::default()),
-    true
-);
-# Ok(())
-# }
-```
-*/
+/// A circle in two dimensions.
+///
+/// # Examples
+///
+/// Basic construction and methods:
+/// ```
+/// use hoomd_geometry::{Volume, shape::Circle};
+/// use hoomd_vector::Cartesian;
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let circle = Circle {
+///     radius: 2.0.try_into()?,
+/// };
+/// let volume = circle.volume();
+///
+/// assert_eq!(volume, PI * 4.0);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Test for intersections:
+/// ```
+/// use hoomd_geometry::{IntersectsAt, shape::Circle};
+/// use hoomd_vector::{Angle, Cartesian};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let circle = Circle {
+///     radius: 1.0.try_into()?,
+/// };
+///
+/// assert_eq!(
+///     circle.intersects_at(
+///         &circle,
+///         &Cartesian::from([2.1, 0.0]),
+///         &Angle::default()
+///     ),
+///     false
+/// );
+/// assert_eq!(
+///     circle.intersects_at(
+///         &circle,
+///         &Cartesian::from([0.0, 1.9]),
+///         &Angle::default()
+///     ),
+///     true
+/// );
+/// # Ok(())
+/// # }
+/// ```
 pub type Circle = Hypersphere<2>;
 
-/** A sphere in three dimensions.
-
-# Examples
-
-Basic construction and methods:
-```
-use hoomd_geometry::{shape::Sphere, SupportMapping, Volume};
-use hoomd_vector::Cartesian;
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let unit_sphere = Sphere { radius: 1.0.try_into()? };
-let volume = unit_sphere.volume();
-
-assert_eq!(unit_sphere.radius.get(), 1.0);
-assert_eq!(volume, 4.0 * PI / 3.0);
-
-assert_eq!(
-    unit_sphere.support_mapping(&Cartesian::from([1.0; 3])),
-    [1.0 / f64::sqrt(3.0); 3].into()
-);
-# Ok(())
-# }
-```
-
-Test for intersections:
-```
-use hoomd_geometry::{IntersectsAt, shape::Sphere};
-use hoomd_vector::{Cartesian, Versor};
-
-let unit_sphere = Sphere::default();
-
-assert_eq!(
-    unit_sphere.intersects_at(&unit_sphere, &Cartesian::from([2.1, 0.0, 0.0]), &Versor::default()),
-    false
-);
-assert_eq!(
-    unit_sphere.intersects_at(&unit_sphere, &Cartesian::from([0.0, 1.9, 0.0]), &Versor::default()),
-    true
-);
-```
-*/
+/// A sphere in three dimensions.
+///
+/// # Examples
+///
+/// Basic construction and methods:
+/// ```
+/// use hoomd_geometry::{SupportMapping, Volume, shape::Sphere};
+/// use hoomd_vector::Cartesian;
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let unit_sphere = Sphere {
+///     radius: 1.0.try_into()?,
+/// };
+/// let volume = unit_sphere.volume();
+///
+/// assert_eq!(unit_sphere.radius.get(), 1.0);
+/// assert_eq!(volume, 4.0 * PI / 3.0);
+///
+/// assert_eq!(
+///     unit_sphere.support_mapping(&Cartesian::from([1.0; 3])),
+///     [1.0 / f64::sqrt(3.0); 3].into()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Test for intersections:
+/// ```
+/// use hoomd_geometry::{IntersectsAt, shape::Sphere};
+/// use hoomd_vector::{Cartesian, Versor};
+///
+/// let unit_sphere = Sphere::default();
+///
+/// assert_eq!(
+///     unit_sphere.intersects_at(
+///         &unit_sphere,
+///         &Cartesian::from([2.1, 0.0, 0.0]),
+///         &Versor::default()
+///     ),
+///     false
+/// );
+/// assert_eq!(
+///     unit_sphere.intersects_at(
+///         &unit_sphere,
+///         &Cartesian::from([0.0, 1.9, 0.0]),
+///         &Versor::default()
+///     ),
+///     true
+/// );
+/// ```
 pub type Sphere = Hypersphere<3>;
 
 impl<const N: usize> Default for Hypersphere<N> {
@@ -222,21 +249,22 @@ impl<const N: usize, V> IsPointInside<V> for Hypersphere<N>
 where
     V: InnerProduct,
 {
-    /** Check if a vector is inside a hypersphere.
-
-    ```
-    use hoomd_geometry::{IsPointInside, shape::Sphere};
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let sphere = Sphere { radius: 3.0.try_into()? };
-
-    assert!(sphere.is_point_inside(&Cartesian::from([2.5, 0.0, 0.0])));
-    assert!(!sphere.is_point_inside(&Cartesian::from([3.0, -3.0, 2.0])));
-    # Ok(())
-    # }
-    ```
-    */
+    /// Check if a vector is inside a hypersphere.
+    ///
+    /// ```
+    /// use hoomd_geometry::{IsPointInside, shape::Sphere};
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let sphere = Sphere {
+    ///     radius: 3.0.try_into()?,
+    /// };
+    ///
+    /// assert!(sphere.is_point_inside(&Cartesian::from([2.5, 0.0, 0.0])));
+    /// assert!(!sphere.is_point_inside(&Cartesian::from([3.0, -3.0, 2.0])));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn is_point_inside(&self, point: &V) -> bool {
         point.dot(point) < self.radius.get().powi(2)
@@ -244,24 +272,25 @@ where
 }
 
 impl<const N: usize> Distribution<Cartesian<N>> for Hypersphere<N> {
-    /** Generate points uniformly distributed in the hypersphere.
-
-    # Example
-
-    ```
-    use hoomd_geometry::{IsPointInside, shape::Sphere};
-    use rand::{SeedableRng, rngs::StdRng, distr::Distribution};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let sphere = Sphere { radius: 5.0.try_into()? };
-    let mut rng = StdRng::seed_from_u64(1);
-
-    let point = sphere.sample(&mut rng);
-    assert!(sphere.is_point_inside(&point));
-    # Ok(())
-    # }
-    ```
-    */
+    /// Generate points uniformly distributed in the hypersphere.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_geometry::{IsPointInside, shape::Sphere};
+    /// use rand::{SeedableRng, distr::Distribution, rngs::StdRng};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let sphere = Sphere {
+    ///     radius: 5.0.try_into()?,
+    /// };
+    /// let mut rng = StdRng::seed_from_u64(1);
+    ///
+    /// let point = sphere.sample(&mut rng);
+    /// assert!(sphere.is_point_inside(&point));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Cartesian<N> {
         let ball = Ball {

--- a/hoomd-geometry/src/shape/sphere.rs
+++ b/hoomd-geometry/src/shape/sphere.rs
@@ -63,21 +63,19 @@ pub(crate) fn sphere_volume_prefactor(n: usize) -> f64 {
 ///
 /// let unit_sphere = Hypersphere::<3>::default();
 ///
-/// assert_eq!(
-///     unit_sphere.intersects_at(
+/// assert!(
+///     !unit_sphere.intersects_at(
 ///         &unit_sphere,
 ///         &Cartesian::from([2.1, 0.0, 0.0]),
 ///         &Versor::default()
-///     ),
-///     false
+///     )
 /// );
-/// assert_eq!(
+/// assert!(
 ///     unit_sphere.intersects_at(
 ///         &unit_sphere,
 ///         &Cartesian::from([0.0, 1.9, 0.0]),
 ///         &Versor::default()
-///     ),
-///     true
+///     )
 /// );
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -172,21 +170,19 @@ pub type Circle = Hypersphere<2>;
 ///
 /// let unit_sphere = Sphere::default();
 ///
-/// assert_eq!(
-///     unit_sphere.intersects_at(
+/// assert!(
+///     !unit_sphere.intersects_at(
 ///         &unit_sphere,
 ///         &Cartesian::from([2.1, 0.0, 0.0]),
 ///         &Versor::default()
-///     ),
-///     false
+///     )
 /// );
-/// assert_eq!(
+/// assert!(
 ///     unit_sphere.intersects_at(
 ///         &unit_sphere,
 ///         &Cartesian::from([0.0, 1.9, 0.0]),
 ///         &Versor::default()
-///     ),
-///     true
+///     )
 /// );
 /// ```
 pub type Sphere = Hypersphere<3>;

--- a/hoomd-geometry/src/shape/sphero.rs
+++ b/hoomd-geometry/src/shape/sphero.rs
@@ -1,41 +1,62 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement [`Sphero`] */
+//! Implement [`Sphero`]
 
 use crate::{BoundingSphereRadius, SupportMapping};
 use hoomd_utility::valid::PositiveReal;
 use hoomd_vector::InnerProduct;
 
-/** Round a shape with a given radius.
-
-[`Sphero`] modifies a given shape by sweeping it with a hypersphere of the
-given radius. The resulting [`Sphero<S>`] type is a shape itself. If `S`
-implements [`crate::SupportMapping`], then [`Sphero<S>`] can be used in
-[`IntersectsAt`](crate::IntersectsAt) tests with other convex shapes. See
-the full list of implementations below to see what other traits [`Sphero<S>`]
-implements for a given `S`.
-
-# Example
-
-Test if a circle overlaps with a rounded rectangle:
-```
-use hoomd_geometry::{Convex, IntersectsAt, shape::{Circle, Rectangle, Sphero}};
-use hoomd_vector::{Cartesian, Angle};
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let circle = Convex(Circle { radius:  0.5.try_into()? });
-let rectangle = Rectangle { edge_lengths: [3.0.try_into()?, 2.0.try_into()?] };
-let rounded_rectangle = Convex(Sphero { shape: rectangle, rounding_radius: 0.5.try_into()? });
-
-assert!(rounded_rectangle.intersects_at(&circle, &[2.4, 0.0].into(), &Angle::default()));
-assert!(!rounded_rectangle.intersects_at(&circle, &[0.0, 2.4].into(), &Angle::default()));
-assert!(circle.intersects_at(&rounded_rectangle, &[0.0, 2.4].into(), &Angle::from(PI / 2.0)));
-# Ok(())
-# }
-```
-*/
+/// Round a shape with a given radius.
+///
+/// [`Sphero`] modifies a given shape by sweeping it with a hypersphere of the
+/// given radius. The resulting [`Sphero<S>`] type is a shape itself. If `S`
+/// implements [`crate::SupportMapping`], then [`Sphero<S>`] can be used in
+/// [`IntersectsAt`](crate::IntersectsAt) tests with other convex shapes. See
+/// the full list of implementations below to see what other traits [`Sphero<S>`]
+/// implements for a given `S`.
+///
+/// # Example
+///
+/// Test if a circle overlaps with a rounded rectangle:
+/// ```
+/// use hoomd_geometry::{
+///     Convex, IntersectsAt,
+///     shape::{Circle, Rectangle, Sphero},
+/// };
+/// use hoomd_vector::{Angle, Cartesian};
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let circle = Convex(Circle {
+///     radius: 0.5.try_into()?,
+/// });
+/// let rectangle = Rectangle {
+///     edge_lengths: [3.0.try_into()?, 2.0.try_into()?],
+/// };
+/// let rounded_rectangle = Convex(Sphero {
+///     shape: rectangle,
+///     rounding_radius: 0.5.try_into()?,
+/// });
+///
+/// assert!(rounded_rectangle.intersects_at(
+///     &circle,
+///     &[2.4, 0.0].into(),
+///     &Angle::default()
+/// ));
+/// assert!(!rounded_rectangle.intersects_at(
+///     &circle,
+///     &[0.0, 2.4].into(),
+///     &Angle::default()
+/// ));
+/// assert!(circle.intersects_at(
+///     &rounded_rectangle,
+///     &[0.0, 2.4].into(),
+///     &Angle::from(PI / 2.0)
+/// ));
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 pub struct Sphero<S> {
     /// The shape to round.

--- a/hoomd-geometry/src/xenocollide.rs
+++ b/hoomd-geometry/src/xenocollide.rs
@@ -1,30 +1,36 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implementations of the Xenocollide collision detection algorithm.
-
-[`collide2d`] and [`collide3d`] test for intersections between arbitrary geometries
-that implement the [`SupportMapping<Cartesian<2|3>>`](`crate::SupportMapping`) trait.
-
-# Example
-
-In general, Xenocollide should be used via the [`IntersectsAt`](`crate::IntersectsAt`)
-trait. However, the raw xenocollide methods can be used where needed.
-```
-use hoomd_geometry::{IntersectsAt, shape::Circle, xenocollide::collide2d};
-use hoomd_vector::Angle;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let (s0, s1) = (Circle {radius: 1.0.try_into()?}, Circle {radius: 2.0.try_into()?});
-let displacement = [3.0; 2].into();
-assert_eq!(
-    collide2d(&s0, &s1, &displacement, &Angle::default()),
-    s0.intersects_at(&s1, &displacement, &Angle::default())
-);
-# Ok(())
-# }
-```
-*/
+//! Implementations of the Xenocollide collision detection algorithm.
+//!
+//! [`collide2d`] and [`collide3d`] test for intersections between arbitrary geometries
+//! that implement the [`SupportMapping<Cartesian<2|3>>`](`crate::SupportMapping`) trait.
+//!
+//! # Example
+//!
+//! In general, Xenocollide should be used via the [`IntersectsAt`](`crate::IntersectsAt`)
+//! trait. However, the raw xenocollide methods can be used where needed.
+//! ```
+//! use hoomd_geometry::{IntersectsAt, shape::Circle, xenocollide::collide2d};
+//! use hoomd_vector::Angle;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let (s0, s1) = (
+//!     Circle {
+//!         radius: 1.0.try_into()?,
+//!     },
+//!     Circle {
+//!         radius: 2.0.try_into()?,
+//!     },
+//! );
+//! let displacement = [3.0; 2].into();
+//! assert_eq!(
+//!     collide2d(&s0, &s1, &displacement, &Angle::default()),
+//!     s0.intersects_at(&s1, &displacement, &Angle::default())
+//! );
+//! # Ok(())
+//! # }
+//! ```
 use crate::SupportMapping;
 use hoomd_vector::{Cartesian, Cross, InnerProduct, Rotate, Rotation, RotationMatrix};
 

--- a/hoomd-gsd/examples/benchmark-sequential-read.rs
+++ b/hoomd-gsd/examples/benchmark-sequential-read.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::print_stdout, reason = "Demonstration purposes")]
 
-/*! This is an example
- */
+//! This is an example
 
 use hoomd_gsd::file_layer::{GsdFile, Mode};
 use std::time::Instant;

--- a/hoomd-gsd/examples/benchmark-write.rs
+++ b/hoomd-gsd/examples/benchmark-write.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::print_stdout, reason = "Demonstration purposes")]
 
-/*! This is an example
- */
+//! This is an example
 
 use clap::Parser;
 use hoomd_gsd::file_layer::GsdFile;

--- a/hoomd-gsd/src/file_layer.rs
+++ b/hoomd-gsd/src/file_layer.rs
@@ -244,16 +244,16 @@ mod private {
 /// Data types that can be stored in chunk arrays.
 ///
 /// GSD files store arrays of data of one of the following types:
-/// [`u8`]
-/// [`u16`]
-/// [`u32`]
-/// [`u64`]
-/// [`i8`]
-/// [`i16`]
-/// [`i32`]
-/// [`i64`]
-/// [`f32`]
-/// [`f64`]
+/// * [`u8`]
+/// * [`u16`]
+/// * [`u32`]
+/// * [`u64`]
+/// * [`i8`]
+/// * [`i16`]
+/// * [`i32`]
+/// * [`i64`]
+/// * [`f32`]
+/// * [`f64`]
 ///
 /// The [`Type`] trait facilitates the generic methods including
 /// [`GsdFile::iter_scalars`], [`GsdFile::write_scalars`], and others. When needed,
@@ -523,28 +523,28 @@ struct Index {
 /// # Overview
 ///
 /// Open files with:
-/// [`open`](GsdFile::open)
-/// [`create`](GsdFile::create)
-/// [`create_new`](GsdFile::create_new)
+/// * [`open`](GsdFile::open)
+/// * [`create`](GsdFile::create)
+/// * [`create_new`](GsdFile::create_new)
 ///
 /// Access file metadata with:
-/// [`n_frames`](GsdFile::n_frames)
-/// [`schema`](GsdFile::schema)
-/// [`schema_version`](GsdFile::schema_version)
-/// [`name_id`](GsdFile::name_id)
-/// [`find_chunk`](GsdFile::find_chunk)
+/// * [`n_frames`](GsdFile::n_frames)
+/// * [`schema`](GsdFile::schema)
+/// * [`schema_version`](GsdFile::schema_version)
+/// * [`name_id`](GsdFile::name_id)
+/// * [`find_chunk`](GsdFile::find_chunk)
 ///
 /// Write data with:
-/// [`write_scalars`](GsdFile::write_scalars)
-/// [`write_arrays`](GsdFile::write_arrays)
-/// [`write_string`](GsdFile::write_string)
-/// [`end_frame`](GsdFile::end_frame)
-/// [`sync_all`](GsdFile::sync_all)
+/// * [`write_scalars`](GsdFile::write_scalars)
+/// * [`write_arrays`](GsdFile::write_arrays)
+/// * [`write_string`](GsdFile::write_string)
+/// * [`end_frame`](GsdFile::end_frame)
+/// * [`sync_all`](GsdFile::sync_all)
 ///
 /// Read data with:
-/// [`iter_scalars`](GsdFile::iter_scalars)
-/// [`iter_arrays`](GsdFile::iter_arrays)
-/// [`read_string`](GsdFile::read_string)
+/// * [`iter_scalars`](GsdFile::iter_scalars)
+/// * [`iter_arrays`](GsdFile::iter_arrays)
+/// * [`read_string`](GsdFile::read_string)
 #[derive(Debug)]
 pub struct GsdFile {
     /// The underlying file.
@@ -949,9 +949,9 @@ impl GsdFile {
     /// # Errors
     ///
     /// Returns a [`OpenError`] when any of the following occur:
-    /// The file does not exist.
-    /// The file is corrupt, unreadable, or there is an I/O error (see
-    /// [`DecodeError`]).
+    /// * The file does not exist.
+    /// * The file is corrupt, unreadable, or there is an I/O error (see
+    ///   [`DecodeError`]).
     #[inline]
     pub fn open<P: AsRef<Path>>(path: P, mode: Mode) -> Result<Self, OpenError> {
         let file = File::open(&path).map_err(|e| OpenError::IO(path.as_ref().into(), e))?;
@@ -985,9 +985,9 @@ impl GsdFile {
     /// # Errors
     ///
     /// Returns a [`OpenError`] when any of the following occur:
-    /// The file cannot be created.
-    /// The file is corrupt, unreadable, or there is an I/O error (see
-    /// [`DecodeError`]).
+    /// * The file cannot be created.
+    /// * The file is corrupt, unreadable, or there is an I/O error (see
+    ///   [`DecodeError`]).
     #[inline]
     pub fn create<P: AsRef<Path>>(
         path: P,
@@ -1035,10 +1035,10 @@ impl GsdFile {
     /// # Errors
     ///
     /// Returns a [`OpenError`] when any of the following occur:
-    /// The file cannot be created.
-    /// The file already exists.
-    /// The file is corrupt, unreadable, or there is an I/O error (see
-    /// [`DecodeError`]).
+    /// * The file cannot be created.
+    /// * The file already exists.
+    /// * The file is corrupt, unreadable, or there is an I/O error (see
+    ///   [`DecodeError`]).
     #[inline]
     pub fn create_new<P: AsRef<Path>>(
         path: P,
@@ -1486,11 +1486,11 @@ impl GsdFile {
     /// # Errors
     ///
     /// Returns a [`ReadError`] when any of the following occur:
-    /// A chunk by the given `name` is not present in the given `frame`.
-    /// The data type stored in the file does not match `T`.
-    /// The array stored in the file does not have dimensions `N x 1`.
-    /// The file is corrupt, unreadable, or there is an I/O error (see
-    /// [`DecodeError`]).
+    /// * A chunk by the given `name` is not present in the given `frame`.
+    /// * The data type stored in the file does not match `T`.
+    /// * The array stored in the file does not have dimensions `N x 1`.
+    /// * The file is corrupt, unreadable, or there is an I/O error (see
+    ///   [`DecodeError`]).
     pub fn iter_scalars<T: Type>(
         &self,
         frame: u64,
@@ -1556,11 +1556,11 @@ impl GsdFile {
     /// # Errors
     ///
     /// Returns a [`ReadError`] when any of the following occur:
-    /// A chunk by the given `name` is not present in the given `frame`.
-    /// The data type stored in the file does not match `T`.
-    /// The array stored in the file does not have dimensions `N x M`.
-    /// The file is corrupt, unreadable, or there is an I/O error (see
-    /// [`DecodeError`]).
+    /// * A chunk by the given `name` is not present in the given `frame`.
+    /// * The data type stored in the file does not match `T`.
+    /// * The array stored in the file does not have dimensions `N x M`.
+    /// * The file is corrupt, unreadable, or there is an I/O error (see
+    ///   [`DecodeError`]).
     pub fn iter_arrays<T: Type, const M: usize>(
         &self,
         frame: u64,
@@ -1623,11 +1623,11 @@ impl GsdFile {
     /// # Errors
     ///
     /// Returns a [`ReadError`] when any of the following occur:
-    /// A chunk by the given `name` is not present in the given `frame`.
-    /// The data type stored in the file is not a UTF-8 string.
-    /// The array stored in the file does not have dimensions `N x 1`.
-    /// The file is corrupt, unreadable, or there is an I/O error (see
-    /// [`DecodeError`]).
+    /// * A chunk by the given `name` is not present in the given `frame`.
+    /// * The data type stored in the file is not a UTF-8 string.
+    /// * The array stored in the file does not have dimensions `N x 1`.
+    /// * The file is corrupt, unreadable, or there is an I/O error (see
+    ///   [`DecodeError`]).
     pub fn read_string(&self, frame: u64, name: &str) -> Result<String, ReadError> {
         let Some(index_entry) = self.find_chunk(frame, name) else {
             return Err(ReadError::ChunkNotFound(name.into(), frame));
@@ -1715,10 +1715,10 @@ impl GsdFile {
     /// # Errors
     ///
     /// Returns a [`WriteError`] when any of the following occur:
-    /// The file is not opened in a write mode.
-    /// There are no available chunk identifiers.
-    /// A chunk with the same name has already been written in this frame.
-    /// There is an I/O error while writing to the file.
+    /// * The file is not opened in a write mode.
+    /// * There are no available chunk identifiers.
+    /// * A chunk with the same name has already been written in this frame.
+    /// * There is an I/O error while writing to the file.
     pub fn write_scalars<'a, T, I>(&mut self, name: &str, data: I) -> Result<(), WriteError>
     where
         T: Type + 'a,
@@ -1776,11 +1776,11 @@ impl GsdFile {
     /// # Errors
     ///
     /// Returns a [`WriteError`] when any of the following occur:
-    /// The file is not opened in a write mode.
-    /// There are no available chunk identifiers.
-    /// A chunk with the same name has already been written in this frame.
-    /// `M` is 0.
-    /// `M` cannot be represented by a `u32`.
+    /// * The file is not opened i* n a write mode.
+    /// * There are no available chunk identifiers.
+    /// * A chunk with the same name has already been written in this frame.
+    /// * `M` is 0.
+    /// * `M` cannot be represented by a `u32`.
     pub fn write_arrays<'a, T, I, const M: usize>(
         &mut self,
         name: &str,
@@ -1825,13 +1825,13 @@ impl GsdFile {
 
     /// Append a string to the current frame.
     ///
-    /// `write_string` writes a UTF-8 string to a named chunk in the current frame
+    /// `write_string` writes a UTF-8 string to a named chunk in the*  current frame
     /// of the GSD file. Call [`end_frame`](GsdFile::end_frame) to complete the
     /// frame and start the next.
     ///
     /// <div class="warning">
     ///
-    /// Dropping a [`GsdFile`] will also drop any pending data chunks in incomplete
+    /// Dropping a [`GsdFile`] will also drop any pending data chunks in inc* omplete
     /// frames.
     ///
     /// </div>
@@ -1854,9 +1854,9 @@ impl GsdFile {
     /// # Errors
     ///
     /// Returns a [`WriteError`] when any of the following occur:
-    /// The file is not opened in a write mode.
-    /// There are no available chunk identifiers.
-    /// A chunk with the same name has already been written in this frame.
+    /// * The file is not opened in a write mode.
+    /// * There are no available chunk identifiers.
+    /// * A chunk with the same name has already been written in this frame.
     pub fn write_string(&mut self, name: &str, data: &str) -> Result<(), WriteError> {
         let data = data.as_bytes();
 
@@ -1964,7 +1964,7 @@ impl GsdFile {
     /// # Errors
     ///
     /// Returns a [`EncodeError`] when any of the following occur:
-    /// The file is not opened in a write mode.
+    /// * The file is not opened in a write mode.
     pub fn end_frame(&mut self) -> Result<(), EncodeError> {
         if self.mode != Mode::Write {
             return Err(EncodeError::NotWritable);
@@ -2189,8 +2189,8 @@ impl GsdFile {
     /// # Errors
     ///
     /// Returns a [`WriteError`] when any of the following occur:
-    /// The file is not opened in a write mode.
-    /// An I/O error writing to the file.
+    /// * The file is not opened in a write mode.
+    /// * An I/O error writing to the file.
     pub fn sync_all(&mut self) -> Result<(), EncodeError> {
         if self.mode != Mode::Write {
             return Err(EncodeError::NotWritable);

--- a/hoomd-gsd/src/file_layer.rs
+++ b/hoomd-gsd/src/file_layer.rs
@@ -1,10 +1,9 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Read and write data chunks in GSD files.
-
-Use [`GsdFile`] to interact with GSD files on the filesystem.
- */
+//! Read and write data chunks in GSD files.
+//!
+//! Use [`GsdFile`] to interact with GSD files on the filesystem.
 
 use itertools::Itertools;
 use memmap2::Mmap;
@@ -223,10 +222,9 @@ where
     }
 }
 
-/** Implement a sealed trait for each data type supported by GSD.
-
-This enables generic implementations that operate on these types.
-*/
+/// Implement a sealed trait for each data type supported by GSD.
+///
+/// This enables generic implementations that operate on these types.
 mod private {
     /// Seal the data type traits so that users cannot add new types.
     pub trait Sealed {}
@@ -243,63 +241,63 @@ mod private {
     impl Sealed for f64 {}
 }
 
-/** Data types that can be stored in chunk arrays.
-
-GSD files store arrays of data of one of the following types:
-* [`u8`]
-* [`u16`]
-* [`u32`]
-* [`u64`]
-* [`i8`]
-* [`i16`]
-* [`i32`]
-* [`i64`]
-* [`f32`]
-* [`f64`]
-
-The [`Type`] trait facilitates the generic methods including
-[`GsdFile::iter_scalars`], [`GsdFile::write_scalars`], and others. When needed,
-pass the type explicitly to these methods to read or write data chunks of the
-given type. In some cases, the Rust compiler may be able to determine the type
-from context.
-
-# Example
-
-```
-use hoomd_gsd::file_layer::GsdFile;
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-# use tempfile::tempdir;
-# let tmp_dir = tempdir().expect("temp dir should be created");
-# let path = tmp_dir.path().join("test.gsd");
-let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
-gsd_file.write_scalars("configuration/box", &[10.0f32, 20.0, 15.0, 0.0, 0.0, 0.0])?;
-gsd_file.end_frame()?;
-gsd_file.sync_all()?;
-
-let box_iter = gsd_file.iter_scalars::<f32>(0, "configuration/box")?;
-itertools::assert_equal(box_iter, [10.0, 20.0, 15.0, 0.0, 0.0, 0.0]);
-# Ok(())
-# }
-```
-*/
+/// Data types that can be stored in chunk arrays.
+///
+/// GSD files store arrays of data of one of the following types:
+/// [`u8`]
+/// [`u16`]
+/// [`u32`]
+/// [`u64`]
+/// [`i8`]
+/// [`i16`]
+/// [`i32`]
+/// [`i64`]
+/// [`f32`]
+/// [`f64`]
+///
+/// The [`Type`] trait facilitates the generic methods including
+/// [`GsdFile::iter_scalars`], [`GsdFile::write_scalars`], and others. When needed,
+/// pass the type explicitly to these methods to read or write data chunks of the
+/// given type. In some cases, the Rust compiler may be able to determine the type
+/// from context.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_gsd::file_layer::GsdFile;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # use tempfile::tempdir;
+/// # let tmp_dir = tempdir().expect("temp dir should be created");
+/// # let path = tmp_dir.path().join("test.gsd");
+/// let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
+/// gsd_file.write_scalars(
+///     "configuration/box",
+///     &[10.0f32, 20.0, 15.0, 0.0, 0.0, 0.0],
+/// )?;
+/// gsd_file.end_frame()?;
+/// gsd_file.sync_all()?;
+///
+/// let box_iter = gsd_file.iter_scalars::<f32>(0, "configuration/box")?;
+/// itertools::assert_equal(box_iter, [10.0, 20.0, 15.0, 0.0, 0.0, 0.0]);
+/// # Ok(())
+/// # }
+/// ```
 pub trait Type: private::Sealed {
     /// Value denoting this type in the file layer.
     #[doc(hidden)]
     fn gsd_data_type() -> u8;
 
-    /** Convert a native endian byte slice to this type.
-
-    This is not the proper idiomatic way to do this, but it gets the job done
-    with minimal lines of code.
-    */
+    /// Convert a native endian byte slice to this type.
+    ///
+    /// This is not the proper idiomatic way to do this, but it gets the job done
+    /// with minimal lines of code.
     #[doc(hidden)]
     fn from_ne_byte_slice(bytes: &[u8]) -> Self;
 
-    /** Append this type to a native endian byte array.
-
-    This is not the proper idiomatic way to do this, but it gets the job done
-    with minimal lines of code.
-    */
+    /// Append this type to a native endian byte array.
+    ///
+    /// This is not the proper idiomatic way to do this, but it gets the job done
+    /// with minimal lines of code.
     #[doc(hidden)]
     fn append_ne_bytes(&self, v: &mut Vec<u8>);
 }
@@ -492,17 +490,16 @@ struct NameList {
     buffer: Vec<u8>,
 }
 
-/** Details about the index.
-
-* `n` counts the number of entries stored in the actual file.
-* `buffer` stores index entries in memory that have not yet been written to the
-  tile (as bytes).
-* `pending` counts the number of entries that are pending in the current frame.
-
-Pending entries are those where `write_*` has been called, but not yet
-`end_frame`. These should not be synced to the file to avoid having
-partial frames in the file.
-*/
+/// Details about the index.
+///
+/// `n` counts the number of entries stored in the actual file.
+/// `buffer` stores index entries in memory that have not yet been written to the
+/// tile (as bytes).
+/// `pending` counts the number of entries that are pending in the current frame.
+///
+/// Pending entries are those where `write_*` has been called, but not yet
+/// `end_frame`. These should not be synced to the file to avoid having
+/// partial frames in the file.
 #[derive(Debug)]
 struct Index {
     /// Number of index entries stored in the file.
@@ -521,34 +518,33 @@ struct Index {
     frame_names: HashSet<u16>,
 }
 
-/** Interact with GSD files on the filesystem.
-
-# Overview
-
-Open files with:
-* [`open`](GsdFile::open)
-* [`create`](GsdFile::create)
-* [`create_new`](GsdFile::create_new)
-
-Access file metadata with:
-* [`n_frames`](GsdFile::n_frames)
-* [`schema`](GsdFile::schema)
-* [`schema_version`](GsdFile::schema_version)
-* [`name_id`](GsdFile::name_id)
-* [`find_chunk`](GsdFile::find_chunk)
-
-Write data with:
-* [`write_scalars`](GsdFile::write_scalars)
-* [`write_arrays`](GsdFile::write_arrays)
-* [`write_string`](GsdFile::write_string)
-* [`end_frame`](GsdFile::end_frame)
-* [`sync_all`](GsdFile::sync_all)
-
-Read data with:
-* [`iter_scalars`](GsdFile::iter_scalars)
-* [`iter_arrays`](GsdFile::iter_arrays)
-* [`read_string`](GsdFile::read_string)
-*/
+/// Interact with GSD files on the filesystem.
+///
+/// # Overview
+///
+/// Open files with:
+/// [`open`](GsdFile::open)
+/// [`create`](GsdFile::create)
+/// [`create_new`](GsdFile::create_new)
+///
+/// Access file metadata with:
+/// [`n_frames`](GsdFile::n_frames)
+/// [`schema`](GsdFile::schema)
+/// [`schema_version`](GsdFile::schema_version)
+/// [`name_id`](GsdFile::name_id)
+/// [`find_chunk`](GsdFile::find_chunk)
+///
+/// Write data with:
+/// [`write_scalars`](GsdFile::write_scalars)
+/// [`write_arrays`](GsdFile::write_arrays)
+/// [`write_string`](GsdFile::write_string)
+/// [`end_frame`](GsdFile::end_frame)
+/// [`sync_all`](GsdFile::sync_all)
+///
+/// Read data with:
+/// [`iter_scalars`](GsdFile::iter_scalars)
+/// [`iter_arrays`](GsdFile::iter_arrays)
+/// [`read_string`](GsdFile::read_string)
 #[derive(Debug)]
 pub struct GsdFile {
     /// The underlying file.
@@ -588,13 +584,12 @@ pub struct GsdFile {
     maximum_write_buffer_size: usize,
 }
 
-/** Properties that describe a given data chunk.
-
-    GSD files store a set of arrays, uniquely identified by their *name* and
-    *frame*. The [`GsdFile::find_chunk`] method search for a matching index
-    entry. The returned [`IndexEntry`] (if present) also carries information
-    about the dimension and type of the array.
-*/
+/// Properties that describe a given data chunk.
+///
+/// GSD files store a set of arrays, uniquely identified by their *name* and
+/// frame*. The [`GsdFile::find_chunk`] method search for a matching index
+/// entry. The returned [`IndexEntry`] (if present) also carries information
+/// about the dimension and type of the array.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct IndexEntry {
     /// Frame index of the chunk.
@@ -619,10 +614,9 @@ pub struct IndexEntry {
     flags: u8,
 }
 
-/** Data types that can be stored in chunks.
-
-Provided by [`IndexEntry::data_type`].
-*/
+/// Data types that can be stored in chunks.
+///
+/// Provided by [`IndexEntry::data_type`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum DataType {
@@ -650,17 +644,16 @@ pub enum DataType {
     String,
 }
 
-/** Choose how opened files can be accessed.
-
-Pass a [`Mode`] value to [`GsdFile::open`].
-
-In the [`Mode::Read`] mode, you can call methods that read the file, such as
-[`GsdFile::find_chunk`] and [`GsdFile::iter_scalars`]. Calling methods that
-write the file, such as [`GsdFile::write_scalars`] or [`GsdFile::sync_all`] will
-result in an error.
-
-In the [`Mode::Write`] mode, you can call both read and write methods.
-*/
+/// Choose how opened files can be accessed.
+///
+/// Pass a [`Mode`] value to [`GsdFile::open`].
+///
+/// In the [`Mode::Read`] mode, you can call methods that read the file, such as
+/// [`GsdFile::find_chunk`] and [`GsdFile::iter_scalars`]. Calling methods that
+/// write the file, such as [`GsdFile::write_scalars`] or [`GsdFile::sync_all`] will
+/// result in an error.
+///
+/// In the [`Mode::Write`] mode, you can call both read and write methods.
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum Mode {
@@ -670,12 +663,11 @@ pub enum Mode {
     Write,
 }
 
-/** Read the first u64 in a byte slice (native endian).
-
-Returns the [`u64`] and the rest of the slice. Testing in Godbolt shows that
-repeated calls to this method can be optimized to a simple series of mov
-instructions.
-*/
+/// Read the first u64 in a byte slice (native endian).
+///
+/// Returns the [`u64`] and the rest of the slice. Testing in Godbolt shows that
+/// repeated calls to this method can be optimized to a simple series of mov
+/// instructions.
 #[inline]
 fn extract_ne_u64(bytes: &[u8]) -> (u64, &[u8]) {
     let (bytes, rest) = bytes.split_at(size_of::<u64>());
@@ -717,11 +709,10 @@ fn extract_ne_u16(bytes: &[u8]) -> (u16, &[u8]) {
     )
 }
 
-/** Read the first null terminated string in a byte slice.
-
-Returns the [`String`] without the null terminator. Also returns the rest of the
-slice after consuming 1 null terminator.
-*/
+/// Read the first null terminated string in a byte slice.
+///
+/// Returns the [`String`] without the null terminator. Also returns the rest of the
+/// slice after consuming 1 null terminator.
 #[inline]
 fn extract_null_terminated_utf8(bytes: &[u8]) -> Result<(String, &[u8]), FromUtf8Error> {
     let null_range_end = bytes
@@ -851,24 +842,23 @@ impl IndexEntry {
         self.m
     }
 
-    /** The array's data type.
-
-    Returns [`Some(data_type)`](Option::Some) when the type is known and
-    [`None`] when it is not.
-
-    # Example
-    ```
-    use hoomd_gsd::file_layer::{DataType, IndexEntry};
-
-    # fn do_something() { }
-    # fn func(index_entry: &IndexEntry) {
-    match index_entry.data_type() {
-        Some(DataType::F32) => do_something(),
-        _ => (),
-    }
-    # }
-    ```
-    */
+    /// The array's data type.
+    ///
+    /// Returns [`Some(data_type)`](Option::Some) when the type is known and
+    /// [`None`] when it is not.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_gsd::file_layer::{DataType, IndexEntry};
+    ///
+    /// # fn do_something() { }
+    /// # fn func(index_entry: &IndexEntry) {
+    /// match index_entry.data_type() {
+    ///     Some(DataType::F32) => do_something(),
+    ///     _ => (),
+    /// }
+    /// # }
+    /// ```
     #[must_use]
     #[inline]
     pub fn data_type(&self) -> Option<DataType> {
@@ -926,80 +916,78 @@ impl IndexEntry {
 }
 
 impl GsdFile {
-    /** Open a GSD file with the given mode.
-
-    # Examples
-
-    Open a file for reading:
-    ```
-    use hoomd_gsd::file_layer::{GsdFile, Mode};
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # use tempfile::tempdir;
-    # let tmp_dir = tempdir().expect("temp dir should be created");
-    # let path = tmp_dir.path().join("test.gsd");
-    # GsdFile::create_new(path.clone(), "example", "hoomd", (1, 4))?;
-    let gsd_file = GsdFile::open(path, Mode::Read);
-    # Ok(())
-    # }
-    ```
-
-    Open a file for both reading and writing:
-    ```
-    use hoomd_gsd::file_layer::{GsdFile, Mode};
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # use tempfile::tempdir;
-    # let tmp_dir = tempdir().expect("temp dir should be created");
-    # let path = tmp_dir.path().join("test.gsd");
-    # GsdFile::create_new(path.clone(), "example", "hoomd", (1, 4))?;
-    let gsd_file = GsdFile::open(path, Mode::Write);
-    # Ok(())
-    # }
-    ```
-
-    # Errors
-
-    Returns a [`OpenError`] when any of the following occur:
-    * The file does not exist.
-    * The file is corrupt, unreadable, or there is an I/O error (see
-      [`DecodeError`]).
-    */
+    /// Open a GSD file with the given mode.
+    ///
+    /// # Examples
+    ///
+    /// Open a file for reading:
+    /// ```
+    /// use hoomd_gsd::file_layer::{GsdFile, Mode};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use tempfile::tempdir;
+    /// # let tmp_dir = tempdir().expect("temp dir should be created");
+    /// # let path = tmp_dir.path().join("test.gsd");
+    /// # GsdFile::create_new(path.clone(), "example", "hoomd", (1, 4))?;
+    /// let gsd_file = GsdFile::open(path, Mode::Read);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Open a file for both reading and writing:
+    /// ```
+    /// use hoomd_gsd::file_layer::{GsdFile, Mode};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use tempfile::tempdir;
+    /// # let tmp_dir = tempdir().expect("temp dir should be created");
+    /// # let path = tmp_dir.path().join("test.gsd");
+    /// # GsdFile::create_new(path.clone(), "example", "hoomd", (1, 4))?;
+    /// let gsd_file = GsdFile::open(path, Mode::Write);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`OpenError`] when any of the following occur:
+    /// The file does not exist.
+    /// The file is corrupt, unreadable, or there is an I/O error (see
+    /// [`DecodeError`]).
     #[inline]
     pub fn open<P: AsRef<Path>>(path: P, mode: Mode) -> Result<Self, OpenError> {
         let file = File::open(&path).map_err(|e| OpenError::IO(path.as_ref().into(), e))?;
         GsdFile::from_file(file, mode).map_err(|e| OpenError::Decode(path.as_ref().into(), e))
     }
 
-    /** Overwrite an existing GSD file (or create a new file).
-
-    Creates a GSD file at the given path, overwriting any file that may already
-    exist. When successful, return a [`GsdFile`] opened in write mode.
-
-    Each GSD file contains metadata describing which application created the
-    file, the data chunk schema, and the schema's version. `application` and
-    `schema` are strings (and must each be less than 80 bytes). `schema_version`
-    is a tuple listing the major and minor version numbers. In your code,
-    replace `"example"` with the name of your application.
-
-    # Example
-
-    ```
-    use hoomd_gsd::file_layer::{GsdFile, Mode};
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # use tempfile::tempdir;
-    # let tmp_dir = tempdir().expect("temp dir should be created");
-    # let path = tmp_dir.path().join("test.gsd");
-    let gsd_file = GsdFile::create(path, "example", "hoomd", (1, 4))?;
-    # Ok(())
-    # }
-    ```
-
-    # Errors
-
-    Returns a [`OpenError`] when any of the following occur:
-    * The file cannot be created.
-    * The file is corrupt, unreadable, or there is an I/O error (see
-      [`DecodeError`]).
-    */
+    /// Overwrite an existing GSD file (or create a new file).
+    ///
+    /// Creates a GSD file at the given path, overwriting any file that may already
+    /// exist. When successful, return a [`GsdFile`] opened in write mode.
+    ///
+    /// Each GSD file contains metadata describing which application created the
+    /// file, the data chunk schema, and the schema's version. `application` and
+    /// `schema` are strings (and must each be less than 80 bytes). `schema_version`
+    /// is a tuple listing the major and minor version numbers. In your code,
+    /// replace `"example"` with the name of your application.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_gsd::file_layer::{GsdFile, Mode};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use tempfile::tempdir;
+    /// # let tmp_dir = tempdir().expect("temp dir should be created");
+    /// # let path = tmp_dir.path().join("test.gsd");
+    /// let gsd_file = GsdFile::create(path, "example", "hoomd", (1, 4))?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`OpenError`] when any of the following occur:
+    /// The file cannot be created.
+    /// The file is corrupt, unreadable, or there is an I/O error (see
+    /// [`DecodeError`]).
     #[inline]
     pub fn create<P: AsRef<Path>>(
         path: P,
@@ -1019,39 +1007,38 @@ impl GsdFile {
             .map_err(|e| OpenError::Decode(path.as_ref().into(), e))
     }
 
-    /** Create a new GSD file.
-
-    Creates a new GSD file at the given path, returning an error when the
-    path already exists. When successful, return a [`GsdFile`] opened in
-    write mode.
-
-    Each GSD file contains metadata describing which application created the
-    file, the data chunk schema, and the schema's version. `application` and
-    `schema` are strings (and must each be less than 80 bytes). `schema_version`
-    is a tuple listing the major and minor version numbers. In your code,
-    replace `"example"` with the name of your application.
-
-    # Example
-
-    ```
-    use hoomd_gsd::file_layer::{GsdFile, Mode};
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # use tempfile::tempdir;
-    # let tmp_dir = tempdir().expect("temp dir should be created");
-    # let path = tmp_dir.path().join("test.gsd");
-    let gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
-    # Ok(())
-    # }
-    ```
-
-    # Errors
-
-    Returns a [`OpenError`] when any of the following occur:
-    * The file cannot be created.
-    * The file already exists.
-    * The file is corrupt, unreadable, or there is an I/O error (see
-      [`DecodeError`]).
-    */
+    /// Create a new GSD file.
+    ///
+    /// Creates a new GSD file at the given path, returning an error when the
+    /// path already exists. When successful, return a [`GsdFile`] opened in
+    /// write mode.
+    ///
+    /// Each GSD file contains metadata describing which application created the
+    /// file, the data chunk schema, and the schema's version. `application` and
+    /// `schema` are strings (and must each be less than 80 bytes). `schema_version`
+    /// is a tuple listing the major and minor version numbers. In your code,
+    /// replace `"example"` with the name of your application.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_gsd::file_layer::{GsdFile, Mode};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use tempfile::tempdir;
+    /// # let tmp_dir = tempdir().expect("temp dir should be created");
+    /// # let path = tmp_dir.path().join("test.gsd");
+    /// let gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`OpenError`] when any of the following occur:
+    /// The file cannot be created.
+    /// The file already exists.
+    /// The file is corrupt, unreadable, or there is an I/O error (see
+    /// [`DecodeError`]).
     #[inline]
     pub fn create_new<P: AsRef<Path>>(
         path: P,
@@ -1398,39 +1385,38 @@ impl GsdFile {
         Ok(r)
     }
 
-    /** Find a chunk in the index.
-
-    Returns [`Some(index_entry)`](Option::Some) when the data chunk is present
-    in the file and [`None`] when it is not.
-
-    # Example
-
-    ```
-    use hoomd_gsd::file_layer::{DataType, GsdFile};
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # use tempfile::tempdir;
-    # let tmp_dir = tempdir().expect("temp dir should be created");
-    # let path = tmp_dir.path().join("test.gsd");
-    let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
-    gsd_file.write_scalars("configuration/step", &[100_000u64])?;
-    gsd_file.end_frame()?;
-    gsd_file.sync_all()?;
-
-    let configuration_box = gsd_file.find_chunk(0, "configuration/box");
-    assert_eq!(configuration_box, None);
-
-    let step = gsd_file.find_chunk(0, "configuration/step");
-    assert!(step.is_some());
-    if let Some(index) = step {
-        assert_eq!(index.frame(), 0);
-        assert_eq!(index.rows(), 1);
-        assert_eq!(index.columns(), 1);
-        assert_eq!(index.data_type(), Some(DataType::U64));
-    }
-    # Ok(())
-    # }
-    ```
-    */
+    /// Find a chunk in the index.
+    ///
+    /// Returns [`Some(index_entry)`](Option::Some) when the data chunk is present
+    /// in the file and [`None`] when it is not.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_gsd::file_layer::{DataType, GsdFile};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use tempfile::tempdir;
+    /// # let tmp_dir = tempdir().expect("temp dir should be created");
+    /// # let path = tmp_dir.path().join("test.gsd");
+    /// let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
+    /// gsd_file.write_scalars("configuration/step", &[100_000u64])?;
+    /// gsd_file.end_frame()?;
+    /// gsd_file.sync_all()?;
+    ///
+    /// let configuration_box = gsd_file.find_chunk(0, "configuration/box");
+    /// assert_eq!(configuration_box, None);
+    ///
+    /// let step = gsd_file.find_chunk(0, "configuration/step");
+    /// assert!(step.is_some());
+    /// if let Some(index) = step {
+    ///     assert_eq!(index.frame(), 0);
+    ///     assert_eq!(index.rows(), 1);
+    ///     assert_eq!(index.columns(), 1);
+    ///     assert_eq!(index.data_type(), Some(DataType::U64));
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     #[must_use]
     pub fn find_chunk(&self, frame: u64, name: &str) -> Option<IndexEntry> {
         if frame >= self.file_frame || self.index.n == 0 {
@@ -1464,45 +1450,47 @@ impl GsdFile {
         None
     }
 
-    /** Iterate over an array of scalars in the given frame.
-
-    Returns [`Ok(iterator)`](Result::Ok) when the data chunk is present in the
-    file and `Err(`[`ReadError::ChunkNotFound`]`)` when it is not. Collect the
-    iterator into a [`Vec`] to make a copy of the data, or process the data in
-    place while iterating.
-
-    Data written to a file is not available for reading until the file
-    is closed or after a call to [`sync_all`](GsdFile::sync_all).
-
-    # Example
-
-    ```
-    use hoomd_gsd::file_layer::{DataType, GsdFile};
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # use tempfile::tempdir;
-    # let tmp_dir = tempdir().expect("temp dir should be created");
-    # let path = tmp_dir.path().join("test.gsd");
-    let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
-    gsd_file.write_scalars("configuration/box", &[10.0f32, 20.0, 15.0, 0.0, 0.0, 0.0])?;
-    gsd_file.end_frame()?;
-    gsd_file.sync_all()?;
-
-    let box_iter = gsd_file.iter_scalars::<f32>(0, "configuration/box")?;
-    let box_vec = box_iter.collect::<Vec<_>>();
-    assert_eq!(box_vec, vec![10.0f32, 20.0, 15.0, 0.0, 0.0, 0.0]);
-    # Ok(())
-    # }
-    ```
-
-    # Errors
-
-    Returns a [`ReadError`] when any of the following occur:
-    * A chunk by the given `name` is not present in the given `frame`.
-    * The data type stored in the file does not match `T`.
-    * The array stored in the file does not have dimensions `N x 1`.
-    * The file is corrupt, unreadable, or there is an I/O error (see
-      [`DecodeError`]).
-    */
+    /// Iterate over an array of scalars in the given frame.
+    ///
+    /// Returns [`Ok(iterator)`](Result::Ok) when the data chunk is present in the
+    /// file and `Err(`[`ReadError::ChunkNotFound`]`)` when it is not. Collect the
+    /// iterator into a [`Vec`] to make a copy of the data, or process the data in
+    /// place while iterating.
+    ///
+    /// Data written to a file is not available for reading until the file
+    /// is closed or after a call to [`sync_all`](GsdFile::sync_all).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_gsd::file_layer::{DataType, GsdFile};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use tempfile::tempdir;
+    /// # let tmp_dir = tempdir().expect("temp dir should be created");
+    /// # let path = tmp_dir.path().join("test.gsd");
+    /// let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
+    /// gsd_file.write_scalars(
+    ///     "configuration/box",
+    ///     &[10.0f32, 20.0, 15.0, 0.0, 0.0, 0.0],
+    /// )?;
+    /// gsd_file.end_frame()?;
+    /// gsd_file.sync_all()?;
+    ///
+    /// let box_iter = gsd_file.iter_scalars::<f32>(0, "configuration/box")?;
+    /// let box_vec = box_iter.collect::<Vec<_>>();
+    /// assert_eq!(box_vec, vec![10.0f32, 20.0, 15.0, 0.0, 0.0, 0.0]);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ReadError`] when any of the following occur:
+    /// A chunk by the given `name` is not present in the given `frame`.
+    /// The data type stored in the file does not match `T`.
+    /// The array stored in the file does not have dimensions `N x 1`.
+    /// The file is corrupt, unreadable, or there is an I/O error (see
+    /// [`DecodeError`]).
     pub fn iter_scalars<T: Type>(
         &self,
         frame: u64,
@@ -1532,47 +1520,47 @@ impl GsdFile {
             .map_err(|e| ReadError::Decode(name.into(), frame, e))
     }
 
-    /** Iterate over an array of arrays in the given frame.
-
-    Returns [`Ok(iterator)`](Result::Ok) when the data chunk is present in the
-    file and `Err(`[`ReadError::ChunkNotFound`]`)` when it is not. Collect the
-    iterator into a [`Vec`] to make a copy of the data, or process the data in
-    place while iterating.
-
-    Data written to a file is not available for reading until the file
-    is closed or after a call to [`sync_all`](GsdFile::sync_all).
-
-    # Example
-
-    ```
-    use hoomd_gsd::file_layer::{DataType, GsdFile};
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # use tempfile::tempdir;
-    # let tmp_dir = tempdir().expect("temp dir should be created");
-    # let path = tmp_dir.path().join("test.gsd");
-    let position = vec![[5.0f32, 3.0, -4.0], [-2.0, 3.0, -6.0]];
-
-    let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
-    gsd_file.write_arrays("particles/position", &position)?;
-    gsd_file.end_frame()?;
-    gsd_file.sync_all()?;
-
-    let position_iter = gsd_file.iter_arrays::<f32, 3>(0, "particles/position")?;
-    let position_vec = position_iter.collect::<Vec<_>>();
-    assert_eq!(position_vec, position);
-    # Ok(())
-    # }
-    ```
-
-    # Errors
-
-    Returns a [`ReadError`] when any of the following occur:
-    * A chunk by the given `name` is not present in the given `frame`.
-    * The data type stored in the file does not match `T`.
-    * The array stored in the file does not have dimensions `N x M`.
-    * The file is corrupt, unreadable, or there is an I/O error (see
-      [`DecodeError`]).
-    */
+    /// Iterate over an array of arrays in the given frame.
+    ///
+    /// Returns [`Ok(iterator)`](Result::Ok) when the data chunk is present in the
+    /// file and `Err(`[`ReadError::ChunkNotFound`]`)` when it is not. Collect the
+    /// iterator into a [`Vec`] to make a copy of the data, or process the data in
+    /// place while iterating.
+    ///
+    /// Data written to a file is not available for reading until the file
+    /// is closed or after a call to [`sync_all`](GsdFile::sync_all).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_gsd::file_layer::{DataType, GsdFile};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use tempfile::tempdir;
+    /// # let tmp_dir = tempdir().expect("temp dir should be created");
+    /// # let path = tmp_dir.path().join("test.gsd");
+    /// let position = vec![[5.0f32, 3.0, -4.0], [-2.0, 3.0, -6.0]];
+    ///
+    /// let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
+    /// gsd_file.write_arrays("particles/position", &position)?;
+    /// gsd_file.end_frame()?;
+    /// gsd_file.sync_all()?;
+    ///
+    /// let position_iter =
+    ///     gsd_file.iter_arrays::<f32, 3>(0, "particles/position")?;
+    /// let position_vec = position_iter.collect::<Vec<_>>();
+    /// assert_eq!(position_vec, position);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ReadError`] when any of the following occur:
+    /// A chunk by the given `name` is not present in the given `frame`.
+    /// The data type stored in the file does not match `T`.
+    /// The array stored in the file does not have dimensions `N x M`.
+    /// The file is corrupt, unreadable, or there is an I/O error (see
+    /// [`DecodeError`]).
     pub fn iter_arrays<T: Type, const M: usize>(
         &self,
         frame: u64,
@@ -1605,42 +1593,41 @@ impl GsdFile {
         })
     }
 
-    /** Read a string in the given frame.
-
-    Returns [`Ok(String)`](Result::Ok) when the data chunk is present
-    in the file and `Err(`[`ReadError::ChunkNotFound`]`)` when it is not.
-
-    Data written to a file is not available for reading until the file
-    is closed or after a call to [`sync_all`](GsdFile::sync_all).
-
-    # Example
-
-    ```
-    use hoomd_gsd::file_layer::{DataType, GsdFile};
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # use tempfile::tempdir;
-    # let tmp_dir = tempdir().expect("temp dir should be created");
-    # let path = tmp_dir.path().join("test.gsd");
-    let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
-    gsd_file.write_string("log/my_string", "Hello, GSD.")?;
-    gsd_file.end_frame()?;
-    gsd_file.sync_all()?;
-
-    let string = gsd_file.read_string(0, "log/my_string")?;
-    assert_eq!(string, "Hello, GSD.");
-    # Ok(())
-    # }
-    ```
-
-    # Errors
-
-    Returns a [`ReadError`] when any of the following occur:
-    * A chunk by the given `name` is not present in the given `frame`.
-    * The data type stored in the file is not a UTF-8 string.
-    * The array stored in the file does not have dimensions `N x 1`.
-    * The file is corrupt, unreadable, or there is an I/O error (see
-      [`DecodeError`]).
-    */
+    /// Read a string in the given frame.
+    ///
+    /// Returns [`Ok(String)`](Result::Ok) when the data chunk is present
+    /// in the file and `Err(`[`ReadError::ChunkNotFound`]`)` when it is not.
+    ///
+    /// Data written to a file is not available for reading until the file
+    /// is closed or after a call to [`sync_all`](GsdFile::sync_all).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_gsd::file_layer::{DataType, GsdFile};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use tempfile::tempdir;
+    /// # let tmp_dir = tempdir().expect("temp dir should be created");
+    /// # let path = tmp_dir.path().join("test.gsd");
+    /// let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
+    /// gsd_file.write_string("log/my_string", "Hello, GSD.")?;
+    /// gsd_file.end_frame()?;
+    /// gsd_file.sync_all()?;
+    ///
+    /// let string = gsd_file.read_string(0, "log/my_string")?;
+    /// assert_eq!(string, "Hello, GSD.");
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ReadError`] when any of the following occur:
+    /// A chunk by the given `name` is not present in the given `frame`.
+    /// The data type stored in the file is not a UTF-8 string.
+    /// The array stored in the file does not have dimensions `N x 1`.
+    /// The file is corrupt, unreadable, or there is an I/O error (see
+    /// [`DecodeError`]).
     pub fn read_string(&self, frame: u64, name: &str) -> Result<String, ReadError> {
         let Some(index_entry) = self.find_chunk(frame, name) else {
             return Err(ReadError::ChunkNotFound(name.into(), frame));
@@ -1694,42 +1681,44 @@ impl GsdFile {
             .map(T::from_ne_byte_slice))
     }
 
-    /** Append an array of scalar values to the current frame.
-
-    `write_scalars` writes one-dimensional array data to a named chunk in the
-    current frame of the GSD file. Call [`end_frame`](GsdFile::end_frame) to
-    complete the frame and start the next.
-
-    <div class="warning">
-
-    Dropping a [`GsdFile`] will also drop any pending data chunks in incomplete
-    frames.
-
-    </div>
-
-    # Example
-
-    ```
-    use hoomd_gsd::file_layer::{DataType, GsdFile};
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # use tempfile::tempdir;
-    # let tmp_dir = tempdir().expect("temp dir should be created");
-    # let path = tmp_dir.path().join("test.gsd");
-    let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
-    gsd_file.write_scalars("configuration/box", &[10.0f32, 20.0, 15.0, 0.0, 0.0, 0.0])?;
-    gsd_file.end_frame()?;
-    # Ok(())
-    # }
-    ```
-
-    # Errors
-
-    Returns a [`WriteError`] when any of the following occur:
-    * The file is not opened in a write mode.
-    * There are no available chunk identifiers.
-    * A chunk with the same name has already been written in this frame.
-    * There is an I/O error while writing to the file.
-    */
+    /// Append an array of scalar values to the current frame.
+    ///
+    /// `write_scalars` writes one-dimensional array data to a named chunk in the
+    /// current frame of the GSD file. Call [`end_frame`](GsdFile::end_frame) to
+    /// complete the frame and start the next.
+    ///
+    /// <div class="warning">
+    ///
+    /// Dropping a [`GsdFile`] will also drop any pending data chunks in incomplete
+    /// frames.
+    ///
+    /// </div>
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_gsd::file_layer::{DataType, GsdFile};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use tempfile::tempdir;
+    /// # let tmp_dir = tempdir().expect("temp dir should be created");
+    /// # let path = tmp_dir.path().join("test.gsd");
+    /// let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
+    /// gsd_file.write_scalars(
+    ///     "configuration/box",
+    ///     &[10.0f32, 20.0, 15.0, 0.0, 0.0, 0.0],
+    /// )?;
+    /// gsd_file.end_frame()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`WriteError`] when any of the following occur:
+    /// The file is not opened in a write mode.
+    /// There are no available chunk identifiers.
+    /// A chunk with the same name has already been written in this frame.
+    /// There is an I/O error while writing to the file.
     pub fn write_scalars<'a, T, I>(&mut self, name: &str, data: I) -> Result<(), WriteError>
     where
         T: Type + 'a,
@@ -1754,45 +1743,44 @@ impl GsdFile {
         .map_err(|e| WriteError::Encode(name.into(), self.buffer_frame, e))
     }
 
-    /** Append an array of array values to the current frame.
-
-    `write_arrays` writes two-dimensional array data to a named chunk in the
-    current frame of the GSD file. Call [`end_frame`](GsdFile::end_frame) to
-    complete the frame and start the next.
-
-    <div class="warning">
-
-    Dropping a [`GsdFile`] will also drop any pending data chunks in incomplete
-    frames.
-
-    </div>
-
-    # Example
-
-    ```
-    use hoomd_gsd::file_layer::{DataType, GsdFile};
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # use tempfile::tempdir;
-    # let tmp_dir = tempdir().expect("temp dir should be created");
-    # let path = tmp_dir.path().join("test.gsd");
-    let position = vec![[5.0f32, 3.0, -4.0], [-2.0, 3.0, -6.0]];
-
-    let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
-    gsd_file.write_arrays("particles/position", &position)?;
-    gsd_file.end_frame()?;
-    # Ok(())
-    # }
-    ```
-
-    # Errors
-
-    Returns a [`WriteError`] when any of the following occur:
-    * The file is not opened in a write mode.
-    * There are no available chunk identifiers.
-    * A chunk with the same name has already been written in this frame.
-    * `M` is 0.
-    * `M` cannot be represented by a `u32`.
-    */
+    /// Append an array of array values to the current frame.
+    ///
+    /// `write_arrays` writes two-dimensional array data to a named chunk in the
+    /// current frame of the GSD file. Call [`end_frame`](GsdFile::end_frame) to
+    /// complete the frame and start the next.
+    ///
+    /// <div class="warning">
+    ///
+    /// Dropping a [`GsdFile`] will also drop any pending data chunks in incomplete
+    /// frames.
+    ///
+    /// </div>
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_gsd::file_layer::{DataType, GsdFile};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use tempfile::tempdir;
+    /// # let tmp_dir = tempdir().expect("temp dir should be created");
+    /// # let path = tmp_dir.path().join("test.gsd");
+    /// let position = vec![[5.0f32, 3.0, -4.0], [-2.0, 3.0, -6.0]];
+    ///
+    /// let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
+    /// gsd_file.write_arrays("particles/position", &position)?;
+    /// gsd_file.end_frame()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`WriteError`] when any of the following occur:
+    /// The file is not opened in a write mode.
+    /// There are no available chunk identifiers.
+    /// A chunk with the same name has already been written in this frame.
+    /// `M` is 0.
+    /// `M` cannot be represented by a `u32`.
     pub fn write_arrays<'a, T, I, const M: usize>(
         &mut self,
         name: &str,
@@ -1835,41 +1823,40 @@ impl GsdFile {
         .map_err(|e| WriteError::Encode(name.into(), self.buffer_frame, e))
     }
 
-    /** Append a string to the current frame.
-
-    `write_string` writes a UTF-8 string to a named chunk in the current frame
-    of the GSD file. Call [`end_frame`](GsdFile::end_frame) to complete the
-    frame and start the next.
-
-    <div class="warning">
-
-    Dropping a [`GsdFile`] will also drop any pending data chunks in incomplete
-    frames.
-
-    </div>
-
-    # Example
-
-    ```
-    use hoomd_gsd::file_layer::{DataType, GsdFile};
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # use tempfile::tempdir;
-    # let tmp_dir = tempdir().expect("temp dir should be created");
-    # let path = tmp_dir.path().join("test.gsd");
-    let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
-    gsd_file.write_string("log/my_string", "Hello, GSD.")?;
-    gsd_file.end_frame()?;
-    # Ok(())
-    # }
-    ```
-
-    # Errors
-
-    Returns a [`WriteError`] when any of the following occur:
-    * The file is not opened in a write mode.
-    * There are no available chunk identifiers.
-    * A chunk with the same name has already been written in this frame.
-    */
+    /// Append a string to the current frame.
+    ///
+    /// `write_string` writes a UTF-8 string to a named chunk in the current frame
+    /// of the GSD file. Call [`end_frame`](GsdFile::end_frame) to complete the
+    /// frame and start the next.
+    ///
+    /// <div class="warning">
+    ///
+    /// Dropping a [`GsdFile`] will also drop any pending data chunks in incomplete
+    /// frames.
+    ///
+    /// </div>
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_gsd::file_layer::{DataType, GsdFile};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use tempfile::tempdir;
+    /// # let tmp_dir = tempdir().expect("temp dir should be created");
+    /// # let path = tmp_dir.path().join("test.gsd");
+    /// let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
+    /// gsd_file.write_string("log/my_string", "Hello, GSD.")?;
+    /// gsd_file.end_frame()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`WriteError`] when any of the following occur:
+    /// The file is not opened in a write mode.
+    /// There are no available chunk identifiers.
+    /// A chunk with the same name has already been written in this frame.
     pub fn write_string(&mut self, name: &str, data: &str) -> Result<(), WriteError> {
         let data = data.as_bytes();
 
@@ -1945,40 +1932,39 @@ impl GsdFile {
         Ok(())
     }
 
-    /** Complete the current frame.
-
-    Commits previous calls to `write_*` methods to the current frame. Calls to
-    `write_*` methods following `end_frame` will write to the next frame.
-
-    Calling `end_frame` does **not** ensure that all buffered data is synced to
-    the filesystem. Call [`sync_all`](GsdFile::sync_all) to do so.
-
-    # Example
-
-    ```
-    use hoomd_gsd::file_layer::{DataType, GsdFile};
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # use tempfile::tempdir;
-    # let tmp_dir = tempdir().expect("temp dir should be created");
-    # let path = tmp_dir.path().join("test.gsd");
-    let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
-    gsd_file.write_scalars("configuration/step", &[100_000u64])?;
-    gsd_file.end_frame()?;
-
-    gsd_file.write_scalars("configuration/step", &[200_000u64])?;
-    gsd_file.end_frame()?;
-
-    gsd_file.write_scalars("configuration/step", &[300_000u64])?;
-    gsd_file.end_frame()?;
-    # Ok(())
-    # }
-    ```
-
-    # Errors
-
-    Returns a [`EncodeError`] when any of the following occur:
-    * The file is not opened in a write mode.
-    */
+    /// Complete the current frame.
+    ///
+    /// Commits previous calls to `write_*` methods to the current frame. Calls to
+    /// `write_*` methods following `end_frame` will write to the next frame.
+    ///
+    /// Calling `end_frame` does **not** ensure that all buffered data is synced to
+    /// the filesystem. Call [`sync_all`](GsdFile::sync_all) to do so.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_gsd::file_layer::{DataType, GsdFile};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use tempfile::tempdir;
+    /// # let tmp_dir = tempdir().expect("temp dir should be created");
+    /// # let path = tmp_dir.path().join("test.gsd");
+    /// let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
+    /// gsd_file.write_scalars("configuration/step", &[100_000u64])?;
+    /// gsd_file.end_frame()?;
+    ///
+    /// gsd_file.write_scalars("configuration/step", &[200_000u64])?;
+    /// gsd_file.end_frame()?;
+    ///
+    /// gsd_file.write_scalars("configuration/step", &[300_000u64])?;
+    /// gsd_file.end_frame()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`EncodeError`] when any of the following occur:
+    /// The file is not opened in a write mode.
     pub fn end_frame(&mut self) -> Result<(), EncodeError> {
         if self.mode != Mode::Write {
             return Err(EncodeError::NotWritable);
@@ -1993,141 +1979,139 @@ impl GsdFile {
 
     #[inline]
     #[must_use]
-    /** The number of frames *written to the file*.
-
-    `n_frames` returns the number of frames *available to read* from the file.
-    Each call to [`end_frame`](GsdFile::end_frame) increments the number of
-    frames, but they are not written to the file until it is closed or by a call
-    to [`sync_all`](GsdFile::sync_all).
-
-    ```
-    use hoomd_gsd::file_layer::{DataType, GsdFile};
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # use tempfile::tempdir;
-    # let tmp_dir = tempdir().expect("temp dir should be created");
-    # let path = tmp_dir.path().join("test.gsd");
-    let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
-    gsd_file.write_scalars("configuration/step", &[100_000u64])?;
-    gsd_file.end_frame()?;
-
-    gsd_file.write_scalars("configuration/step", &[200_000u64])?;
-    gsd_file.end_frame()?;
-
-    gsd_file.write_scalars("configuration/step", &[300_000u64])?;
-    gsd_file.end_frame()?;
-    gsd_file.sync_all()?;
-
-    let n_frames = gsd_file.n_frames();
-    assert_eq!(n_frames, 3);
-    # Ok(())
-    # }
-    ```
-    */
+    /// The number of frames *written to the file*.
+    ///
+    /// `n_frames` returns the number of frames *available to read* from the file.
+    /// Each call to [`end_frame`](GsdFile::end_frame) increments the number of
+    /// frames, but they are not written to the file until it is closed or by a call
+    /// to [`sync_all`](GsdFile::sync_all).
+    ///
+    /// ```
+    /// use hoomd_gsd::file_layer::{DataType, GsdFile};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use tempfile::tempdir;
+    /// # let tmp_dir = tempdir().expect("temp dir should be created");
+    /// # let path = tmp_dir.path().join("test.gsd");
+    /// let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
+    /// gsd_file.write_scalars("configuration/step", &[100_000u64])?;
+    /// gsd_file.end_frame()?;
+    ///
+    /// gsd_file.write_scalars("configuration/step", &[200_000u64])?;
+    /// gsd_file.end_frame()?;
+    ///
+    /// gsd_file.write_scalars("configuration/step", &[300_000u64])?;
+    /// gsd_file.end_frame()?;
+    /// gsd_file.sync_all()?;
+    ///
+    /// let n_frames = gsd_file.n_frames();
+    /// assert_eq!(n_frames, 3);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn n_frames(&self) -> u64 {
         self.file_frame
     }
 
     #[inline]
     #[must_use]
-    /** Provide the mapping from data chunk names to ids.
-
-    The mapping includes keys for all data chunk names in the file.
-
-    # Example
-
-    ```
-    use hoomd_gsd::file_layer::GsdFile;
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # use tempfile::tempdir;
-    # let tmp_dir = tempdir().expect("temp dir should be created");
-    # let path = tmp_dir.path().join("test.gsd");
-    let position = vec![[5.0f32, 3.0, -4.0], [-2.0, 3.0, -6.0]];
-
-    let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
-    gsd_file.write_scalars("configuration/step", &[100_000u64])?;
-    gsd_file.write_scalars("configuration/box", &[10.0f32, 20.0, 15.0, 0.0, 0.0, 0.0])?;
-    gsd_file.write_arrays("particles/position", &position)?;
-    gsd_file.end_frame()?;
-
-    let name_id = gsd_file.name_id();
-    assert!(name_id.contains_key("configuration/step"));
-    assert!(name_id.contains_key("configuration/box"));
-    assert!(name_id.contains_key("particles/position"));
-    assert!(!name_id.contains_key("particles/orientation"));
-    # Ok(())
-    # }
-    ```
-    */
+    /// Provide the mapping from data chunk names to ids.
+    ///
+    /// The mapping includes keys for all data chunk names in the file.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_gsd::file_layer::GsdFile;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use tempfile::tempdir;
+    /// # let tmp_dir = tempdir().expect("temp dir should be created");
+    /// # let path = tmp_dir.path().join("test.gsd");
+    /// let position = vec![[5.0f32, 3.0, -4.0], [-2.0, 3.0, -6.0]];
+    ///
+    /// let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
+    /// gsd_file.write_scalars("configuration/step", &[100_000u64])?;
+    /// gsd_file.write_scalars(
+    ///     "configuration/box",
+    ///     &[10.0f32, 20.0, 15.0, 0.0, 0.0, 0.0],
+    /// )?;
+    /// gsd_file.write_arrays("particles/position", &position)?;
+    /// gsd_file.end_frame()?;
+    ///
+    /// let name_id = gsd_file.name_id();
+    /// assert!(name_id.contains_key("configuration/step"));
+    /// assert!(name_id.contains_key("configuration/box"));
+    /// assert!(name_id.contains_key("particles/position"));
+    /// assert!(!name_id.contains_key("particles/orientation"));
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn name_id(&self) -> &HashMap<String, u16> {
         &self.name_list.name_id
     }
 
-    /** The name of the application used to write the file.
-
-    # Example
-
-    ```
-    use hoomd_gsd::file_layer::GsdFile;
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # use tempfile::tempdir;
-    # let tmp_dir = tempdir().expect("temp dir should be created");
-    # let path = tmp_dir.path().join("test.gsd");
-    let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
-
-    let application = gsd_file.application();
-    assert_eq!(application, "example");
-    # Ok(())
-    # }
-    ```
-    */
+    /// The name of the application used to write the file.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_gsd::file_layer::GsdFile;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use tempfile::tempdir;
+    /// # let tmp_dir = tempdir().expect("temp dir should be created");
+    /// # let path = tmp_dir.path().join("test.gsd");
+    /// let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
+    ///
+    /// let application = gsd_file.application();
+    /// assert_eq!(application, "example");
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     #[must_use]
     pub fn application(&self) -> &str {
         &self.header.application
     }
 
-    /** The schema that describes the expected data chunks.
-
-    # Example
-
-    ```
-    use hoomd_gsd::file_layer::GsdFile;
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # use tempfile::tempdir;
-    # let tmp_dir = tempdir().expect("temp dir should be created");
-    # let path = tmp_dir.path().join("test.gsd");
-    let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
-
-    let schema = gsd_file.schema();
-    assert_eq!(schema, "hoomd");
-    # Ok(())
-    # }
-    ```
-    */
+    /// The schema that describes the expected data chunks.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_gsd::file_layer::GsdFile;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use tempfile::tempdir;
+    /// # let tmp_dir = tempdir().expect("temp dir should be created");
+    /// # let path = tmp_dir.path().join("test.gsd");
+    /// let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
+    ///
+    /// let schema = gsd_file.schema();
+    /// assert_eq!(schema, "hoomd");
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     #[must_use]
     pub fn schema(&self) -> &str {
         &self.header.schema
     }
 
-    /** The schema version (major, minor).
-
-    # Example
-
-    ```
-    use hoomd_gsd::file_layer::GsdFile;
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    # use tempfile::tempdir;
-    # let tmp_dir = tempdir().expect("temp dir should be created");
-    # let path = tmp_dir.path().join("test.gsd");
-    let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
-
-    let schema_version = gsd_file.schema_version();
-    assert_eq!(schema_version, (1,4));
-    # Ok(())
-    # }
-    ```
-    */
+    /// The schema version (major, minor).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_gsd::file_layer::GsdFile;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # use tempfile::tempdir;
+    /// # let tmp_dir = tempdir().expect("temp dir should be created");
+    /// # let path = tmp_dir.path().join("test.gsd");
+    /// let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
+    ///
+    /// let schema_version = gsd_file.schema_version();
+    /// assert_eq!(schema_version, (1, 4));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     #[must_use]
     pub fn schema_version(&self) -> (u16, u16) {
@@ -2148,10 +2132,9 @@ impl GsdFile {
         &mut self.maximum_write_buffer_size
     }
 
-    /** Flush data buffer to the filesystem.
-
-    Returns true when any data was written to the file.
-    */
+    /// Flush data buffer to the filesystem.
+    ///
+    /// Returns true when any data was written to the file.
     fn flush_data(&mut self) -> Result<bool, EncodeError> {
         if self.data_buffer.is_empty() {
             Ok(false)
@@ -2165,10 +2148,9 @@ impl GsdFile {
         }
     }
 
-    /** Flush the name buffer to the filesystem.
-
-    Returns true when any data was written to the file.
-    */
+    /// Flush the name buffer to the filesystem.
+    ///
+    /// Returns true when any data was written to the file.
     fn flush_names(&mut self) -> Result<bool, EncodeError> {
         if self.name_list.buffer.is_empty() {
             Ok(false)
@@ -2194,22 +2176,21 @@ impl GsdFile {
         }
     }
 
-    /** Write buffered data to the filesystem.
-
-    `sync_all` ensures that the data and indices for all complete frames is
-    written to the filesystem.
-
-    In most cases, callers should not call `sync_all` manually. It will be
-    called automatically when a [`GsdFile`] is dropped. Call `sync_all` only
-    when you need to read data arrays written in previous frames or when you
-    want to ensure that all data up to a specific frame are present in the file.
-
-    # Errors
-
-    Returns a [`WriteError`] when any of the following occur:
-    * The file is not opened in a write mode.
-    * An I/O error writing to the file.
-    */
+    /// Write buffered data to the filesystem.
+    ///
+    /// `sync_all` ensures that the data and indices for all complete frames is
+    /// written to the filesystem.
+    ///
+    /// In most cases, callers should not call `sync_all` manually. It will be
+    /// called automatically when a [`GsdFile`] is dropped. Call `sync_all` only
+    /// when you need to read data arrays written in previous frames or when you
+    /// want to ensure that all data up to a specific frame are present in the file.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`WriteError`] when any of the following occur:
+    /// The file is not opened in a write mode.
+    /// An I/O error writing to the file.
     pub fn sync_all(&mut self) -> Result<(), EncodeError> {
         if self.mode != Mode::Write {
             return Err(EncodeError::NotWritable);
@@ -2365,12 +2346,11 @@ impl GsdFile {
     }
 }
 
-/** Automatically synchronize buffered data before closing the file.
-
-[`GsdFile`] automatically calls [`sync_all`](GsdFile::sync_all) when
-dropped and ignores and errors. To check for any potential errors, call
-[`sync_all`](GsdFile::sync_all) before dropping a [`GsdFile`].
-*/
+/// Automatically synchronize buffered data before closing the file.
+///
+/// [`GsdFile`] automatically calls [`sync_all`](GsdFile::sync_all) when
+/// dropped and ignores and errors. To check for any potential errors, call
+/// [`sync_all`](GsdFile::sync_all) before dropping a [`GsdFile`].
 impl Drop for GsdFile {
     fn drop(&mut self) {
         let _ = self.sync_all();

--- a/hoomd-gsd/src/lib.rs
+++ b/hoomd-gsd/src/lib.rs
@@ -12,72 +12,74 @@
     reason = "GSD methods are not meant to be customized"
 )]
 
-/*! Read and write GSD files.
-
-# GSD files
-
-A GSD file stores 2D arrays of integer and floating point types in named chunks
-that are associated with trajectory frames. The [GSD Python package] can read
-and write these files. `hoomd-gsd` implements GSD file I/O in native Rust.
-
-[GSD Python package]: https://gsd.readthedocs.io
-
-# The file layer
-
-[`GsdFile`](file_layer::GsdFile) provides direct access to read and write GSD
-formatted files. Call [`create_new`](file_layer::GsdFile::create_new) to create
-a new GSD file:
-
-```
-use hoomd_gsd::file_layer::GsdFile;
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-# use tempfile::tempdir;
-# let tmp_dir = tempdir().expect("temp dir should be created");
-# let path = tmp_dir.path().join("test.gsd");
-// let path = "file.gsd";
-let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
-# Ok(())
-# }
-```
-
-Add new arrays to the current frame with
-[`write_scalars`](file_layer::GsdFile::write_scalars) and
-[`write_arrays`](file_layer::GsdFile::write_arrays). You **must** end the frame
-with [`end_frame`](file_layer::GsdFile::end_frame) or no data will be written to
-the file!
-```
-use hoomd_gsd::file_layer::GsdFile;
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-# use tempfile::tempdir;
-# let tmp_dir = tempdir().expect("temp dir should be created");
-# let path = tmp_dir.path().join("test.gsd");
-let position = vec![[5.0f32, 3.0, -4.0], [-2.0, 3.0, -6.0]];
-
-let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
-gsd_file.write_scalars("configuration/step", &[100_000u64])?;
-gsd_file.write_scalars("configuration/box", &[10.0f32, 20.0, 15.0, 0.0, 0.0, 0.0])?;
-gsd_file.write_arrays("particles/position", &position)?;
-gsd_file.end_frame()?;
-# Ok(())
-# }
-```
-Each array in the file in stored in a specific type. `write_scalars` and
-`write_arrays` automatically infer that type from the argument given.
-
-# HOOMD schema
-
-See the [GSD Python package] documentation for a full specification of the HOOMD
-schema. Files written with this schema will interoperate with [HOOMD-blue],
-[OVITO], and other applications.
-
-[HOOMD-blue]: https://hoomd-blue.readthedocs.io
-[Ovito]: https://www.ovito.org
-
-At this time, the `hoomd-gsd` crate does not provide any high level API for
-reading or writing the HOOMD schema. See the code examples throughout the
-[`file_layer`] module for minimal examples that write files with the HOOMD
-schema. Note that the HOOMD schema uses f32 data types, so convert appropriately
-when mapping vectors from `hoomd-vector`.
- */
+//! Read and write GSD files.
+//!
+//! # GSD files
+//!
+//! A GSD file stores 2D arrays of integer and floating point types in named chunks
+//! that are associated with trajectory frames. The [GSD Python package] can read
+//! and write these files. `hoomd-gsd` implements GSD file I/O in native Rust.
+//!
+//! [GSD Python package]: https://gsd.readthedocs.io
+//!
+//! # The file layer
+//!
+//! [`GsdFile`](file_layer::GsdFile) provides direct access to read and write GSD
+//! formatted files. Call [`create_new`](file_layer::GsdFile::create_new) to create
+//! a new GSD file:
+//!
+//! ```
+//! use hoomd_gsd::file_layer::GsdFile;
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # use tempfile::tempdir;
+//! # let tmp_dir = tempdir().expect("temp dir should be created");
+//! # let path = tmp_dir.path().join("test.gsd");
+//! let path = "file.gsd";
+//! let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Add new arrays to the current frame with
+//! [`write_scalars`](file_layer::GsdFile::write_scalars) and
+//! [`write_arrays`](file_layer::GsdFile::write_arrays). You **must** end the frame
+//! with [`end_frame`](file_layer::GsdFile::end_frame) or no data will be written to
+//! the file!
+//! ```
+//! use hoomd_gsd::file_layer::GsdFile;
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # use tempfile::tempdir;
+//! # let tmp_dir = tempdir().expect("temp dir should be created");
+//! # let path = tmp_dir.path().join("test.gsd");
+//! let position = vec![[5.0f32, 3.0, -4.0], [-2.0, 3.0, -6.0]];
+//!
+//! let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
+//! gsd_file.write_scalars("configuration/step", &[100_000u64])?;
+//! gsd_file.write_scalars(
+//!     "configuration/box",
+//!     &[10.0f32, 20.0, 15.0, 0.0, 0.0, 0.0],
+//! )?;
+//! gsd_file.write_arrays("particles/position", &position)?;
+//! gsd_file.end_frame()?;
+//! # Ok(())
+//! # }
+//! ```
+//! Each array in the file in stored in a specific type. `write_scalars` and
+//! `write_arrays` automatically infer that type from the argument given.
+//!
+//! # HOOMD schema
+//!
+//! See the [GSD Python package] documentation for a full specification of the HOOMD
+//! schema. Files written with this schema will interoperate with [HOOMD-blue],
+//! [OVITO], and other applications.
+//!
+//! [HOOMD-blue]: https://hoomd-blue.readthedocs.io
+//! [Ovito]: https://www.ovito.org
+//!
+//! At this time, the `hoomd-gsd` crate does not provide any high level API for
+//! reading or writing the HOOMD schema. See the code examples throughout the
+//! [`file_layer`] module for minimal examples that write files with the HOOMD
+//! schema. Note that the HOOMD schema uses f32 data types, so convert appropriately
+//! when mapping vectors from `hoomd-vector`.
 
 pub mod file_layer;

--- a/hoomd-gsd/src/lib.rs
+++ b/hoomd-gsd/src/lib.rs
@@ -34,7 +34,7 @@
 //! # use tempfile::tempdir;
 //! # let tmp_dir = tempdir().expect("temp dir should be created");
 //! # let path = tmp_dir.path().join("test.gsd");
-//! let path = "file.gsd";
+//! // let path = "file.gsd";
 //! let mut gsd_file = GsdFile::create_new(path, "example", "hoomd", (1, 4))?;
 //! # Ok(())
 //! # }

--- a/hoomd-interaction/benches/angular-mask.rs
+++ b/hoomd-interaction/benches/angular-mask.rs
@@ -10,7 +10,7 @@
     reason = "benches can use expect without individual reasons"
 )]
 
-//! Benchmark `LennardJones`
+//! Benchmark `AngularMask`
 
 use divan::{self, Bencher, black_box, counter::ItemsCount};
 use rand::{Rng, SeedableRng, rngs::StdRng};

--- a/hoomd-interaction/benches/angular-mask.rs
+++ b/hoomd-interaction/benches/angular-mask.rs
@@ -10,7 +10,7 @@
     reason = "benches can use expect without individual reasons"
 )]
 
-/*! Benchmark `LennardJones` */
+//! Benchmark `LennardJones`
 
 use divan::{self, Bencher, black_box, counter::ItemsCount};
 use rand::{Rng, SeedableRng, rngs::StdRng};

--- a/hoomd-interaction/benches/lennard-jones.rs
+++ b/hoomd-interaction/benches/lennard-jones.rs
@@ -6,7 +6,7 @@
     reason = "benches don't need public documentation"
 )]
 
-/*! Benchmark `LennardJones` */
+//! Benchmark `LennardJones`
 
 use divan::{self, Bencher, black_box, counter::ItemsCount};
 use rand::{Rng, SeedableRng, rngs::StdRng};

--- a/hoomd-interaction/src/cutoff_pair.rs
+++ b/hoomd-interaction/src/cutoff_pair.rs
@@ -174,7 +174,6 @@ where
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut microstate = Microstate::new();
-    /// Place two pairs of particles separated by a large distance.
     /// microstate.extend_bodies([Body::point(Cartesian::from([0.0, 0.0])),
     /// Body::point(Cartesian::from([1.0, 0.0])),
     /// Body::point(Cartesian::from([0.0, 5.0])),
@@ -186,11 +185,11 @@ where
     /// let evaluator = Isotropic(lennard_jones);
     /// let cutoff_pair = CutoffPair { r_cut: 2.5, evaluator };
     ///
-    /// The potential energy is set to 0 beyond r_cut when computed by `CutoffPair`.
+    /// // The potential energy is set to 0 beyond r_cut when computed by `CutoffPair`.
     /// let total_energy = cutoff_pair.total_energy(&microstate);
     /// assert_eq!(total_energy, -3.0);
     ///
-    /// However, individual pairwise `site_pair_energy` evaluations are always computed.
+    /// // However, individual pairwise `site_pair_energy` evaluations are always computed.
     /// let a = &microstate.sites()[0].properties;
     /// let b = &microstate.sites()[2].properties;
     /// assert_eq!((*a.position() - *b.position()).norm(), 5.0);

--- a/hoomd-interaction/src/cutoff_pair.rs
+++ b/hoomd-interaction/src/cutoff_pair.rs
@@ -1,78 +1,87 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement `CutoffPair`
- */
+//! Implement `CutoffPair`
 
 use crate::{DeltaEnergyInsert, DeltaEnergyOne, DeltaEnergyRemove, SitePairEnergy, TotalEnergy};
 use hoomd_microstate::{Body, Microstate, Site, Transform, boundary::Wrap, property::Position};
 use hoomd_vector::Vector;
 
-/** Short-ranged pairwise interactions between sites.
-
-Given an evaluator that implements [`SitePairEnergy`], [`CutoffPair`] represents:
-
-```math
-U_\mathrm{total} = \sum_{i=0}^{N-1}\sum_{j=i+1}^{N-1} U\left(s_i, s_j \right) \left[ \left|\vec{r}_j - \vec{r}_i\right| \lt r_\mathrm{cut} \right]\left[b_i \ne b_j\right]
-```
-where $`U(s_i, s_j)`$ is the potential computed by [`CutoffPair::evaluator`],
-$`s_i`$ is the full set of site properties for site i, $`\vec{r}_i`$ is
-the position of site i, $`b_i`$ is the body tag that holds site *i*, and
-$`\left[ \  \right]`$ denotes the Iverson bracket.
-
-In other words, [`CutoffPair`] sums the energy for all pairs that are separated
-by a distance less than `r_cut` and belong to different bodies.
-
-For the evaluator, use [`Anisotropic`], [`Isotropic`] or your own custom type.
-
-TODO: Reword this when [`CutoffPair`] also implements `SitePairForce`.
-
-[`Anisotropic`]: crate::pairwise::Anisotropic
-[`Isotropic`]: crate::pairwise::Isotropic
-
-# Example
-
-Basic usage:
-```
-use hoomd_interaction::{CutoffPair,
-    pairwise::{Isotropic, LennardJones}};
-
-let lennard_jones: LennardJones = LennardJones { epsilon: 1.5, sigma: 2.0 };
-let evaluator = Isotropic(lennard_jones);
-let cutoff_pair = CutoffPair { r_cut: 5.0, evaluator };
-```
-
-Set a custom potential using a closure:
-```
-use hoomd_interaction::{CutoffPair, pairwise::Isotropic};
-
-let cutoff_pair = CutoffPair {
-    r_cut: 3.0,
-    evaluator: Isotropic(|r: f64| 1.0 / (r.powi(12))),
-};
-```
-
-Implement a custom potential via a type:
-```
-use hoomd_interaction::{CutoffPair, pairwise::{Isotropic, IsotropicEnergy}};
-
-struct Custom {
-    a: f64,
-}
-
-impl IsotropicEnergy for Custom {
-    fn energy(&self, r: f64) -> f64 {
-        self.a / r.powi(12)
-    }
-}
-
-let custom = Custom { a: 2.0 };
-let cutoff_pair = CutoffPair {
-    r_cut: 2.0,
-    evaluator: Isotropic(custom),
-};
-```
-*/
+/// Short-ranged pairwise interactions between sites.
+///
+/// Given an evaluator that implements [`SitePairEnergy`], [`CutoffPair`] represents:
+///
+/// ```math
+/// U_\mathrm{total} = \sum_{i=0}^{N-1}\sum_{j=i+1}^{N-1} U\left(s_i, s_j \right) \left[ \left|\vec{r}_j - \vec{r}_i\right| \lt r_\mathrm{cut} \right]\left[b_i \ne b_j\right]
+/// ```
+/// where $`U(s_i, s_j)`$ is the potential computed by [`CutoffPair::evaluator`],
+/// $`s_i`$ is the full set of site properties for site i, $`\vec{r}_i`$ is
+/// the position of site i, $`b_i`$ is the body tag that holds site *i*, and
+/// $`\left[ \  \right]`$ denotes the Iverson bracket.
+///
+/// In other words, [`CutoffPair`] sums the energy for all pairs that are separated
+/// by a distance less than `r_cut` and belong to different bodies.
+///
+/// For the evaluator, use [`Anisotropic`], [`Isotropic`] or your own custom type.
+///
+/// TODO: Reword this when [`CutoffPair`] also implements `SitePairForce`.
+///
+/// [`Anisotropic`]: crate::pairwise::Anisotropic
+/// [`Isotropic`]: crate::pairwise::Isotropic
+///
+/// # Example
+///
+/// Basic usage:
+/// ```
+/// use hoomd_interaction::{
+///     CutoffPair,
+///     pairwise::{Isotropic, LennardJones},
+/// };
+///
+/// let lennard_jones: LennardJones = LennardJones {
+///     epsilon: 1.5,
+///     sigma: 2.0,
+/// };
+/// let evaluator = Isotropic(lennard_jones);
+/// let cutoff_pair = CutoffPair {
+///     r_cut: 5.0,
+///     evaluator,
+/// };
+/// ```
+///
+/// Set a custom potential using a closure:
+/// ```
+/// use hoomd_interaction::{CutoffPair, pairwise::Isotropic};
+///
+/// let cutoff_pair = CutoffPair {
+///     r_cut: 3.0,
+///     evaluator: Isotropic(|r: f64| 1.0 / (r.powi(12))),
+/// };
+/// ```
+///
+/// Implement a custom potential via a type:
+/// ```
+/// use hoomd_interaction::{
+///     CutoffPair,
+///     pairwise::{Isotropic, IsotropicEnergy},
+/// };
+///
+/// struct Custom {
+///     a: f64,
+/// }
+///
+/// impl IsotropicEnergy for Custom {
+///     fn energy(&self, r: f64) -> f64 {
+///         self.a / r.powi(12)
+///     }
+/// }
+///
+/// let custom = Custom { a: 2.0 };
+/// let cutoff_pair = CutoffPair {
+///     r_cut: 2.0,
+///     evaluator: Isotropic(custom),
+/// };
+/// ```
 pub struct CutoffPair<E> {
     /// The distance beyond which all pairwise interactions evaluate to 0.
     pub r_cut: f64,
@@ -82,47 +91,54 @@ pub struct CutoffPair<E> {
 }
 
 impl<E> CutoffPair<E> {
-    /** Compute the pair energy between two sites.
-
-    Use this method to compute an individual term in the total pair energy,
-    subject to the `r_cut` and inter-body checks:
-
-    ```math
-    U\left(s_i, s_j \right) \left[ \left|\vec{r}_j - \vec{r}_i\right| \lt r_\mathrm{cut} \right]\left[b_i \ne b_j\right]
-    ```
-
-    # Example
-    ```
-    use ::approx::assert_relative_eq;
-
-    use hoomd_interaction::{CutoffPair,
-        pairwise::{Isotropic, LennardJones}};
-    use hoomd_microstate::{Body, MicrostateBuilder, Site};
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let lennard_jones: LennardJones = LennardJones { epsilon: 1.0, sigma: 1.0 };
-    let evaluator = Isotropic(lennard_jones);
-    let cutoff_pair = CutoffPair { r_cut: 2.5, evaluator };
-
-    let body_a = Body::point(Cartesian::from([0.0, 0.0]));
-    let body_b = Body::point(Cartesian::from([0.0, 3.0]));
-    let body_c = Body::point(Cartesian::from([0.0, -2.0f64.powf(1.0 / 6.0)]));
-
-    let microstate = MicrostateBuilder::new()
-        .bodies([body_a, body_b, body_c])
-        .try_build()?;
-
-    let sites = microstate.sites();
-    let energy_ab = cutoff_pair.site_pair_energy(&sites[0], &sites[1]);
-    let energy_ac = cutoff_pair.site_pair_energy(&sites[0], &sites[2]);
-
-    assert_eq!(energy_ab, 0.0);
-    assert_relative_eq!(energy_ac, -1.0);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Compute the pair energy between two sites.
+    ///
+    /// Use this method to compute an individual term in the total pair energy,
+    /// subject to the `r_cut` and inter-body checks:
+    ///
+    /// ```math
+    /// U\left(s_i, s_j \right) \left[ \left|\vec{r}_j - \vec{r}_i\right| \lt r_\mathrm{cut} \right]\left[b_i \ne b_j\right]
+    /// ```
+    ///
+    /// # Example
+    /// ```
+    /// use ::approx::assert_relative_eq;
+    ///
+    /// use hoomd_interaction::{
+    ///     CutoffPair,
+    ///     pairwise::{Isotropic, LennardJones},
+    /// };
+    /// use hoomd_microstate::{Body, MicrostateBuilder, Site};
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let lennard_jones: LennardJones = LennardJones {
+    ///     epsilon: 1.0,
+    ///     sigma: 1.0,
+    /// };
+    /// let evaluator = Isotropic(lennard_jones);
+    /// let cutoff_pair = CutoffPair {
+    ///     r_cut: 2.5,
+    ///     evaluator,
+    /// };
+    ///
+    /// let body_a = Body::point(Cartesian::from([0.0, 0.0]));
+    /// let body_b = Body::point(Cartesian::from([0.0, 3.0]));
+    /// let body_c = Body::point(Cartesian::from([0.0, -2.0f64.powf(1.0 / 6.0)]));
+    ///
+    /// let microstate = MicrostateBuilder::new()
+    ///     .bodies([body_a, body_b, body_c])
+    ///     .try_build()?;
+    ///
+    /// let sites = microstate.sites();
+    /// let energy_ab = cutoff_pair.site_pair_energy(&sites[0], &sites[1]);
+    /// let energy_ac = cutoff_pair.site_pair_energy(&sites[0], &sites[2]);
+    ///
+    /// assert_eq!(energy_ab, 0.0);
+    /// assert_relative_eq!(energy_ac, -1.0);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     pub fn site_pair_energy<V, S>(&self, a: &Site<S>, b: &Site<S>) -> f64
     where
@@ -146,43 +162,42 @@ where
     S: Position<Vector = V>,
     V: Vector,
 {
-    /** Compute the total energy of the microstate contributed by functions on pairs of sites.
-
-    # Example
-    ```
-    use hoomd_interaction::{CutoffPair, SitePairEnergy, TotalEnergy,
-        pairwise::{Isotropic, LennardJones}};
-    use hoomd_microstate::{Microstate, Body};
-    use hoomd_microstate::property::{Point, Position};
-    use hoomd_vector::{Cartesian, InnerProduct};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut microstate = Microstate::new();
-    // Place two pairs of particles separated by a large distance.
-    microstate.extend_bodies([Body::point(Cartesian::from([0.0, 0.0])),
-                              Body::point(Cartesian::from([1.0, 0.0])),
-                              Body::point(Cartesian::from([0.0, 5.0])),
-                              Body::point(Cartesian::from([-1.0, 5.0])),
-                            ])?;
-
-    let lennard_jones: LennardJones = LennardJones { epsilon: 1.5,
-        sigma: 1.0 / 2.0_f64.powf(1.0 / 6.0) };
-    let evaluator = Isotropic(lennard_jones);
-    let cutoff_pair = CutoffPair { r_cut: 2.5, evaluator };
-
-    // The potential energy is set to 0 beyond r_cut when computed by `CutoffPair`.
-    let total_energy = cutoff_pair.total_energy(&microstate);
-    assert_eq!(total_energy, -3.0);
-
-    // However, individual pairwise `site_pair_energy` evaluations are always computed.
-    let a = &microstate.sites()[0].properties;
-    let b = &microstate.sites()[2].properties;
-    assert_eq!((*a.position() - *b.position()).norm(), 5.0);
-    assert!(cutoff_pair.evaluator.site_pair_energy(a, b) < 0.0);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Compute the total energy of the microstate contributed by functions on pairs of sites.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_interaction::{CutoffPair, SitePairEnergy, TotalEnergy,
+    /// pairwise::{Isotropic, LennardJones}};
+    /// use hoomd_microstate::{Microstate, Body};
+    /// use hoomd_microstate::property::{Point, Position};
+    /// use hoomd_vector::{Cartesian, InnerProduct};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut microstate = Microstate::new();
+    /// Place two pairs of particles separated by a large distance.
+    /// microstate.extend_bodies([Body::point(Cartesian::from([0.0, 0.0])),
+    /// Body::point(Cartesian::from([1.0, 0.0])),
+    /// Body::point(Cartesian::from([0.0, 5.0])),
+    /// Body::point(Cartesian::from([-1.0, 5.0])),
+    /// ])?;
+    ///
+    /// let lennard_jones: LennardJones = LennardJones { epsilon: 1.5,
+    /// sigma: 1.0 / 2.0_f64.powf(1.0 / 6.0) };
+    /// let evaluator = Isotropic(lennard_jones);
+    /// let cutoff_pair = CutoffPair { r_cut: 2.5, evaluator };
+    ///
+    /// The potential energy is set to 0 beyond r_cut when computed by `CutoffPair`.
+    /// let total_energy = cutoff_pair.total_energy(&microstate);
+    /// assert_eq!(total_energy, -3.0);
+    ///
+    /// However, individual pairwise `site_pair_energy` evaluations are always computed.
+    /// let a = &microstate.sites()[0].properties;
+    /// let b = &microstate.sites()[2].properties;
+    /// assert_eq!((*a.position() - *b.position()).norm(), 5.0);
+    /// assert!(cutoff_pair.evaluator.site_pair_energy(a, b) < 0.0);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn total_energy(&self, microstate: &Microstate<B, S, C>) -> f64 {
         let mut total = 0.0;
@@ -201,35 +216,47 @@ where
     }
 }
 
-/** Evaluate the change in energy contributed by `CutoffPair` when one body is updated.
-
-# Example
-
-```
-use hoomd_interaction::{CutoffPair, DeltaEnergyOne, pairwise::{Boxcar, Isotropic}};
-use hoomd_microstate::{Microstate, Body, property::Point};
-use hoomd_vector::Cartesian;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = Microstate::new();
-microstate.extend_bodies([Body::point(Cartesian::from([0.0, 0.0])),
-    Body::point(Cartesian::from([1.0, 0.0])),
-])?;
-
-
-let epsilon = 2.0;
-let (left,right) = (0.0, 1.5);
-let boxcar = Boxcar { epsilon, left, right };
-let evaluator = Isotropic(boxcar);
-let cutoff_pair = CutoffPair { r_cut: 1.5, evaluator };
-
-let delta_energy = cutoff_pair.delta_energy_one(&microstate, 0,
-    &Body::point([-1.0, 0.0].into()));
-assert_eq!(delta_energy, -2.0);
-# Ok(())
-# }
-```
-*/
+/// Evaluate the change in energy contributed by `CutoffPair` when one body is updated.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::{
+///     CutoffPair, DeltaEnergyOne,
+///     pairwise::{Boxcar, Isotropic},
+/// };
+/// use hoomd_microstate::{Body, Microstate, property::Point};
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.extend_bodies([
+///     Body::point(Cartesian::from([0.0, 0.0])),
+///     Body::point(Cartesian::from([1.0, 0.0])),
+/// ])?;
+///
+/// let epsilon = 2.0;
+/// let (left, right) = (0.0, 1.5);
+/// let boxcar = Boxcar {
+///     epsilon,
+///     left,
+///     right,
+/// };
+/// let evaluator = Isotropic(boxcar);
+/// let cutoff_pair = CutoffPair {
+///     r_cut: 1.5,
+///     evaluator,
+/// };
+///
+/// let delta_energy = cutoff_pair.delta_energy_one(
+///     &microstate,
+///     0,
+///     &Body::point([-1.0, 0.0].into()),
+/// );
+/// assert_eq!(delta_energy, -2.0);
+/// # Ok(())
+/// # }
+/// ```
 impl<V, B, S, C, E> DeltaEnergyOne<B, S, C> for CutoffPair<E>
 where
     E: SitePairEnergy<S>,
@@ -283,35 +310,44 @@ where
     }
 }
 
-/** Evaluate the change in energy contributed by `CutoffPair` when one body is inserted.
-
-# Example
-
-```
-use hoomd_interaction::{CutoffPair, DeltaEnergyInsert, pairwise::{Boxcar, Isotropic}};
-use hoomd_microstate::{Microstate, Body, property::Point};
-use hoomd_vector::Cartesian;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = Microstate::new();
-microstate.extend_bodies([Body::point(Cartesian::from([0.0, 0.0])),
-    Body::point(Cartesian::from([1.0, 0.0])),
-])?;
-
-
-let epsilon = 2.0;
-let (left,right) = (0.0, 1.5);
-let boxcar = Boxcar { epsilon, left, right };
-let evaluator = Isotropic(boxcar);
-let cutoff_pair = CutoffPair { r_cut: 1.5, evaluator };
-
-let delta_energy = cutoff_pair.delta_energy_insert(&microstate,
-    &Body::point([-1.0, 0.0].into()));
-assert_eq!(delta_energy, 2.0);
-# Ok(())
-# }
-```
-*/
+/// Evaluate the change in energy contributed by `CutoffPair` when one body is inserted.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::{
+///     CutoffPair, DeltaEnergyInsert,
+///     pairwise::{Boxcar, Isotropic},
+/// };
+/// use hoomd_microstate::{Body, Microstate, property::Point};
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.extend_bodies([
+///     Body::point(Cartesian::from([0.0, 0.0])),
+///     Body::point(Cartesian::from([1.0, 0.0])),
+/// ])?;
+///
+/// let epsilon = 2.0;
+/// let (left, right) = (0.0, 1.5);
+/// let boxcar = Boxcar {
+///     epsilon,
+///     left,
+///     right,
+/// };
+/// let evaluator = Isotropic(boxcar);
+/// let cutoff_pair = CutoffPair {
+///     r_cut: 1.5,
+///     evaluator,
+/// };
+///
+/// let delta_energy = cutoff_pair
+///     .delta_energy_insert(&microstate, &Body::point([-1.0, 0.0].into()));
+/// assert_eq!(delta_energy, 2.0);
+/// # Ok(())
+/// # }
+/// ```
 impl<V, B, S, C, E> DeltaEnergyInsert<B, S, C> for CutoffPair<E>
 where
     E: SitePairEnergy<S>,
@@ -354,34 +390,43 @@ where
     }
 }
 
-/** Evaluate the change in energy contributed by `CutoffPair` when one body is removed.
-
-# Example
-
-```
-use hoomd_interaction::{CutoffPair, DeltaEnergyRemove, pairwise::{Boxcar, Isotropic}};
-use hoomd_microstate::{Microstate, Body, property::Point};
-use hoomd_vector::Cartesian;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = Microstate::new();
-microstate.extend_bodies([Body::point(Cartesian::from([0.0, 0.0])),
-    Body::point(Cartesian::from([1.0, 0.0])),
-])?;
-
-
-let epsilon = 2.0;
-let (left,right) = (0.0, 1.5);
-let boxcar = Boxcar { epsilon, left, right };
-let evaluator = Isotropic(boxcar);
-let cutoff_pair = CutoffPair { r_cut: 1.5, evaluator };
-
-let delta_energy = cutoff_pair.delta_energy_remove(&microstate,0);
-assert_eq!(delta_energy, -2.0);
-# Ok(())
-# }
-```
-*/
+/// Evaluate the change in energy contributed by `CutoffPair` when one body is removed.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::{
+///     CutoffPair, DeltaEnergyRemove,
+///     pairwise::{Boxcar, Isotropic},
+/// };
+/// use hoomd_microstate::{Body, Microstate, property::Point};
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.extend_bodies([
+///     Body::point(Cartesian::from([0.0, 0.0])),
+///     Body::point(Cartesian::from([1.0, 0.0])),
+/// ])?;
+///
+/// let epsilon = 2.0;
+/// let (left, right) = (0.0, 1.5);
+/// let boxcar = Boxcar {
+///     epsilon,
+///     left,
+///     right,
+/// };
+/// let evaluator = Isotropic(boxcar);
+/// let cutoff_pair = CutoffPair {
+///     r_cut: 1.5,
+///     evaluator,
+/// };
+///
+/// let delta_energy = cutoff_pair.delta_energy_remove(&microstate, 0);
+/// assert_eq!(delta_energy, -2.0);
+/// # Ok(())
+/// # }
+/// ```
 impl<V, B, S, C, E> DeltaEnergyRemove<B, S, C> for CutoffPair<E>
 where
     E: SitePairEnergy<S>,

--- a/hoomd-interaction/src/cutoff_pair_overlap.rs
+++ b/hoomd-interaction/src/cutoff_pair_overlap.rs
@@ -51,7 +51,23 @@ use hoomd_vector::Vector;
 ///
 /// Hard shape:
 ///
-/// TODO: Example
+/// ```
+/// use hoomd_geometry::shape::Ellipse;
+/// use hoomd_interaction::{CutoffPairOverlap, pairwise::HardShape};
+/// use hoomd_microstate::property::Point;
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let ellipse = Ellipse {
+///     semi_axes: [4.0.try_into()?, 1.0.try_into()?],
+/// };
+/// let hard_ellipse = CutoffPairOverlap {
+///     r_cut: 8.0,
+///     evaluator: HardShape(ellipse),
+/// };
+/// # Ok(())
+/// # }
+/// ```
 pub struct CutoffPairOverlap<E> {
     /// The distance beyond which all pairwise interactions evaluate to 0.
     pub r_cut: f64,

--- a/hoomd-interaction/src/cutoff_pair_overlap.rs
+++ b/hoomd-interaction/src/cutoff_pair_overlap.rs
@@ -1,56 +1,57 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement `CutoffPairOverlap`
- */
+//! Implement `CutoffPairOverlap`
 
 use crate::{DeltaEnergyInsert, DeltaEnergyOne, DeltaEnergyRemove, SitePairOverlap, TotalEnergy};
 use hoomd_microstate::{Body, Microstate, Transform, boundary::Wrap, property::Position};
 use hoomd_vector::Vector;
 
-/** Short-ranged hard overlaps between pairs of sites.
-
-Use [`CutoffPairOverlap`] instead of [`CutoffPair`] for hard interactions.
-[`CutoffPairOverlap`] does not need to compute the initial energy and it can
-short-circuit energy evaluations when the first overlap is detected. Both of
-these lead to improved performance.
-
-Given an evaluator that implements [`SitePairOverlap`], [`CutoffPairOverlap`]
-represents:
-
-```math
-U_\mathrm{total} = \sum_{i=0}^{N-1}\sum_{j=i+1}^{N-1} U\left(s_i, s_j \right) \left[ \left|\vec{r}_j - \vec{r}_i\right| \lt r_\mathrm{cut} \right]\left[b_i \ne b_j\right]
-```
-where $`U(s_i, s_j)`$ is $`\infty`$ when [`CutoffPairOverlap::evaluator`] finds an
-overlap and 0 when it does not,
-$`s_i`$ is the full set of site properties for site i, $`\vec{r}_i`$ is
-the position of site i, $`b_i`$ is the body tag that holds site *i*, and
-$`\left[ \  \right]`$ denotes the Iverson bracket.
-
-In other words, [`CutoffPairOverlap`] checks for overlaps between all site pairs that
-are separated by a distance less than `r_cut` and belong to different bodies.
-
-For the evaluator, use [`AlwaysTrue`], [`HardShape`] or your own custom type.
-
-[`CutoffPair`]: crate::CutoffPair
-[`AlwaysTrue`]: crate::pairwise::AlwaysTrue
-[`HardShape`]: crate::pairwise::HardShape
-
-# Example
-
-Hard sphere:
-```
-use hoomd_interaction::{CutoffPairOverlap, pairwise::AlwaysTrue};
-use hoomd_microstate::property::Point;
-use hoomd_vector::Cartesian;
-
-let hard_sphere = CutoffPairOverlap { r_cut: 1.0, evaluator: AlwaysTrue };
-```
-
-Hard shape:
-
-TODO: Example
-*/
+/// Short-ranged hard overlaps between pairs of sites.
+///
+/// Use [`CutoffPairOverlap`] instead of [`CutoffPair`] for hard interactions.
+/// [`CutoffPairOverlap`] does not need to compute the initial energy and it can
+/// short-circuit energy evaluations when the first overlap is detected. Both of
+/// these lead to improved performance.
+///
+/// Given an evaluator that implements [`SitePairOverlap`], [`CutoffPairOverlap`]
+/// represents:
+///
+/// ```math
+/// U_\mathrm{total} = \sum_{i=0}^{N-1}\sum_{j=i+1}^{N-1} U\left(s_i, s_j \right) \left[ \left|\vec{r}_j - \vec{r}_i\right| \lt r_\mathrm{cut} \right]\left[b_i \ne b_j\right]
+/// ```
+/// where $`U(s_i, s_j)`$ is $`\infty`$ when [`CutoffPairOverlap::evaluator`] finds an
+/// overlap and 0 when it does not,
+/// $`s_i`$ is the full set of site properties for site i, $`\vec{r}_i`$ is
+/// the position of site i, $`b_i`$ is the body tag that holds site *i*, and
+/// $`\left[ \  \right]`$ denotes the Iverson bracket.
+///
+/// In other words, [`CutoffPairOverlap`] checks for overlaps between all site pairs that
+/// are separated by a distance less than `r_cut` and belong to different bodies.
+///
+/// For the evaluator, use [`AlwaysTrue`], [`HardShape`] or your own custom type.
+///
+/// [`CutoffPair`]: crate::CutoffPair
+/// [`AlwaysTrue`]: crate::pairwise::AlwaysTrue
+/// [`HardShape`]: crate::pairwise::HardShape
+///
+/// # Example
+///
+/// Hard sphere:
+/// ```
+/// use hoomd_interaction::{CutoffPairOverlap, pairwise::AlwaysTrue};
+/// use hoomd_microstate::property::Point;
+/// use hoomd_vector::Cartesian;
+///
+/// let hard_sphere = CutoffPairOverlap {
+///     r_cut: 1.0,
+///     evaluator: AlwaysTrue,
+/// };
+/// ```
+///
+/// Hard shape:
+///
+/// TODO: Example
 pub struct CutoffPairOverlap<E> {
     /// The distance beyond which all pairwise interactions evaluate to 0.
     pub r_cut: f64,
@@ -65,34 +66,38 @@ where
     S: Position<Vector = V>,
     V: Vector,
 {
-    /** Compute the total energy of the microstate contributed by functions on pairs of sites.
-
-    # Example
-
-    ```
-    use hoomd_interaction::{CutoffPairOverlap, TotalEnergy, pairwise::AlwaysTrue};
-    use hoomd_microstate::{Microstate, Body};
-    use hoomd_microstate::property::Point;
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut microstate = Microstate::new();
-    microstate.extend_bodies([Body::point(Cartesian::from([0.0, 0.0])),
-                              Body::point(Cartesian::from([0.5, 0.0])),
-                            ])?;
-
-    let hard_sphere = CutoffPairOverlap { r_cut: 1.0, evaluator: AlwaysTrue };
-
-    let total_energy = hard_sphere.total_energy(&microstate);
-    assert_eq!(total_energy, f64::INFINITY);
-
-    microstate.update_body_properties(0, Point::new([0.0, -2.0].into()));
-    let total_energy = hard_sphere.total_energy(&microstate);
-    assert_eq!(total_energy, 0.0);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Compute the total energy of the microstate contributed by functions on pairs of sites.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_interaction::{
+    ///     CutoffPairOverlap, TotalEnergy, pairwise::AlwaysTrue,
+    /// };
+    /// use hoomd_microstate::{Body, Microstate, property::Point};
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut microstate = Microstate::new();
+    /// microstate.extend_bodies([
+    ///     Body::point(Cartesian::from([0.0, 0.0])),
+    ///     Body::point(Cartesian::from([0.5, 0.0])),
+    /// ])?;
+    ///
+    /// let hard_sphere = CutoffPairOverlap {
+    ///     r_cut: 1.0,
+    ///     evaluator: AlwaysTrue,
+    /// };
+    ///
+    /// let total_energy = hard_sphere.total_energy(&microstate);
+    /// assert_eq!(total_energy, f64::INFINITY);
+    ///
+    /// microstate.update_body_properties(0, Point::new([0.0, -2.0].into()));
+    /// let total_energy = hard_sphere.total_energy(&microstate);
+    /// assert_eq!(total_energy, 0.0);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn total_energy(&self, microstate: &Microstate<B, S, C>) -> f64 {
         for site_i in microstate.sites() {
@@ -113,35 +118,45 @@ where
     }
 }
 
-/** Evaluate the change in energy contributed by `CutoffPairOverlap` when one body is updated.
-
-# Example
-
-```
-use hoomd_interaction::{CutoffPairOverlap, DeltaEnergyOne, pairwise::AlwaysTrue};
-use hoomd_microstate::{Microstate, Body};
-use hoomd_microstate::property::Point;
-use hoomd_vector::Cartesian;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = Microstate::new();
-microstate.extend_bodies([Body::point(Cartesian::from([0.0, 0.0])),
-                          Body::point(Cartesian::from([2.0, 0.0])),
-                        ])?;
-
-let hard_sphere = CutoffPairOverlap { r_cut: 1.0, evaluator: AlwaysTrue };
-
-let delta_energy = hard_sphere.delta_energy_one(&microstate, 1,
-    &Body::point([0.5, 0.0].into()));
-assert_eq!(delta_energy, f64::INFINITY);
-
-let delta_energy = hard_sphere.delta_energy_one(&microstate, 1,
-    &Body::point([1.5, 0.0].into()));
-assert_eq!(delta_energy, 0.0);
-# Ok(())
-# }
-```
-*/
+/// Evaluate the change in energy contributed by `CutoffPairOverlap` when one body is updated.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::{
+///     CutoffPairOverlap, DeltaEnergyOne, pairwise::AlwaysTrue,
+/// };
+/// use hoomd_microstate::{Body, Microstate, property::Point};
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.extend_bodies([
+///     Body::point(Cartesian::from([0.0, 0.0])),
+///     Body::point(Cartesian::from([2.0, 0.0])),
+/// ])?;
+///
+/// let hard_sphere = CutoffPairOverlap {
+///     r_cut: 1.0,
+///     evaluator: AlwaysTrue,
+/// };
+///
+/// let delta_energy = hard_sphere.delta_energy_one(
+///     &microstate,
+///     1,
+///     &Body::point([0.5, 0.0].into()),
+/// );
+/// assert_eq!(delta_energy, f64::INFINITY);
+///
+/// let delta_energy = hard_sphere.delta_energy_one(
+///     &microstate,
+///     1,
+///     &Body::point([1.5, 0.0].into()),
+/// );
+/// assert_eq!(delta_energy, 0.0);
+/// # Ok(())
+/// # }
+/// ```
 impl<V, B, S, C, E> DeltaEnergyOne<B, S, C> for CutoffPairOverlap<E>
 where
     E: SitePairOverlap<S>,
@@ -193,34 +208,36 @@ where
     }
 }
 
-/** Evaluate the change in energy contributed by `CutoffPairOverlap` when one body is inserted.
-
-# Example
-
-```
-use hoomd_interaction::{CutoffPairOverlap, DeltaEnergyInsert, pairwise::AlwaysTrue};
-use hoomd_microstate::{Microstate, Body};
-use hoomd_microstate::property::Point;
-use hoomd_vector::Cartesian;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = Microstate::new();
-microstate.extend_bodies([Body::point(Cartesian::from([0.0, 0.0])),
-                        ])?;
-
-let hard_sphere = CutoffPairOverlap { r_cut: 1.0, evaluator: AlwaysTrue };
-
-let delta_energy = hard_sphere.delta_energy_insert(&microstate,
-    &Body::point([0.5, 0.0].into()));
-assert_eq!(delta_energy, f64::INFINITY);
-
-let delta_energy = hard_sphere.delta_energy_insert(&microstate,
-    &Body::point([1.5, 0.0].into()));
-assert_eq!(delta_energy, 0.0);
-# Ok(())
-# }
-```
-*/
+/// Evaluate the change in energy contributed by `CutoffPairOverlap` when one body is inserted.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::{
+///     CutoffPairOverlap, DeltaEnergyInsert, pairwise::AlwaysTrue,
+/// };
+/// use hoomd_microstate::{Body, Microstate, property::Point};
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.extend_bodies([Body::point(Cartesian::from([0.0, 0.0]))])?;
+///
+/// let hard_sphere = CutoffPairOverlap {
+///     r_cut: 1.0,
+///     evaluator: AlwaysTrue,
+/// };
+///
+/// let delta_energy = hard_sphere
+///     .delta_energy_insert(&microstate, &Body::point([0.5, 0.0].into()));
+/// assert_eq!(delta_energy, f64::INFINITY);
+///
+/// let delta_energy = hard_sphere
+///     .delta_energy_insert(&microstate, &Body::point([1.5, 0.0].into()));
+/// assert_eq!(delta_energy, 0.0);
+/// # Ok(())
+/// # }
+/// ```
 impl<V, B, S, C, E> DeltaEnergyInsert<B, S, C> for CutoffPairOverlap<E>
 where
     E: SitePairOverlap<S>,
@@ -269,30 +286,34 @@ where
     }
 }
 
-/** Evaluate the change in energy contributed by `CutoffPair` when one body is removed.
-
-# Example
-
-```
-use hoomd_interaction::{CutoffPairOverlap, DeltaEnergyRemove, pairwise::AlwaysTrue};
-use hoomd_microstate::{Microstate, Body};
-use hoomd_microstate::property::Point;
-use hoomd_vector::Cartesian;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = Microstate::new();
-microstate.extend_bodies([Body::point(Cartesian::from([0.0, 0.0])),
-                          Body::point(Cartesian::from([2.0, 0.0])),
-                        ])?;
-
-let hard_sphere = CutoffPairOverlap { r_cut: 1.0, evaluator: AlwaysTrue };
-
-let delta_energy = hard_sphere.delta_energy_remove(&microstate, 1);
-assert_eq!(delta_energy, 0.0);
-# Ok(())
-# }
-```
-*/
+/// Evaluate the change in energy contributed by `CutoffPair` when one body is removed.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::{
+///     CutoffPairOverlap, DeltaEnergyRemove, pairwise::AlwaysTrue,
+/// };
+/// use hoomd_microstate::{Body, Microstate, property::Point};
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.extend_bodies([
+///     Body::point(Cartesian::from([0.0, 0.0])),
+///     Body::point(Cartesian::from([2.0, 0.0])),
+/// ])?;
+///
+/// let hard_sphere = CutoffPairOverlap {
+///     r_cut: 1.0,
+///     evaluator: AlwaysTrue,
+/// };
+///
+/// let delta_energy = hard_sphere.delta_energy_remove(&microstate, 1);
+/// assert_eq!(delta_energy, 0.0);
+/// # Ok(())
+/// # }
+/// ```
 impl<V, B, S, C, E> DeltaEnergyRemove<B, S, C> for CutoffPairOverlap<E>
 where
     E: SitePairOverlap<S>,

--- a/hoomd-interaction/src/external.rs
+++ b/hoomd-interaction/src/external.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! External interactions.
- */
+//! External interactions.
 
 mod linear;
 pub use linear::Linear;

--- a/hoomd-interaction/src/external/linear.rs
+++ b/hoomd-interaction/src/external/linear.rs
@@ -1,39 +1,38 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement [`Linear`]
- */
+//! Implement [`Linear`]
 
 use super::super::SiteEnergy;
 use hoomd_microstate::property::Position;
 use hoomd_vector::{InnerProduct, Unit};
 
-/** Linear potential based on position.
-
-```math
-U = \alpha \cdot \vec{n} \cdot ( \vec{r} - \vec{p} )
-```
-
-Computes a linear external potential at a point in space relative to the plane
-origin `p`, plane normal `n`, and the interaction strength `alpha`.
-
-# Example
-
-Basic usage:
-
-```
-use hoomd_interaction::external::Linear;
-use hoomd_vector::{Cartesian, Unit};
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let linear = Linear { alpha: 2.0,
-    plane_origin: [0.0, -10.0].into(),
-    plane_normal: [0.0, 1.0].try_into()?,
-};
-# Ok(())
-# }
-```
-*/
+/// Linear potential based on position.
+///
+/// ```math
+/// U = \alpha \cdot \vec{n} \cdot ( \vec{r} - \vec{p} )
+/// ```
+///
+/// Computes a linear external potential at a point in space relative to the plane
+/// origin `p`, plane normal `n`, and the interaction strength `alpha`.
+///
+/// # Example
+///
+/// Basic usage:
+///
+/// ```
+/// use hoomd_interaction::external::Linear;
+/// use hoomd_vector::{Cartesian, Unit};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let linear = Linear {
+///     alpha: 2.0,
+///     plane_origin: [0.0, -10.0].into(),
+///     plane_normal: [0.0, 1.0].try_into()?,
+/// };
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Linear<V> {
     /// Interaction strength *(\[energy\] \[length\]^(-1))*.
@@ -48,26 +47,26 @@ impl<V> Linear<V>
 where
     V: InnerProduct,
 {
-    /** Compute the energy of a point in the linear field.
-
-    # Example
-
-    ```
-    use hoomd_interaction::external::Linear;
-    use hoomd_vector::{Cartesian, Unit};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let linear = Linear { alpha: 2.0,
-        plane_origin: [0.0, -10.0].into(),
-        plane_normal: [0.0, 1.0].try_into()?,
-    };
-
-    let energy = linear.energy(&[0.0, 0.0].into());
-    assert_eq!(energy, 20.0);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Compute the energy of a point in the linear field.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_interaction::external::Linear;
+    /// use hoomd_vector::{Cartesian, Unit};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let linear = Linear {
+    ///     alpha: 2.0,
+    ///     plane_origin: [0.0, -10.0].into(),
+    ///     plane_normal: [0.0, 1.0].try_into()?,
+    /// };
+    ///
+    /// let energy = linear.energy(&[0.0, 0.0].into());
+    /// assert_eq!(energy, 20.0);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     #[must_use]
     pub fn energy(&self, r: &V) -> f64 {

--- a/hoomd-interaction/src/hamiltonian.rs
+++ b/hoomd-interaction/src/hamiltonian.rs
@@ -1,47 +1,61 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement `*Energy` for varying lengths of tuples.
- */
+//! Implement `*Energy` for varying lengths of tuples.
 
 use super::{DeltaEnergyInsert, DeltaEnergyOne, TotalEnergy};
 use hoomd_microstate::{Body, Microstate};
 
-/** Sum two delta energy terms.
-
-# Example
-
-```
-use hoomd_interaction::{CutoffPair, DeltaEnergyOne, Single, external::Linear, pairwise::{Boxcar, Isotropic}};
-use hoomd_microstate::{Microstate, Body, property::Point};
-use hoomd_vector::Cartesian;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = Microstate::new();
-microstate.extend_bodies([Body::point(Cartesian::from([0.0, 0.0])),
-    Body::point(Cartesian::from([1.0, 0.0])),
-])?;
-
-
-let epsilon = 2.0;
-let (left,right) = (0.0, 1.5);
-let boxcar = Boxcar { epsilon, left, right };
-let evaluator = Isotropic(boxcar);
-let cutoff_pair = CutoffPair { r_cut: right, evaluator };
-
-let linear = Single(Linear{ alpha: 10.0,
-    plane_origin: Cartesian::default(),
-    plane_normal: [0.0, 1.0].try_into()? });
-
-let hamiltonian = (cutoff_pair, linear);
-
-let delta_energy = hamiltonian.delta_energy_one(&microstate, 0,
-    &Body::point([-1.0, 0.0].into()));
-assert_eq!(delta_energy, -2.0);
-# Ok(())
-# }
-```
-*/
+/// Sum two delta energy terms.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::{
+///     CutoffPair, DeltaEnergyOne, Single,
+///     external::Linear,
+///     pairwise::{Boxcar, Isotropic},
+/// };
+/// use hoomd_microstate::{Body, Microstate, property::Point};
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.extend_bodies([
+///     Body::point(Cartesian::from([0.0, 0.0])),
+///     Body::point(Cartesian::from([1.0, 0.0])),
+/// ])?;
+///
+/// let epsilon = 2.0;
+/// let (left, right) = (0.0, 1.5);
+/// let boxcar = Boxcar {
+///     epsilon,
+///     left,
+///     right,
+/// };
+/// let evaluator = Isotropic(boxcar);
+/// let cutoff_pair = CutoffPair {
+///     r_cut: right,
+///     evaluator,
+/// };
+///
+/// let linear = Single(Linear {
+///     alpha: 10.0,
+///     plane_origin: Cartesian::default(),
+///     plane_normal: [0.0, 1.0].try_into()?,
+/// });
+///
+/// let hamiltonian = (cutoff_pair, linear);
+///
+/// let delta_energy = hamiltonian.delta_energy_one(
+///     &microstate,
+///     0,
+///     &Body::point([-1.0, 0.0].into()),
+/// );
+/// assert_eq!(delta_energy, -2.0);
+/// # Ok(())
+/// # }
+/// ```
 impl<B, S, C, E1, E2> DeltaEnergyOne<B, S, C> for (E1, E2)
 where
     E1: DeltaEnergyOne<B, S, C>,
@@ -66,43 +80,52 @@ where
     }
 }
 
-/** Sum two total energy terms.
-
-# Example
-
-```
-use hoomd_interaction::{CutoffPair, Single, TotalEnergy,
-    external::Linear,
-    pairwise::{Boxcar, Isotropic}};
-use hoomd_microstate::{Microstate, Body, property::Point};
-use hoomd_vector::Cartesian;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = Microstate::new();
-microstate.extend_bodies([
-    Body::point(Cartesian::from([0.0, 4.0])),
-    Body::point(Cartesian::from([1.0, 4.0])),
-])?;
-
-
-let epsilon = 2.0;
-let (left,right) = (0.0, 1.5);
-let boxcar = Boxcar { epsilon, left, right };
-let evaluator = Isotropic(boxcar);
-let cutoff_pair = CutoffPair { r_cut: right, evaluator };
-
-let linear = Single(Linear{ alpha: 1.0,
-    plane_origin: Cartesian::default(),
-    plane_normal: [0.0, 1.0].try_into()? });
-
-let hamiltonian = (cutoff_pair, linear);
-
-let total_energy = hamiltonian.total_energy(&microstate);
-assert_eq!(total_energy, 10.0);
-# Ok(())
-# }
-```
-*/
+/// Sum two total energy terms.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::{
+///     CutoffPair, Single, TotalEnergy,
+///     external::Linear,
+///     pairwise::{Boxcar, Isotropic},
+/// };
+/// use hoomd_microstate::{Body, Microstate, property::Point};
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.extend_bodies([
+///     Body::point(Cartesian::from([0.0, 4.0])),
+///     Body::point(Cartesian::from([1.0, 4.0])),
+/// ])?;
+///
+/// let epsilon = 2.0;
+/// let (left, right) = (0.0, 1.5);
+/// let boxcar = Boxcar {
+///     epsilon,
+///     left,
+///     right,
+/// };
+/// let evaluator = Isotropic(boxcar);
+/// let cutoff_pair = CutoffPair {
+///     r_cut: right,
+///     evaluator,
+/// };
+///
+/// let linear = Single(Linear {
+///     alpha: 1.0,
+///     plane_origin: Cartesian::default(),
+///     plane_normal: [0.0, 1.0].try_into()?,
+/// });
+///
+/// let hamiltonian = (cutoff_pair, linear);
+///
+/// let total_energy = hamiltonian.total_energy(&microstate);
+/// assert_eq!(total_energy, 10.0);
+/// # Ok(())
+/// # }
+/// ```
 impl<M, E1, E2> TotalEnergy<M> for (E1, E2)
 where
     E1: TotalEnergy<M>,
@@ -118,42 +141,50 @@ where
     }
 }
 
-/** Sum two delta energy insert.
-
-# Example
-
-```
-use hoomd_interaction::{CutoffPair, Single, DeltaEnergyInsert,
-    external::Linear,
-    pairwise::{Boxcar, Isotropic}};
-use hoomd_microstate::{Microstate, Body, property::Point};
-use hoomd_vector::Cartesian;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = Microstate::new();
-microstate.extend_bodies([
-    Body::point(Cartesian::from([0.0, 4.0])),
-])?;
-
-let epsilon = 2.0;
-let (left,right) = (0.0, 1.5);
-let boxcar = Boxcar { epsilon, left, right };
-let evaluator = Isotropic(boxcar);
-let cutoff_pair = CutoffPair { r_cut: right, evaluator };
-
-let linear = Single(Linear{ alpha: 1.0,
-    plane_origin: Cartesian::default(),
-    plane_normal: [0.0, 1.0].try_into()? });
-
-let hamiltonian = (cutoff_pair, linear);
-
-let new_body = Body::point(Cartesian::from([1.0, 4.0]));
-let delta_energy = hamiltonian.delta_energy_insert(&microstate, &new_body);
-assert_eq!(delta_energy, 6.0);
-# Ok(())
-# }
-```
-*/
+/// Sum two delta energy insert.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::{
+///     CutoffPair, DeltaEnergyInsert, Single,
+///     external::Linear,
+///     pairwise::{Boxcar, Isotropic},
+/// };
+/// use hoomd_microstate::{Body, Microstate, property::Point};
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.extend_bodies([Body::point(Cartesian::from([0.0, 4.0]))])?;
+///
+/// let epsilon = 2.0;
+/// let (left, right) = (0.0, 1.5);
+/// let boxcar = Boxcar {
+///     epsilon,
+///     left,
+///     right,
+/// };
+/// let evaluator = Isotropic(boxcar);
+/// let cutoff_pair = CutoffPair {
+///     r_cut: right,
+///     evaluator,
+/// };
+///
+/// let linear = Single(Linear {
+///     alpha: 1.0,
+///     plane_origin: Cartesian::default(),
+///     plane_normal: [0.0, 1.0].try_into()?,
+/// });
+///
+/// let hamiltonian = (cutoff_pair, linear);
+///
+/// let new_body = Body::point(Cartesian::from([1.0, 4.0]));
+/// let delta_energy = hamiltonian.delta_energy_insert(&microstate, &new_body);
+/// assert_eq!(delta_energy, 6.0);
+/// # Ok(())
+/// # }
+/// ```
 impl<B, S, C, E1, E2> DeltaEnergyInsert<B, S, C> for (E1, E2)
 where
     E1: DeltaEnergyInsert<B, S, C>,

--- a/hoomd-interaction/src/lib.rs
+++ b/hoomd-interaction/src/lib.rs
@@ -48,7 +48,6 @@ pub use zero::Zero;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut microstate = Microstate::new();
-/// Place two pairs of particles separated by a large distance.
 /// microstate.extend_bodies([Body::point(Cartesian::from([0.0, 0.0])),
 /// Body::point(Cartesian::from([1.0, 0.0])),
 /// Body::point(Cartesian::from([0.0, 5.0])),
@@ -81,7 +80,7 @@ pub trait TotalEnergy<M> {
 /// compute system-wide properties.
 ///
 /// The generic type names are:
-/// `S`: The [`Site::properties`](hoomd_microstate::Site) type.
+/// * `S`: The [`Site::properties`](hoomd_microstate::Site) type.
 ///
 /// ## Examples
 ///
@@ -142,7 +141,7 @@ pub trait SiteEnergy<S> {
 /// compute system-wide properties.
 ///
 /// The generic type names are:
-/// `S`: The [`Site::properties`](hoomd_microstate::Site) type.
+/// * `S`: The [`Site::properties`](hoomd_microstate::Site) type.
 ///
 /// ## Examples
 ///
@@ -162,8 +161,8 @@ pub trait SiteEnergy<S> {
 /// where
 /// S: Position<Vector = Cartesian<2>>
 /// {
+/// /// Check for overlaps of a disk with a circular boundary.
 /// fn site_overlap(&self, site_properties: &S) -> bool {
-/// Check for overlaps of a disk with a circular boundary.
 /// site_properties.position().distance(&Cartesian::default()) > self.r - 0.5
 /// }
 /// }
@@ -200,7 +199,7 @@ pub trait SiteOverlap<S> {
 /// properties.
 ///
 /// The generic type names are:
-/// `S`: The [`Site::properties`](hoomd_microstate::Site) type.
+/// * `S`: The [`Site::properties`](hoomd_microstate::Site) type.
 ///
 /// [`Isotropic`]: pairwise::Isotropic
 /// [`Anisotropic`]: pairwise::Isotropic
@@ -266,7 +265,7 @@ pub trait SitePairEnergy<S> {
 /// simulations or to compute system-wide properties.
 ///
 /// The generic type names are:
-/// `S`: The [`Site::properties`](hoomd_microstate::Site) type.
+/// * `S`: The [`Site::properties`](hoomd_microstate::Site) type.
 ///
 /// [`HardShape`]: pairwise::HardShape
 ///
@@ -380,9 +379,9 @@ pub trait SitePairOverlap<S> {
 /// implements `DeltaEnergyOne` to efficiently compute the change in energy.
 ///
 /// The generic type names are:
-/// `B`: The [`Body::properties`](hoomd_microstate::Body) type.
-/// `S`: The [`Site::properties`](hoomd_microstate::Site) type.
-/// `C`: The [`boundary`](hoomd_microstate::boundary) condition type.
+/// * `B`: The [`Body::properties`](hoomd_microstate::Body) type.
+/// * `S`: The [`Site::properties`](hoomd_microstate::Site) type.
+/// * `C`: The [`boundary`](hoomd_microstate::boundary) condition type.
 ///
 /// See the [Implementors](#implementors) section below for examples.
 pub trait DeltaEnergyOne<B, S, C> {
@@ -412,9 +411,9 @@ pub trait DeltaEnergyOne<B, S, C> {
 /// implements `DeltaEnergyInsert` to efficiently compute the change in energy.
 ///
 /// The generic type names are:
-/// `B`: The [`Body::properties`](hoomd_microstate::Body) type.
-/// `S`: The [`Site::properties`](hoomd_microstate::Site) type.
-/// `C`: The [`boundary`](hoomd_microstate::boundary) condition type.
+/// * `B`: The [`Body::properties`](hoomd_microstate::Body) type.
+/// * `S`: The [`Site::properties`](hoomd_microstate::Site) type.
+/// * `C`: The [`boundary`](hoomd_microstate::boundary) condition type.
 ///
 /// See the [Implementors](#implementors) section below for examples.
 pub trait DeltaEnergyInsert<B, S, C> {
@@ -442,9 +441,9 @@ pub trait DeltaEnergyInsert<B, S, C> {
 /// implements `DeltaEnergyRemove` to efficiently compute the change in energy.
 ///
 /// The generic type names are:
-/// `B`: The [`Body::properties`](hoomd_microstate::Body) type.
-/// `S`: The [`Site::properties`](hoomd_microstate::Site) type.
-/// `C`: The [`boundary`](hoomd_microstate::boundary) condition type.
+/// * `B`: The [`Body::properties`](hoomd_microstate::Body) type.
+/// * `S`: The [`Site::properties`](hoomd_microstate::Site) type.
+/// * `C`: The [`boundary`](hoomd_microstate::boundary) condition type.
 ///
 /// See the [Implementors](#implementors) section below for examples.
 pub trait DeltaEnergyRemove<B, S, C> {

--- a/hoomd-interaction/src/lib.rs
+++ b/hoomd-interaction/src/lib.rs
@@ -8,10 +8,9 @@
     html_logo_url = "https://hoomd-blue.readthedocs.io/en/latest/_static/hoomdblue-logo-favicon.svg"
 )]
 
-/*! Particle interactions and physical models that apply to microstates.
-
-TODO: Expand documentation.
- */
+//! Particle interactions and physical models that apply to microstates.
+//!
+//! TODO: Expand documentation.
 
 use hoomd_microstate::{Body, Microstate};
 
@@ -31,350 +30,373 @@ pub use single::Single;
 pub use single_overlap::SingleOverlap;
 pub use zero::Zero;
 
-/** Compute the total energy of a potential applied to the microstate.
-
-The `TotalEnergy` trait describes a type that can compute the energy of a
-given microstate. Depending on the type, `total_energy` might compute the total
-potential energy of the system or a single term, such as the Lennard-Jones
-potential energy.
-
-# Example
-
-```
-use hoomd_interaction::{CutoffPair, SitePairEnergy, TotalEnergy,
-    pairwise::{Isotropic, LennardJones}};
-use hoomd_microstate::{Microstate, Body};
-use hoomd_microstate::property::{Point, Position};
-use hoomd_vector::{Cartesian, Vector};
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = Microstate::new();
-// Place two pairs of particles separated by a large distance.
-microstate.extend_bodies([Body::point(Cartesian::from([0.0, 0.0])),
-                          Body::point(Cartesian::from([1.0, 0.0])),
-                          Body::point(Cartesian::from([0.0, 5.0])),
-                          Body::point(Cartesian::from([-1.0, 5.0])),
-                        ])?;
-
-let lennard_jones: LennardJones = LennardJones { epsilon: 1.5, sigma: 1.0 / 2.0_f64.powf(1.0 / 6.0) };
-let lennard_jones = Isotropic(lennard_jones);
-let cutoff_pair = CutoffPair { r_cut: 2.5, evaluator: lennard_jones, };
-
-let total_energy = cutoff_pair.total_energy(&microstate);
-assert_eq!(total_energy, -3.0);
-# Ok(())
-# }
-```
-*/
+/// Compute the total energy of a potential applied to the microstate.
+///
+/// The `TotalEnergy` trait describes a type that can compute the energy of a
+/// given microstate. Depending on the type, `total_energy` might compute the total
+/// potential energy of the system or a single term, such as the Lennard-Jones
+/// potential energy.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::{CutoffPair, SitePairEnergy, TotalEnergy,
+/// pairwise::{Isotropic, LennardJones}};
+/// use hoomd_microstate::{Microstate, Body};
+/// use hoomd_microstate::property::{Point, Position};
+/// use hoomd_vector::{Cartesian, Vector};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// Place two pairs of particles separated by a large distance.
+/// microstate.extend_bodies([Body::point(Cartesian::from([0.0, 0.0])),
+/// Body::point(Cartesian::from([1.0, 0.0])),
+/// Body::point(Cartesian::from([0.0, 5.0])),
+/// Body::point(Cartesian::from([-1.0, 5.0])),
+/// ])?;
+///
+/// let lennard_jones: LennardJones = LennardJones { epsilon: 1.5, sigma: 1.0 / 2.0_f64.powf(1.0 / 6.0) };
+/// let lennard_jones = Isotropic(lennard_jones);
+/// let cutoff_pair = CutoffPair { r_cut: 2.5, evaluator: lennard_jones, };
+///
+/// let total_energy = cutoff_pair.total_energy(&microstate);
+/// assert_eq!(total_energy, -3.0);
+/// # Ok(())
+/// # }
+/// ```
 pub trait TotalEnergy<M> {
     /// Compute the energy.
     #[must_use]
     fn total_energy(&self, microstate: &M) -> f64;
 }
 
-/** Compute the energy contribution of a single site.
-
-The `SiteEnergy` trait describes a type that can compute the energy contribution
-of a site to the system's total energy *as a function only of that site's
-properties*.
-
-The [`external`] module provides a number of commonly used implementations.
-Combine them with [`Single`] newtype for use with MC and MD simulations or to
-compute system-wide properties.
-
-The generic type names are:
-* `S`: The [`Site::properties`](hoomd_microstate::Site) type.
-
-## Examples
-
-Implement a custom site energy method:
-
-```
-use hoomd_interaction::{Single, TotalEnergy, SiteEnergy};
-use hoomd_microstate::{Microstate, Body};
-use hoomd_microstate::property::{Point, Position};
-use hoomd_vector::Cartesian;
-
-struct Custom {
-    a: f64,
-    b: f64,
-}
-
-impl<S> SiteEnergy<S> for Custom
-where
-    S: Position<Vector = Cartesian<2>>
-{
-    fn site_energy(&self, site_properties: &S) -> f64 {
-        self.a * (site_properties.position()[0] / self.b).cos()
-    }
-}
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = Microstate::new();
-microstate.extend_bodies([Body::point(Cartesian::from([1.0, 0.0])),
-                          Body::point(Cartesian::from([-1.0, 2.0]))])?;
-
-let custom_evaluator = Custom { a: 1.0, b: 10.0 };
-let site_energy = custom_evaluator.site_energy(&microstate.sites()[0].properties);
-
-let custom = Single(custom_evaluator);
-let total_energy = custom.total_energy(&microstate);
-# Ok(())
-# }
-```
-*/
+/// Compute the energy contribution of a single site.
+///
+/// The `SiteEnergy` trait describes a type that can compute the energy contribution
+/// of a site to the system's total energy *as a function only of that site's
+/// properties*.
+///
+/// The [`external`] module provides a number of commonly used implementations.
+/// Combine them with [`Single`] newtype for use with MC and MD simulations or to
+/// compute system-wide properties.
+///
+/// The generic type names are:
+/// `S`: The [`Site::properties`](hoomd_microstate::Site) type.
+///
+/// ## Examples
+///
+/// Implement a custom site energy method:
+///
+/// ```
+/// use hoomd_interaction::{Single, SiteEnergy, TotalEnergy};
+/// use hoomd_microstate::{
+///     Body, Microstate,
+///     property::{Point, Position},
+/// };
+/// use hoomd_vector::Cartesian;
+///
+/// struct Custom {
+///     a: f64,
+///     b: f64,
+/// }
+///
+/// impl<S> SiteEnergy<S> for Custom
+/// where
+///     S: Position<Vector = Cartesian<2>>,
+/// {
+///     fn site_energy(&self, site_properties: &S) -> f64 {
+///         self.a * (site_properties.position()[0] / self.b).cos()
+///     }
+/// }
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.extend_bodies([
+///     Body::point(Cartesian::from([1.0, 0.0])),
+///     Body::point(Cartesian::from([-1.0, 2.0])),
+/// ])?;
+///
+/// let custom_evaluator = Custom { a: 1.0, b: 10.0 };
+/// let site_energy =
+///     custom_evaluator.site_energy(&microstate.sites()[0].properties);
+///
+/// let custom = Single(custom_evaluator);
+/// let total_energy = custom.total_energy(&microstate);
+/// # Ok(())
+/// # }
+/// ```
 pub trait SiteEnergy<S> {
     /// Evaluate the energy contribution of a single site.
     #[must_use]
     fn site_energy(&self, site_properties: &S) -> f64;
 }
 
-/** Check if a site overlaps with an object external to the microstate.
-
-The `SiteOverlap` trait describes a type that can determine whether or not
-a site overlaps with another object *as a function only of that site's
-properties*.
-
-The [`external`] module provides a number of commonly used implementations.
-Combine them with [`SingleOverlap`] newtype for use with MC simulations or to
-compute system-wide properties.
-
-The generic type names are:
-* `S`: The [`Site::properties`](hoomd_microstate::Site) type.
-
-## Examples
-
-Implement a custom site overlap method:
-
-```
-use hoomd_interaction::{SingleOverlap, TotalEnergy, SiteOverlap};
-use hoomd_microstate::{Microstate, Body};
-use hoomd_microstate::property::{Point, Position};
-use hoomd_vector::{Cartesian, Vector};
-
-struct Custom {
-    r: f64,
-}
-
-impl<S> SiteOverlap<S> for Custom
-where
-    S: Position<Vector = Cartesian<2>>
-{
-    fn site_overlap(&self, site_properties: &S) -> bool {
-        // Check for overlaps of a disk with a circular boundary.
-        site_properties.position().distance(&Cartesian::default()) > self.r - 0.5
-    }
-}
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = Microstate::new();
-microstate.extend_bodies([Body::point(Cartesian::from([9.6, 0.0]))])?;
-
-let custom_evaluator = Custom { r: 10.0 };
-let site_overlap = custom_evaluator.site_overlap(&microstate.sites()[0].properties);
-assert!(site_overlap);
-
-let custom = SingleOverlap(custom_evaluator);
-let total_energy = custom.total_energy(&microstate);
-assert_eq!(total_energy, f64::INFINITY);
-# Ok(())
-# }
-```
-*/
+/// Check if a site overlaps with an object external to the microstate.
+///
+/// The `SiteOverlap` trait describes a type that can determine whether or not
+/// a site overlaps with another object *as a function only of that site's
+/// properties*.
+///
+/// The [`external`] module provides a number of commonly used implementations.
+/// Combine them with [`SingleOverlap`] newtype for use with MC simulations or to
+/// compute system-wide properties.
+///
+/// The generic type names are:
+/// `S`: The [`Site::properties`](hoomd_microstate::Site) type.
+///
+/// ## Examples
+///
+/// Implement a custom site overlap method:
+///
+/// ```
+/// use hoomd_interaction::{SingleOverlap, TotalEnergy, SiteOverlap};
+/// use hoomd_microstate::{Microstate, Body};
+/// use hoomd_microstate::property::{Point, Position};
+/// use hoomd_vector::{Cartesian, Vector};
+///
+/// struct Custom {
+/// r: f64,
+/// }
+///
+/// impl<S> SiteOverlap<S> for Custom
+/// where
+/// S: Position<Vector = Cartesian<2>>
+/// {
+/// fn site_overlap(&self, site_properties: &S) -> bool {
+/// Check for overlaps of a disk with a circular boundary.
+/// site_properties.position().distance(&Cartesian::default()) > self.r - 0.5
+/// }
+/// }
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.extend_bodies([Body::point(Cartesian::from([9.6, 0.0]))])?;
+///
+/// let custom_evaluator = Custom { r: 10.0 };
+/// let site_overlap = custom_evaluator.site_overlap(&microstate.sites()[0].properties);
+/// assert!(site_overlap);
+///
+/// let custom = SingleOverlap(custom_evaluator);
+/// let total_energy = custom.total_energy(&microstate);
+/// assert_eq!(total_energy, f64::INFINITY);
+/// # Ok(())
+/// # }
+/// ```
 pub trait SiteOverlap<S> {
     /// Determine if a site overlaps with an object external to the microstate.
     #[must_use]
     fn site_overlap(&self, site_properties: &S) -> bool;
 }
 
-/** Compute the energy contribution from a pair of sites.
-
-The `SitePairEnergy` trait describes a type that can compute the energy
-contribution from a pair of sites to the system's total energy *as a function
-only of those site's properties*.
-
-The [`pairwise`] module provides a number of commonly used implementations,
-such as [`Isotropic`] and [`Anisotropic`]. Combine any of them with the
-[`CutoffPair`] for use with MC and MD simulations or to compute system-wide
-properties.
-
-The generic type names are:
-* `S`: The [`Site::properties`](hoomd_microstate::Site) type.
-
-[`Isotropic`]: pairwise::Isotropic
-[`Anisotropic`]: pairwise::Isotropic
-
-## Examples
-
-Implement a custom site energy method:
-
-```
-use hoomd_interaction::{CutoffPair, TotalEnergy, SitePairEnergy};
-use hoomd_microstate::{Microstate, Body};
-use hoomd_microstate::property::{Point, Position};
-use hoomd_vector::{Cartesian, InnerProduct};
-
-struct Custom {
-    epsilon: f64,
-}
-
-impl<S> SitePairEnergy<S> for Custom
-where
-    S: Position<Vector = Cartesian<2>>
-{
-    fn site_pair_energy(&self, a: &S, b: &S) -> f64 {
-        self.epsilon * a.position().dot(&b.position())
-    }
-}
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = Microstate::new();
-microstate.extend_bodies([Body::point(Cartesian::from([1.0, 0.0])),
-                          Body::point(Cartesian::from([0.0, 1.0]))])?;
-
-let evaluator = Custom { epsilon: 1.0 };
-let site_pair_energy = evaluator.site_pair_energy(
-    &microstate.sites()[0].properties,
-    &microstate.sites()[1].properties);
-
-let custom = CutoffPair { r_cut: 2.5, evaluator };
-let total_energy = custom.total_energy(&microstate);
-# Ok(())
-# }
-```
-*/
+/// Compute the energy contribution from a pair of sites.
+///
+/// The `SitePairEnergy` trait describes a type that can compute the energy
+/// contribution from a pair of sites to the system's total energy *as a function
+/// only of those site's properties*.
+///
+/// The [`pairwise`] module provides a number of commonly used implementations,
+/// such as [`Isotropic`] and [`Anisotropic`]. Combine any of them with the
+/// [`CutoffPair`] for use with MC and MD simulations or to compute system-wide
+/// properties.
+///
+/// The generic type names are:
+/// `S`: The [`Site::properties`](hoomd_microstate::Site) type.
+///
+/// [`Isotropic`]: pairwise::Isotropic
+/// [`Anisotropic`]: pairwise::Isotropic
+///
+/// ## Examples
+///
+/// Implement a custom site energy method:
+///
+/// ```
+/// use hoomd_interaction::{CutoffPair, SitePairEnergy, TotalEnergy};
+/// use hoomd_microstate::{
+///     Body, Microstate,
+///     property::{Point, Position},
+/// };
+/// use hoomd_vector::{Cartesian, InnerProduct};
+///
+/// struct Custom {
+///     epsilon: f64,
+/// }
+///
+/// impl<S> SitePairEnergy<S> for Custom
+/// where
+///     S: Position<Vector = Cartesian<2>>,
+/// {
+///     fn site_pair_energy(&self, a: &S, b: &S) -> f64 {
+///         self.epsilon * a.position().dot(&b.position())
+///     }
+/// }
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.extend_bodies([
+///     Body::point(Cartesian::from([1.0, 0.0])),
+///     Body::point(Cartesian::from([0.0, 1.0])),
+/// ])?;
+///
+/// let evaluator = Custom { epsilon: 1.0 };
+/// let site_pair_energy = evaluator.site_pair_energy(
+///     &microstate.sites()[0].properties,
+///     &microstate.sites()[1].properties,
+/// );
+///
+/// let custom = CutoffPair {
+///     r_cut: 2.5,
+///     evaluator,
+/// };
+/// let total_energy = custom.total_energy(&microstate);
+/// # Ok(())
+/// # }
+/// ```
 pub trait SitePairEnergy<S> {
     /// Evaluate the energy contribution from a pair of sites.
     fn site_pair_energy(&self, a: &S, b: &S) -> f64;
 }
 
-/** Check if two sites overlap.
-
-The `SitePairOverlap` trait describes a type that can determine if a pair of
-sites overlap *as a function only of those site's properties*.
-
-The [`pairwise`] module provides a number of commonly used implementations, such
-as [`HardShape`]. Combine any of these the [`CutoffPairOverlap`] for use with MC
-simulations or to compute system-wide properties.
-
-The generic type names are:
-* `S`: The [`Site::properties`](hoomd_microstate::Site) type.
-
-[`HardShape`]: pairwise::HardShape
-
-## Examples
-
-Implement a custom site overlap method:
-
-```
-use hoomd_interaction::{CutoffPairOverlap, TotalEnergy, SitePairOverlap};
-use hoomd_microstate::{Microstate, Body};
-use hoomd_microstate::{Transform, property::{Point, Position}};
-use hoomd_vector::{self, Cartesian, Angle};
-use hoomd_utility::valid::PositiveReal;
-use hoomd_geometry::{IntersectsAt, shape::Circle};
-
-#[derive(Default)]
-struct CircleSiteProperties {
-    position: Cartesian<2>,
-    radius: PositiveReal,
-}
-
-impl Position for CircleSiteProperties {
-    type Vector = Cartesian<2>;
-
-    fn position(&self) -> &Cartesian<2> {
-        &self.position
-    }
-
-    fn position_mut(&mut self) -> &mut Cartesian<2> {
-        &mut self.position
-    }
-}
-
-impl Transform<CircleSiteProperties> for Point<Cartesian<2>> {
-    fn transform(&self, site_properties: &CircleSiteProperties) -> CircleSiteProperties {
-        CircleSiteProperties {
-            position: self.position + site_properties.position,
-            radius: site_properties.radius,
-        }
-    }
-}
-
-struct PolydisperseCircleOverlap;
-
-impl SitePairOverlap<CircleSiteProperties> for PolydisperseCircleOverlap
-{
-    fn site_pair_overlap(&self, a: &CircleSiteProperties, b: &CircleSiteProperties) -> bool {
-        let circle_a = Circle { radius: a.radius, };
-        let circle_b = Circle { radius: b.radius, };
-        let (v_ij, o_ij) = hoomd_vector::pair_system_to_local(
-            a.position(),
-            &Angle::default(),
-            b.position(),
-            &Angle::default(),
-        );
-        circle_a.intersects_at(&circle_b, &v_ij, &o_ij)
-    }
-}
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = Microstate::new();
-microstate.extend_bodies([
-    Body { properties: Point::new(Cartesian::from([0.0, 0.0])),
-           sites: vec![ CircleSiteProperties { position: Cartesian::from([0.0, 0.0]),
-            radius: 0.5.try_into()?,
-            }], },
-    Body { properties: Point::new(Cartesian::from([1.4, 0.0])),
-           sites: vec![ CircleSiteProperties { position: Cartesian::from([0.0, 0.0]),
-            radius: 1.0.try_into()?,
-            }], },
-    ]
-)?;
-
-let evaluator = PolydisperseCircleOverlap;
-let site_pair_overlap = evaluator.site_pair_overlap(
-    &microstate.sites()[0].properties,
-    &microstate.sites()[1].properties);
-assert!(site_pair_overlap);
-
-let cutoff_pair_overlap = CutoffPairOverlap { r_cut: 1.5, evaluator };
-let total_energy = cutoff_pair_overlap.total_energy(&microstate);
-assert_eq!(total_energy, f64::INFINITY);
-# Ok(())
-# }
-```
-*/
+/// Check if two sites overlap.
+///
+/// The `SitePairOverlap` trait describes a type that can determine if a pair of
+/// sites overlap *as a function only of those site's properties*.
+///
+/// The [`pairwise`] module provides a number of commonly used implementations, such
+/// as [`HardShape`]. Combine any of these the [`CutoffPairOverlap`] for use with MC
+/// simulations or to compute system-wide properties.
+///
+/// The generic type names are:
+/// `S`: The [`Site::properties`](hoomd_microstate::Site) type.
+///
+/// [`HardShape`]: pairwise::HardShape
+///
+/// ## Examples
+///
+/// Implement a custom site overlap method:
+///
+/// ```
+/// use hoomd_geometry::{IntersectsAt, shape::Circle};
+/// use hoomd_interaction::{CutoffPairOverlap, SitePairOverlap, TotalEnergy};
+/// use hoomd_microstate::{
+///     Body, Microstate, Transform,
+///     property::{Point, Position},
+/// };
+/// use hoomd_utility::valid::PositiveReal;
+/// use hoomd_vector::{self, Angle, Cartesian};
+///
+/// #[derive(Default)]
+/// struct CircleSiteProperties {
+///     position: Cartesian<2>,
+///     radius: PositiveReal,
+/// }
+///
+/// impl Position for CircleSiteProperties {
+///     type Vector = Cartesian<2>;
+///
+///     fn position(&self) -> &Cartesian<2> {
+///         &self.position
+///     }
+///
+///     fn position_mut(&mut self) -> &mut Cartesian<2> {
+///         &mut self.position
+///     }
+/// }
+///
+/// impl Transform<CircleSiteProperties> for Point<Cartesian<2>> {
+///     fn transform(
+///         &self,
+///         site_properties: &CircleSiteProperties,
+///     ) -> CircleSiteProperties {
+///         CircleSiteProperties {
+///             position: self.position + site_properties.position,
+///             radius: site_properties.radius,
+///         }
+///     }
+/// }
+///
+/// struct PolydisperseCircleOverlap;
+///
+/// impl SitePairOverlap<CircleSiteProperties> for PolydisperseCircleOverlap {
+///     fn site_pair_overlap(
+///         &self,
+///         a: &CircleSiteProperties,
+///         b: &CircleSiteProperties,
+///     ) -> bool {
+///         let circle_a = Circle { radius: a.radius };
+///         let circle_b = Circle { radius: b.radius };
+///         let (v_ij, o_ij) = hoomd_vector::pair_system_to_local(
+///             a.position(),
+///             &Angle::default(),
+///             b.position(),
+///             &Angle::default(),
+///         );
+///         circle_a.intersects_at(&circle_b, &v_ij, &o_ij)
+///     }
+/// }
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.extend_bodies([
+///     Body {
+///         properties: Point::new(Cartesian::from([0.0, 0.0])),
+///         sites: vec![CircleSiteProperties {
+///             position: Cartesian::from([0.0, 0.0]),
+///             radius: 0.5.try_into()?,
+///         }],
+///     },
+///     Body {
+///         properties: Point::new(Cartesian::from([1.4, 0.0])),
+///         sites: vec![CircleSiteProperties {
+///             position: Cartesian::from([0.0, 0.0]),
+///             radius: 1.0.try_into()?,
+///         }],
+///     },
+/// ])?;
+///
+/// let evaluator = PolydisperseCircleOverlap;
+/// let site_pair_overlap = evaluator.site_pair_overlap(
+///     &microstate.sites()[0].properties,
+///     &microstate.sites()[1].properties,
+/// );
+/// assert!(site_pair_overlap);
+///
+/// let cutoff_pair_overlap = CutoffPairOverlap {
+///     r_cut: 1.5,
+///     evaluator,
+/// };
+/// let total_energy = cutoff_pair_overlap.total_energy(&microstate);
+/// assert_eq!(total_energy, f64::INFINITY);
+/// # Ok(())
+/// # }
+/// ```
 pub trait SitePairOverlap<S> {
     /// Determine if two sites overlap.
     fn site_pair_overlap(&self, a: &S, b: &S) -> bool;
 }
 
-/** Compute the change energy as a function of a single modified body.
-
-Some trial moves apply to a single body at a time and use a Hamiltonian that
-implements `DeltaEnergyOne` to efficiently compute the change in energy.
-
-The generic type names are:
-* `B`: The [`Body::properties`](hoomd_microstate::Body) type.
-* `S`: The [`Site::properties`](hoomd_microstate::Site) type.
-* `C`: The [`boundary`](hoomd_microstate::boundary) condition type.
-
-See the [Implementors](#implementors) section below for examples.
-*/
+/// Compute the change energy as a function of a single modified body.
+///
+/// Some trial moves apply to a single body at a time and use a Hamiltonian that
+/// implements `DeltaEnergyOne` to efficiently compute the change in energy.
+///
+/// The generic type names are:
+/// `B`: The [`Body::properties`](hoomd_microstate::Body) type.
+/// `S`: The [`Site::properties`](hoomd_microstate::Site) type.
+/// `C`: The [`boundary`](hoomd_microstate::boundary) condition type.
+///
+/// See the [Implementors](#implementors) section below for examples.
 pub trait DeltaEnergyOne<B, S, C> {
-    /** Compute the change in energy.
-
-    `initial_microstate` describes the initial configuration and `final_body`
-    describes the new body configuration. In the final configuration, the
-    body may have changed properties and/or sites. The index `body_index`
-    identifies which body in `initial_microstate` is changing.
-
-    Returns:
-    ```math
-    \Delta E = E_\mathrm{final} - E_\mathrm{initial}
-    ```
-    */
+    /// Compute the change in energy.
+    ///
+    /// `initial_microstate` describes the initial configuration and `final_body`
+    /// describes the new body configuration. In the final configuration, the
+    /// body may have changed properties and/or sites. The index `body_index`
+    /// identifies which body in `initial_microstate` is changing.
+    ///
+    /// Returns:
+    /// ```math
+    /// \Delta E = E_\mathrm{final} - E_\mathrm{initial}
+    /// ```
     #[must_use]
     fn delta_energy_one(
         &self,
@@ -384,30 +406,28 @@ pub trait DeltaEnergyOne<B, S, C> {
     ) -> f64;
 }
 
-/** Compute the change energy when a single body is inserted.
-
-Some trial moves insert a single body at a time and use a Hamiltonian that
-implements `DeltaEnergyInsert` to efficiently compute the change in energy.
-
-The generic type names are:
-* `B`: The [`Body::properties`](hoomd_microstate::Body) type.
-* `S`: The [`Site::properties`](hoomd_microstate::Site) type.
-* `C`: The [`boundary`](hoomd_microstate::boundary) condition type.
-
-See the [Implementors](#implementors) section below for examples.
-*/
+/// Compute the change energy when a single body is inserted.
+///
+/// Some trial moves insert a single body at a time and use a Hamiltonian that
+/// implements `DeltaEnergyInsert` to efficiently compute the change in energy.
+///
+/// The generic type names are:
+/// `B`: The [`Body::properties`](hoomd_microstate::Body) type.
+/// `S`: The [`Site::properties`](hoomd_microstate::Site) type.
+/// `C`: The [`boundary`](hoomd_microstate::boundary) condition type.
+///
+/// See the [Implementors](#implementors) section below for examples.
 pub trait DeltaEnergyInsert<B, S, C> {
-    /** Compute the change in energy.
-
-    `initial_microstate` describes the initial configuration and `new_body`
-    describes the new body configuration. The final configuration includes
-    all bodies in the initial microstate and `new_body`.
-
-    Returns:
-    ```math
-    \Delta E = E_\mathrm{final} - E_\mathrm{initial}
-    ```
-    */
+    /// Compute the change in energy.
+    ///
+    /// `initial_microstate` describes the initial configuration and `new_body`
+    /// describes the new body configuration. The final configuration includes
+    /// all bodies in the initial microstate and `new_body`.
+    ///
+    /// Returns:
+    /// ```math
+    /// \Delta E = E_\mathrm{final} - E_\mathrm{initial}
+    /// ```
     #[must_use]
     fn delta_energy_insert(
         &self,
@@ -416,30 +436,28 @@ pub trait DeltaEnergyInsert<B, S, C> {
     ) -> f64;
 }
 
-/** Compute the change energy when a single body is removed.
-
-Some trial moves remove a single body at a time and use a Hamiltonian that
-implements `DeltaEnergyRemove` to efficiently compute the change in energy.
-
-The generic type names are:
-* `B`: The [`Body::properties`](hoomd_microstate::Body) type.
-* `S`: The [`Site::properties`](hoomd_microstate::Site) type.
-* `C`: The [`boundary`](hoomd_microstate::boundary) condition type.
-
-See the [Implementors](#implementors) section below for examples.
-*/
+/// Compute the change energy when a single body is removed.
+///
+/// Some trial moves remove a single body at a time and use a Hamiltonian that
+/// implements `DeltaEnergyRemove` to efficiently compute the change in energy.
+///
+/// The generic type names are:
+/// `B`: The [`Body::properties`](hoomd_microstate::Body) type.
+/// `S`: The [`Site::properties`](hoomd_microstate::Site) type.
+/// `C`: The [`boundary`](hoomd_microstate::boundary) condition type.
+///
+/// See the [Implementors](#implementors) section below for examples.
 pub trait DeltaEnergyRemove<B, S, C> {
-    /** Compute the change in energy.
-
-    `initial_microstate` describes the initial configuration and `body_index` is
-    the index of the body to remove. The final configuration includes all bodies
-    in the initial microstate except the body previously at `body_index`.
-
-    Returns:
-    ```math
-    \Delta E = E_\mathrm{final} - E_\mathrm{initial}
-    ```
-    */
+    /// Compute the change in energy.
+    ///
+    /// `initial_microstate` describes the initial configuration and `body_index` is
+    /// the index of the body to remove. The final configuration includes all bodies
+    /// in the initial microstate except the body previously at `body_index`.
+    ///
+    /// Returns:
+    /// ```math
+    /// \Delta E = E_\mathrm{final} - E_\mathrm{initial}
+    /// ```
     #[must_use]
     fn delta_energy_remove(
         &self,

--- a/hoomd-interaction/src/lib.rs
+++ b/hoomd-interaction/src/lib.rs
@@ -40,23 +40,34 @@ pub use zero::Zero;
 /// # Example
 ///
 /// ```
-/// use hoomd_interaction::{CutoffPair, SitePairEnergy, TotalEnergy,
-/// pairwise::{Isotropic, LennardJones}};
-/// use hoomd_microstate::{Microstate, Body};
-/// use hoomd_microstate::property::{Point, Position};
+/// use hoomd_interaction::{
+///     CutoffPair, SitePairEnergy, TotalEnergy,
+///     pairwise::{Isotropic, LennardJones},
+/// };
+/// use hoomd_microstate::{
+///     Body, Microstate,
+///     property::{Point, Position},
+/// };
 /// use hoomd_vector::{Cartesian, Vector};
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut microstate = Microstate::new();
-/// microstate.extend_bodies([Body::point(Cartesian::from([0.0, 0.0])),
-/// Body::point(Cartesian::from([1.0, 0.0])),
-/// Body::point(Cartesian::from([0.0, 5.0])),
-/// Body::point(Cartesian::from([-1.0, 5.0])),
+/// microstate.extend_bodies([
+///     Body::point(Cartesian::from([0.0, 0.0])),
+///     Body::point(Cartesian::from([1.0, 0.0])),
+///     Body::point(Cartesian::from([0.0, 5.0])),
+///     Body::point(Cartesian::from([-1.0, 5.0])),
 /// ])?;
 ///
-/// let lennard_jones: LennardJones = LennardJones { epsilon: 1.5, sigma: 1.0 / 2.0_f64.powf(1.0 / 6.0) };
+/// let lennard_jones: LennardJones = LennardJones {
+///     epsilon: 1.5,
+///     sigma: 1.0 / 2.0_f64.powf(1.0 / 6.0),
+/// };
 /// let lennard_jones = Isotropic(lennard_jones);
-/// let cutoff_pair = CutoffPair { r_cut: 2.5, evaluator: lennard_jones, };
+/// let cutoff_pair = CutoffPair {
+///     r_cut: 2.5,
+///     evaluator: lennard_jones,
+/// };
 ///
 /// let total_energy = cutoff_pair.total_energy(&microstate);
 /// assert_eq!(total_energy, -3.0);
@@ -148,23 +159,26 @@ pub trait SiteEnergy<S> {
 /// Implement a custom site overlap method:
 ///
 /// ```
-/// use hoomd_interaction::{SingleOverlap, TotalEnergy, SiteOverlap};
-/// use hoomd_microstate::{Microstate, Body};
-/// use hoomd_microstate::property::{Point, Position};
+/// use hoomd_interaction::{SingleOverlap, SiteOverlap, TotalEnergy};
+/// use hoomd_microstate::{
+///     Body, Microstate,
+///     property::{Point, Position},
+/// };
 /// use hoomd_vector::{Cartesian, Vector};
 ///
 /// struct Custom {
-/// r: f64,
+///     r: f64,
 /// }
 ///
 /// impl<S> SiteOverlap<S> for Custom
 /// where
-/// S: Position<Vector = Cartesian<2>>
+///     S: Position<Vector = Cartesian<2>>,
 /// {
-/// /// Check for overlaps of a disk with a circular boundary.
-/// fn site_overlap(&self, site_properties: &S) -> bool {
-/// site_properties.position().distance(&Cartesian::default()) > self.r - 0.5
-/// }
+///     /// Check for overlaps of a disk with a circular boundary.
+///     fn site_overlap(&self, site_properties: &S) -> bool {
+///         site_properties.position().distance(&Cartesian::default())
+///             > self.r - 0.5
+///     }
 /// }
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -172,7 +186,8 @@ pub trait SiteEnergy<S> {
 /// microstate.extend_bodies([Body::point(Cartesian::from([9.6, 0.0]))])?;
 ///
 /// let custom_evaluator = Custom { r: 10.0 };
-/// let site_overlap = custom_evaluator.site_overlap(&microstate.sites()[0].properties);
+/// let site_overlap =
+///     custom_evaluator.site_overlap(&microstate.sites()[0].properties);
 /// assert!(site_overlap);
 ///
 /// let custom = SingleOverlap(custom_evaluator);

--- a/hoomd-interaction/src/pairwise.rs
+++ b/hoomd-interaction/src/pairwise.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Pairwise interactions.
- */
+//! Pairwise interactions.
 
 use hoomd_vector::{Rotate, Vector};
 
@@ -42,58 +41,56 @@ pub use shifted::Shifted;
 pub use weeks_chandler_anderson::WeeksChandlerAnderson;
 pub use xplor::Xplor;
 
-/** Computes pairwise energies between point particles.
-
-An isotropic pairwise energy is function only of the distances between the
-particles: $`U(r)`$
-
-Implement [`IsotropicEnergy`] on a custom type or use one of the provided
-potentials in [`pairwise`](crate::pairwise) in MD or MC simulations.
-Use an [`IsotropicEnergy`] in combination with [`Isotropic`] and
-[`CutoffPair`](crate::CutoffPair).
-
-# Examples
-
-Set a custom potential using a closure:
-```
-use hoomd_interaction::pairwise::IsotropicEnergy;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let a = 2.0;
-let custom = |r: f64| a / (r.powi(12));
-
-let energy = custom.energy(1.0);
-assert_eq!(energy, 2.0);
-# Ok(())
-# }
-```
-
-Implement a custom potential via a type:
-```
-use hoomd_interaction::pairwise::IsotropicEnergy;
-
-struct Custom {
-    a: f64,
-}
-
-impl IsotropicEnergy for Custom {
-    fn energy(&self, r: f64) -> f64 {
-        self.a / r.powi(12)
-    }
-}
-
-let custom = Custom { a: 2.0 };
-
-let energy = custom.energy(1.0);
-assert_eq!(energy, 2.0);
-```
-*/
+/// Computes pairwise energies between point particles.
+///
+/// An isotropic pairwise energy is function only of the distances between the
+/// particles: $`U(r)`$
+///
+/// Implement [`IsotropicEnergy`] on a custom type or use one of the provided
+/// potentials in [`pairwise`](crate::pairwise) in MD or MC simulations.
+/// Use an [`IsotropicEnergy`] in combination with [`Isotropic`] and
+/// [`CutoffPair`](crate::CutoffPair).
+///
+/// # Examples
+///
+/// Set a custom potential using a closure:
+/// ```
+/// use hoomd_interaction::pairwise::IsotropicEnergy;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let a = 2.0;
+/// let custom = |r: f64| a / (r.powi(12));
+///
+/// let energy = custom.energy(1.0);
+/// assert_eq!(energy, 2.0);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Implement a custom potential via a type:
+/// ```
+/// use hoomd_interaction::pairwise::IsotropicEnergy;
+///
+/// struct Custom {
+///     a: f64,
+/// }
+///
+/// impl IsotropicEnergy for Custom {
+///     fn energy(&self, r: f64) -> f64 {
+///         self.a / r.powi(12)
+///     }
+/// }
+///
+/// let custom = Custom { a: 2.0 };
+///
+/// let energy = custom.energy(1.0);
+/// assert_eq!(energy, 2.0);
+/// ```
 pub trait IsotropicEnergy {
-    /** Compute the pairwise energy between two point particles.
-    ```math
-    U(r)
-    ```
-    */
+    /// Compute the pairwise energy between two point particles.
+    /// ```math
+    /// U(r)
+    /// ```
     #[must_use]
     fn energy(&self, r: f64) -> f64;
 }
@@ -108,48 +105,44 @@ where
     }
 }
 
-/** Computes pairwise forces between point particles.
-
-An isotropic pairwise force is function only of the distances between the
-particles and acts along the vector separating the particles.
-
-Implement [`IsotropicForce`] on a custom type or use one of the provided
-forces in [`pairwise`](crate::pairwise) in MD simulations.
-*/
+/// Computes pairwise forces between point particles.
+///
+/// An isotropic pairwise force is function only of the distances between the
+/// particles and acts along the vector separating the particles.
+///
+/// Implement [`IsotropicForce`] on a custom type or use one of the provided
+/// forces in [`pairwise`](crate::pairwise) in MD simulations.
 pub trait IsotropicForce {
-    /** Compute the radial component of the pairwise force between two point
-    particles.
-
-    The direction of the force is along the unit vector between the two
-    particles.
-
-    When the force is associated with a potential energy [`IsotropicEnergy`],
-    it must follow:
-    ```math
-    -\frac{\mathrm{d} U}{\mathrm{d} r}
-    ```
-    */
+    /// Compute the radial component of the pairwise force between two point
+    /// particles.
+    ///
+    /// The direction of the force is along the unit vector between the two
+    /// particles.
+    ///
+    /// When the force is associated with a potential energy [`IsotropicEnergy`],
+    /// it must follow:
+    /// ```math
+    /// -\frac{\mathrm{d} U}{\mathrm{d} r}
+    /// ```
     #[must_use]
     fn force(&self, r: f64) -> f64;
 }
 
-/** Computes pairwise energies between oriented particles.
-
-An anisotropic pairwise energy is function of the relative position and
-orientation of the *j* particle in *i's* reference frame:
-```math
-U(\vec{r}_{ij}, \mathbf{o}_{ij})
-```
-
-Implement [`AnisotropicEnergy`] on a custom type or use one of the provided
-potentials in [`pairwise`](crate::pairwise) in MD or MC simulations.
-*/
+/// Computes pairwise energies between oriented particles.
+///
+/// An anisotropic pairwise energy is function of the relative position and
+/// orientation of the *j* particle in *i's* reference frame:
+/// ```math
+/// U(\vec{r}_{ij}, \mathbf{o}_{ij})
+/// ```
+///
+/// Implement [`AnisotropicEnergy`] on a custom type or use one of the provided
+/// potentials in [`pairwise`](crate::pairwise) in MD or MC simulations.
 pub trait AnisotropicEnergy<V: Vector, R: Rotate<V>> {
-    /** Compute the pairwise energy between two oriented particles.
-    ```math
-    U(\vec{r}_{ij}, \mathbf{o}_{ij})
-    ```
-    */
+    /// Compute the pairwise energy between two oriented particles.
+    /// ```math
+    /// U(\vec{r}_{ij}, \mathbf{o}_{ij})
+    /// ```
     #[must_use]
     fn energy(&self, r_ij: &V, o_ij: &R) -> f64;
 }

--- a/hoomd-interaction/src/pairwise/always_true.rs
+++ b/hoomd-interaction/src/pairwise/always_true.rs
@@ -1,18 +1,16 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement `AlwaysTrue`
- */
+//! Implement `AlwaysTrue`
 
 use crate::SitePairOverlap;
 
-/** All site pairs overlap (*not differentiable*).
-
-Use [`AlwaysTrue`] with [`CutoffPairOverlap`] to implement hard sphere overlap
-checks. See [`CutoffPairOverlap`] for examples.
-
-[`CutoffPairOverlap`]: crate::CutoffPairOverlap
-*/
+/// All site pairs overlap (*not differentiable*).
+///
+/// Use [`AlwaysTrue`] with [`CutoffPairOverlap`] to implement hard sphere overlap
+/// checks. See [`CutoffPairOverlap`] for examples.
+///
+/// [`CutoffPairOverlap`]: crate::CutoffPairOverlap
 pub struct AlwaysTrue;
 
 impl<S> SitePairOverlap<S> for AlwaysTrue {

--- a/hoomd-interaction/src/pairwise/angular_mask.rs
+++ b/hoomd-interaction/src/pairwise/angular_mask.rs
@@ -1,28 +1,29 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! [`AngularMask`] and related data structures.
- */
+//! [`AngularMask`] and related data structures.
 
 use super::{AnisotropicEnergy, IsotropicEnergy};
 use hoomd_vector::{InnerProduct, Rotate, Unit, Vector};
 
-/** A single patch in the [`AngularMask`] potential.
-
-The width of the patch is given as the cosine of its half-angle.
-
-# Example
-
-```
-use hoomd_interaction::pairwise::angular_mask::Patch;
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let patch = Patch { director: [0.0, 1.0, 0.0].try_into()?, cos_delta: (PI / 4.0).cos() };
-# Ok(())
-# }
-```
- */
+/// A single patch in the [`AngularMask`] potential.
+///
+/// The width of the patch is given as the cosine of its half-angle.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::pairwise::angular_mask::Patch;
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let patch = Patch {
+///     director: [0.0, 1.0, 0.0].try_into()?,
+///     cos_delta: (PI / 4.0).cos(),
+/// };
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Patch<V> {
     /// Vector pointing from the center of the particle to the center of the mask `[unitless]`.
@@ -31,152 +32,174 @@ pub struct Patch<V> {
     pub cos_delta: f64,
 }
 
-/** Evaluate an isotropic pairwise energy masked by angular patches (_not differentiable_).
-
-```math
-U(\vec{r}_{ij}, \mathbf{o}_{ij}) = f(|\vec{r}_{ij}|) \cdot \max
-    \left(1,
-    \sum_{m=1}^{N_{\mathrm{masks},i}}
-    \sum_{n=1}^{N_{\mathrm{masks},j}}
-    s(\vec{d}_{m,i},
-      \mathbf{o}_{ij} \vec{d}_{n,j} \mathbf{o}_{ij}^*,
-      \delta_{m,i},
-      \delta_{n,j}) \right)
-```
-where
-```math
-s(\vec{a}, \vec{b}, \delta_a, \delta_b) =
- \begin{cases}
- 1 & \hat{a} \cdot \hat{r}_{ij} \ge \cos \delta_{a} \land
- \hat{b} \cdot \hat{r}_{ji} \ge \cos \delta_{b} \\
- 0 & \text{otherwise} \\
-\end{cases}
-```
-
-Implement the [Kern-Frenkel] potential with the [`Boxcar`](super::Boxcar) isotropic potential
-and single patch in both `masks_i` and `masks_j`.
-
-[Kern-Frenkel]: http://dx.doi.org/10.1063/1.1569473
-
-# Examples
-
-Construction:
-
-```
-use hoomd_interaction::pairwise::{AngularMask, Boxcar, angular_mask::Patch};
-use hoomd_vector::Angle;
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let boxcar = Boxcar { epsilon: -1.0, left: 1.0, right: 1.5 };
-let masks = [Patch { director: [1.0, 0.0].try_into()?, cos_delta: (PI / 8.0).cos() }];
-let angular_mask = AngularMask::new(boxcar, masks);
-# Ok(())
-# }
-```
-
-All fields are public and can be directly manipulated:
-```
-use hoomd_interaction::pairwise::{AngularMask, Boxcar, angular_mask::Patch};
-use hoomd_vector::Angle;
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let boxcar = Boxcar { epsilon: -1.0, left: 1.0, right: 1.5 };
-let masks = [Patch { director: [1.0, 0.0].try_into()?, cos_delta: (PI / 8.0).cos() }];
-let mut angular_mask = AngularMask::new(boxcar, masks);
-
-angular_mask.masks_i[0].cos_delta = (PI / 4.0).cos();
-angular_mask.isotropic.epsilon = -2.0;
-# Ok(())
-# }
-```
-
-Evaluate energy between particles:
-
-```
-use hoomd_interaction::pairwise::{AngularMask, AnisotropicEnergy, Boxcar, angular_mask::Patch};
-use hoomd_vector::Angle;
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let boxcar = Boxcar { epsilon: -1.0, left: 1.0, right: 1.5 };
-let masks = [Patch { director: [1.0, 0.0].try_into()?, cos_delta: (PI / 8.0).cos() }];
-let angular_mask = AngularMask::new(boxcar, masks);
-
-// With the same relative orientation, the patches do not overlap and the
-// energy is 0.
-let energy = angular_mask.energy(&[1.0, 0.0].into(), &Angle::from(0.0));
-assert_eq!(energy, 0.0);
-
-// Rotate the j particle to point at the i particle so the patches overlap.
-let energy = angular_mask.energy(&[1.0, 0.0].into(), &Angle::from(PI));
-assert_eq!(energy, -1.0);
-# Ok(())
-# }
-```
-
-Apply different patches to the _i_ and _j_ particles:
-```
-use hoomd_interaction::pairwise::{AngularMask, AnisotropicEnergy, Boxcar, angular_mask::Patch};
-use hoomd_vector::Angle;
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let boxcar = Boxcar { epsilon: -1.0, left: 1.0, right: 1.5 };
-let masks_i = vec![Patch { director: [1.0, 0.0].try_into()?, cos_delta: (PI / 8.0).cos() },
-    Patch { director: [-1.0, 0.0].try_into()?, cos_delta: (PI / 8.0).cos() }];
-let masks_j = vec![Patch { director: [0.0, 1.0].try_into()?, cos_delta: (PI / 8.0).cos() }];
-let angular_mask = AngularMask { isotropic: boxcar, masks_i, masks_j, };
-
-// With the same relative orientation, the patches do not overlap and the
-// energy is 0.
-let energy = angular_mask.energy(&[-1.0, 0.0].into(), &Angle::from(0.0));
-assert_eq!(energy, 0.0);
-
-// Rotate the j particle to point at the i particle so the patches overlap.
-let energy = angular_mask.energy(&[-1.0, 0.0].into(), &Angle::from(-PI / 2.0));
-assert_eq!(energy, -1.0);
-# Ok(())
-# }
-```
-
-Evaluate the angular mask potential on 3D particles:
-```
-use hoomd_interaction::pairwise::{AngularMask, AnisotropicEnergy, Boxcar, angular_mask::Patch};
-use hoomd_vector::{Cartesian, InnerProduct, Versor};
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let boxcar = Boxcar { epsilon: -1.0, left: 1.0, right: 1.5 };
-
-let mask = [Patch {
-    director: [0.0, 0.0, 1.0].try_into()?,
-    cos_delta: (PI / 8.0).cos(),
-}];
-let (x_axis, _) = Cartesian::from([1.0, 0.0, 0.0]).to_unit_unchecked();
-
-let angular_mask = AngularMask::new(boxcar, mask);
-
-assert_eq!(
-    angular_mask.energy(
-        &Cartesian::from([0.0, 0.0, 1.0]),
-        &Versor::from_axis_angle(x_axis, 0.0)
-    ),
-    0.0
-);
-assert_eq!(
-    angular_mask.energy(
-        &Cartesian::from([0.0, 0.0, 1.0]),
-        &Versor::from_axis_angle(x_axis, PI)
-    ),
-    -1.0
-);
-# Ok(())
-# }
-
-```
-*/
+/// Evaluate an isotropic pairwise energy masked by angular patches (_not differentiable_).
+///
+/// ```math
+/// U(\vec{r}_{ij}, \mathbf{o}_{ij}) = f(|\vec{r}_{ij}|) \cdot \max
+/// \left(1,
+/// \sum_{m=1}^{N_{\mathrm{masks},i}}
+/// \sum_{n=1}^{N_{\mathrm{masks},j}}
+/// s(\vec{d}_{m,i},
+/// \mathbf{o}_{ij} \vec{d}_{n,j} \mathbf{o}_{ij}^*,
+/// \delta_{m,i},
+/// \delta_{n,j}) \right)
+/// ```
+/// where
+/// ```math
+/// s(\vec{a}, \vec{b}, \delta_a, \delta_b) =
+/// \begin{cases}
+/// 1 & \hat{a} \cdot \hat{r}_{ij} \ge \cos \delta_{a} \land
+/// \hat{b} \cdot \hat{r}_{ji} \ge \cos \delta_{b} \\
+/// 0 & \text{otherwise} \\
+/// \end{cases}
+/// ```
+///
+/// Implement the [Kern-Frenkel] potential with the [`Boxcar`](super::Boxcar) isotropic potential
+/// and single patch in both `masks_i` and `masks_j`.
+///
+/// [Kern-Frenkel]: http://dx.doi.org/10.1063/1.1569473
+///
+/// # Examples
+///
+/// Construction:
+///
+/// ```
+/// use hoomd_interaction::pairwise::{
+///     AngularMask, Boxcar, angular_mask::Patch,
+/// };
+/// use hoomd_vector::Angle;
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let boxcar = Boxcar {
+///     epsilon: -1.0,
+///     left: 1.0,
+///     right: 1.5,
+/// };
+/// let masks = [Patch {
+///     director: [1.0, 0.0].try_into()?,
+///     cos_delta: (PI / 8.0).cos(),
+/// }];
+/// let angular_mask = AngularMask::new(boxcar, masks);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// All fields are public and can be directly manipulated:
+/// ```
+/// use hoomd_interaction::pairwise::{
+///     AngularMask, Boxcar, angular_mask::Patch,
+/// };
+/// use hoomd_vector::Angle;
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let boxcar = Boxcar {
+///     epsilon: -1.0,
+///     left: 1.0,
+///     right: 1.5,
+/// };
+/// let masks = [Patch {
+///     director: [1.0, 0.0].try_into()?,
+///     cos_delta: (PI / 8.0).cos(),
+/// }];
+/// let mut angular_mask = AngularMask::new(boxcar, masks);
+///
+/// angular_mask.masks_i[0].cos_delta = (PI / 4.0).cos();
+/// angular_mask.isotropic.epsilon = -2.0;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Evaluate energy between particles:
+///
+/// ```
+/// use hoomd_interaction::pairwise::{AngularMask, AnisotropicEnergy, Boxcar, angular_mask::Patch};
+/// use hoomd_vector::Angle;
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let boxcar = Boxcar { epsilon: -1.0, left: 1.0, right: 1.5 };
+/// let masks = [Patch { director: [1.0, 0.0].try_into()?, cos_delta: (PI / 8.0).cos() }];
+/// let angular_mask = AngularMask::new(boxcar, masks);
+///
+/// With the same relative orientation, the patches do not overlap and the
+/// energy is 0.
+/// let energy = angular_mask.energy(&[1.0, 0.0].into(), &Angle::from(0.0));
+/// assert_eq!(energy, 0.0);
+///
+/// Rotate the j particle to point at the i particle so the patches overlap.
+/// let energy = angular_mask.energy(&[1.0, 0.0].into(), &Angle::from(PI));
+/// assert_eq!(energy, -1.0);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Apply different patches to the _i_ and _j_ particles:
+/// ```
+/// use hoomd_interaction::pairwise::{AngularMask, AnisotropicEnergy, Boxcar, angular_mask::Patch};
+/// use hoomd_vector::Angle;
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let boxcar = Boxcar { epsilon: -1.0, left: 1.0, right: 1.5 };
+/// let masks_i = vec![Patch { director: [1.0, 0.0].try_into()?, cos_delta: (PI / 8.0).cos() },
+/// Patch { director: [-1.0, 0.0].try_into()?, cos_delta: (PI / 8.0).cos() }];
+/// let masks_j = vec![Patch { director: [0.0, 1.0].try_into()?, cos_delta: (PI / 8.0).cos() }];
+/// let angular_mask = AngularMask { isotropic: boxcar, masks_i, masks_j, };
+///
+/// With the same relative orientation, the patches do not overlap and the
+/// energy is 0.
+/// let energy = angular_mask.energy(&[-1.0, 0.0].into(), &Angle::from(0.0));
+/// assert_eq!(energy, 0.0);
+///
+/// Rotate the j particle to point at the i particle so the patches overlap.
+/// let energy = angular_mask.energy(&[-1.0, 0.0].into(), &Angle::from(-PI / 2.0));
+/// assert_eq!(energy, -1.0);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Evaluate the angular mask potential on 3D particles:
+/// ```
+/// use hoomd_interaction::pairwise::{
+///     AngularMask, AnisotropicEnergy, Boxcar, angular_mask::Patch,
+/// };
+/// use hoomd_vector::{Cartesian, InnerProduct, Versor};
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let boxcar = Boxcar {
+///     epsilon: -1.0,
+///     left: 1.0,
+///     right: 1.5,
+/// };
+///
+/// let mask = [Patch {
+///     director: [0.0, 0.0, 1.0].try_into()?,
+///     cos_delta: (PI / 8.0).cos(),
+/// }];
+/// let (x_axis, _) = Cartesian::from([1.0, 0.0, 0.0]).to_unit_unchecked();
+///
+/// let angular_mask = AngularMask::new(boxcar, mask);
+///
+/// assert_eq!(
+///     angular_mask.energy(
+///         &Cartesian::from([0.0, 0.0, 1.0]),
+///         &Versor::from_axis_angle(x_axis, 0.0)
+///     ),
+///     0.0
+/// );
+/// assert_eq!(
+///     angular_mask.energy(
+///         &Cartesian::from([0.0, 0.0, 1.0]),
+///         &Versor::from_axis_angle(x_axis, PI)
+///     ),
+///     -1.0
+/// );
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 pub struct AngularMask<E, V> {
     /// The original potential.
@@ -193,31 +216,39 @@ impl<E, V> AngularMask<E, V>
 where
     V: Vector,
 {
-    /** Construct a [`AngularMask`] with the given function and masks.
-
-    To obtain the best performance, construct [`AngularMask`] once and
-    call use it many times. `new` dynamically allocates `Vec` types
-    and is therefore not suitable to be called per particle,
-    unlike other potentials such as [`LennardJones`](super::LennardJones)
-    or [`Boxcar`](super::Boxcar).
-
-    `new` sets both `masks_i` and `masks_j` to `masks`. Use struct initialization
-    syntax to set these separately.
-
-    # Example
-
-    ```
-    use hoomd_interaction::pairwise::{AngularMask, Boxcar, angular_mask::Patch};
-    use std::f64::consts::PI;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let boxcar = Boxcar { epsilon: -1.0, left: 1.0, right: 1.5 };
-    let masks = [Patch { director: [1.0, 0.0].try_into()?, cos_delta: (PI / 8.0).cos() }];
-    let angular_mask = AngularMask::new(boxcar, masks);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Construct a [`AngularMask`] with the given function and masks.
+    ///
+    /// To obtain the best performance, construct [`AngularMask`] once and
+    /// call use it many times. `new` dynamically allocates `Vec` types
+    /// and is therefore not suitable to be called per particle,
+    /// unlike other potentials such as [`LennardJones`](super::LennardJones)
+    /// or [`Boxcar`](super::Boxcar).
+    ///
+    /// `new` sets both `masks_i` and `masks_j` to `masks`. Use struct initialization
+    /// syntax to set these separately.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_interaction::pairwise::{
+    ///     AngularMask, Boxcar, angular_mask::Patch,
+    /// };
+    /// use std::f64::consts::PI;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let boxcar = Boxcar {
+    ///     epsilon: -1.0,
+    ///     left: 1.0,
+    ///     right: 1.5,
+    /// };
+    /// let masks = [Patch {
+    ///     director: [1.0, 0.0].try_into()?,
+    ///     cos_delta: (PI / 8.0).cos(),
+    /// }];
+    /// let angular_mask = AngularMask::new(boxcar, masks);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     #[must_use]
     pub fn new<I>(isotropic: E, masks: I) -> Self

--- a/hoomd-interaction/src/pairwise/angular_mask.rs
+++ b/hoomd-interaction/src/pairwise/angular_mask.rs
@@ -114,13 +114,22 @@ pub struct Patch<V> {
 /// Evaluate energy between particles:
 ///
 /// ```
-/// use hoomd_interaction::pairwise::{AngularMask, AnisotropicEnergy, Boxcar, angular_mask::Patch};
+/// use hoomd_interaction::pairwise::{
+///     AngularMask, AnisotropicEnergy, Boxcar, angular_mask::Patch,
+/// };
 /// use hoomd_vector::Angle;
 /// use std::f64::consts::PI;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let boxcar = Boxcar { epsilon: -1.0, left: 1.0, right: 1.5 };
-/// let masks = [Patch { director: [1.0, 0.0].try_into()?, cos_delta: (PI / 8.0).cos() }];
+/// let boxcar = Boxcar {
+///     epsilon: -1.0,
+///     left: 1.0,
+///     right: 1.5,
+/// };
+/// let masks = [Patch {
+///     director: [1.0, 0.0].try_into()?,
+///     cos_delta: (PI / 8.0).cos(),
+/// }];
 /// let angular_mask = AngularMask::new(boxcar, masks);
 ///
 /// let energy = angular_mask.energy(&[1.0, 0.0].into(), &Angle::from(0.0));
@@ -134,21 +143,43 @@ pub struct Patch<V> {
 ///
 /// Apply different patches to the _i_ and _j_ particles:
 /// ```
-/// use hoomd_interaction::pairwise::{AngularMask, AnisotropicEnergy, Boxcar, angular_mask::Patch};
+/// use hoomd_interaction::pairwise::{
+///     AngularMask, AnisotropicEnergy, Boxcar, angular_mask::Patch,
+/// };
 /// use hoomd_vector::Angle;
 /// use std::f64::consts::PI;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let boxcar = Boxcar { epsilon: -1.0, left: 1.0, right: 1.5 };
-/// let masks_i = vec![Patch { director: [1.0, 0.0].try_into()?, cos_delta: (PI / 8.0).cos() },
-/// Patch { director: [-1.0, 0.0].try_into()?, cos_delta: (PI / 8.0).cos() }];
-/// let masks_j = vec![Patch { director: [0.0, 1.0].try_into()?, cos_delta: (PI / 8.0).cos() }];
-/// let angular_mask = AngularMask { isotropic: boxcar, masks_i, masks_j, };
+/// let boxcar = Boxcar {
+///     epsilon: -1.0,
+///     left: 1.0,
+///     right: 1.5,
+/// };
+/// let masks_i = vec![
+///     Patch {
+///         director: [1.0, 0.0].try_into()?,
+///         cos_delta: (PI / 8.0).cos(),
+///     },
+///     Patch {
+///         director: [-1.0, 0.0].try_into()?,
+///         cos_delta: (PI / 8.0).cos(),
+///     },
+/// ];
+/// let masks_j = vec![Patch {
+///     director: [0.0, 1.0].try_into()?,
+///     cos_delta: (PI / 8.0).cos(),
+/// }];
+/// let angular_mask = AngularMask {
+///     isotropic: boxcar,
+///     masks_i,
+///     masks_j,
+/// };
 ///
 /// let energy = angular_mask.energy(&[-1.0, 0.0].into(), &Angle::from(0.0));
 /// assert_eq!(energy, 0.0);
 ///
-/// let energy = angular_mask.energy(&[-1.0, 0.0].into(), &Angle::from(-PI / 2.0));
+/// let energy =
+///     angular_mask.energy(&[-1.0, 0.0].into(), &Angle::from(-PI / 2.0));
 /// assert_eq!(energy, -1.0);
 /// # Ok(())
 /// # }

--- a/hoomd-interaction/src/pairwise/angular_mask.rs
+++ b/hoomd-interaction/src/pairwise/angular_mask.rs
@@ -123,12 +123,9 @@ pub struct Patch<V> {
 /// let masks = [Patch { director: [1.0, 0.0].try_into()?, cos_delta: (PI / 8.0).cos() }];
 /// let angular_mask = AngularMask::new(boxcar, masks);
 ///
-/// With the same relative orientation, the patches do not overlap and the
-/// energy is 0.
 /// let energy = angular_mask.energy(&[1.0, 0.0].into(), &Angle::from(0.0));
 /// assert_eq!(energy, 0.0);
 ///
-/// Rotate the j particle to point at the i particle so the patches overlap.
 /// let energy = angular_mask.energy(&[1.0, 0.0].into(), &Angle::from(PI));
 /// assert_eq!(energy, -1.0);
 /// # Ok(())
@@ -148,12 +145,9 @@ pub struct Patch<V> {
 /// let masks_j = vec![Patch { director: [0.0, 1.0].try_into()?, cos_delta: (PI / 8.0).cos() }];
 /// let angular_mask = AngularMask { isotropic: boxcar, masks_i, masks_j, };
 ///
-/// With the same relative orientation, the patches do not overlap and the
-/// energy is 0.
 /// let energy = angular_mask.energy(&[-1.0, 0.0].into(), &Angle::from(0.0));
 /// assert_eq!(energy, 0.0);
 ///
-/// Rotate the j particle to point at the i particle so the patches overlap.
 /// let energy = angular_mask.energy(&[-1.0, 0.0].into(), &Angle::from(-PI / 2.0));
 /// assert_eq!(energy, -1.0);
 /// # Ok(())

--- a/hoomd-interaction/src/pairwise/anisotropic.rs
+++ b/hoomd-interaction/src/pairwise/anisotropic.rs
@@ -1,40 +1,47 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement `Anisotropic`
- */
+//! Implement `Anisotropic`
 
 use super::AnisotropicEnergy;
 use crate::SitePairEnergy;
 use hoomd_microstate::property::{Orientation, Position};
 use hoomd_vector::{Rotate, Rotation, Vector};
 
-/** Compute anisotropic properties from a pair of sites.
-
-[`Anisotropic`] is a newtype that provides a single implementation to compute
-pairwise properties. It fills the gap between traits like [`SitePairEnergy`]
-which operates on site properties and [`AnisotropicEnergy`] which is a function
-only of the the relative position and orientation.
-
-Use [`Anisotropic`] with [`CutoffPair`](crate::CutoffPair) in MD and MC
-simulations.
-
-# Example
-
-```
-use hoomd_interaction::pairwise::{AngularMask, Anisotropic, Boxcar, angular_mask::Patch};
-use hoomd_vector::Angle;
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let boxcar = Boxcar { epsilon: -1.0, left: 1.0, right: 1.5 };
-let masks = [Patch { director: [1.0, 0.0].try_into()?, cos_delta: (PI / 8.0).cos() }];
-
-let angular_mask = Anisotropic(AngularMask::new(boxcar, masks));
-# Ok(())
-# }
-```
-*/
+/// Compute anisotropic properties from a pair of sites.
+///
+/// [`Anisotropic`] is a newtype that provides a single implementation to compute
+/// pairwise properties. It fills the gap between traits like [`SitePairEnergy`]
+/// which operates on site properties and [`AnisotropicEnergy`] which is a function
+/// only of the the relative position and orientation.
+///
+/// Use [`Anisotropic`] with [`CutoffPair`](crate::CutoffPair) in MD and MC
+/// simulations.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::pairwise::{
+///     AngularMask, Anisotropic, Boxcar, angular_mask::Patch,
+/// };
+/// use hoomd_vector::Angle;
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let boxcar = Boxcar {
+///     epsilon: -1.0,
+///     left: 1.0,
+///     right: 1.5,
+/// };
+/// let masks = [Patch {
+///     director: [1.0, 0.0].try_into()?,
+///     cos_delta: (PI / 8.0).cos(),
+/// }];
+///
+/// let angular_mask = Anisotropic(AngularMask::new(boxcar, masks));
+/// # Ok(())
+/// # }
+/// ```
 pub struct Anisotropic<E>(pub E);
 
 impl<V, R, S, E> SitePairEnergy<S> for Anisotropic<E>
@@ -44,39 +51,53 @@ where
     R: Rotation + Rotate<V>,
     E: AnisotropicEnergy<V, R>,
 {
-    /** Compute the pair energy between two sites.
-
-
-    # Example
-
-    ```
-    use hoomd_interaction::{SitePairEnergy,
-        pairwise::{AngularMask, Anisotropic, Boxcar, angular_mask::Patch}};
-    use hoomd_microstate::property::OrientedPoint;
-    use hoomd_vector::{Angle, Cartesian};
-    use std::f64::consts::PI;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let boxcar = Boxcar { epsilon: -1.0, left: 1.0, right: 1.5 };
-    let masks = [Patch { director: [1.0, 0.0].try_into()?, cos_delta: (PI / 8.0).cos() }];
-
-    let angular_mask = Anisotropic(AngularMask::new(boxcar, masks));
-
-    let a = OrientedPoint { position: Cartesian::from([0.0, 0.0]),
-        orientation: Angle::from(0.0), };
-    let b = OrientedPoint { position: Cartesian::from([1.0, 0.0]),
-        orientation: Angle::from(0.0), };
-    let energy = angular_mask.site_pair_energy(&a, &b);
-    assert_eq!(energy, 0.0);
-
-    let c = OrientedPoint { position: Cartesian::from([1.0, 0.0]),
-        orientation: Angle::from(PI), };
-    let energy = angular_mask.site_pair_energy(&a, &c);
-    assert_eq!(energy, -1.0);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Compute the pair energy between two sites.
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_interaction::{
+    ///     SitePairEnergy,
+    ///     pairwise::{AngularMask, Anisotropic, Boxcar, angular_mask::Patch},
+    /// };
+    /// use hoomd_microstate::property::OrientedPoint;
+    /// use hoomd_vector::{Angle, Cartesian};
+    /// use std::f64::consts::PI;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let boxcar = Boxcar {
+    ///     epsilon: -1.0,
+    ///     left: 1.0,
+    ///     right: 1.5,
+    /// };
+    /// let masks = [Patch {
+    ///     director: [1.0, 0.0].try_into()?,
+    ///     cos_delta: (PI / 8.0).cos(),
+    /// }];
+    ///
+    /// let angular_mask = Anisotropic(AngularMask::new(boxcar, masks));
+    ///
+    /// let a = OrientedPoint {
+    ///     position: Cartesian::from([0.0, 0.0]),
+    ///     orientation: Angle::from(0.0),
+    /// };
+    /// let b = OrientedPoint {
+    ///     position: Cartesian::from([1.0, 0.0]),
+    ///     orientation: Angle::from(0.0),
+    /// };
+    /// let energy = angular_mask.site_pair_energy(&a, &b);
+    /// assert_eq!(energy, 0.0);
+    ///
+    /// let c = OrientedPoint {
+    ///     position: Cartesian::from([1.0, 0.0]),
+    ///     orientation: Angle::from(PI),
+    /// };
+    /// let energy = angular_mask.site_pair_energy(&a, &c);
+    /// assert_eq!(energy, -1.0);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn site_pair_energy(&self, a: &S, b: &S) -> f64 {
         let (r_ab, o_ab) = hoomd_vector::pair_system_to_local(

--- a/hoomd-interaction/src/pairwise/approximate_shape_overlap.rs
+++ b/hoomd-interaction/src/pairwise/approximate_shape_overlap.rs
@@ -1,49 +1,50 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement [`ApproximateShapeOverlap`].
- */
+//! Implement [`ApproximateShapeOverlap`].
 
 use super::{AnisotropicEnergy, IsotropicEnergy};
 use hoomd_geometry::IntersectsAt;
 use hoomd_utility::valid::PositiveReal;
 use hoomd_vector::{InnerProduct, Rotate, Rotation};
 
-/** Apply an isotropic potential evaluated at the approximate signed overlap distance.
-
-Use [`ApproximateShapeOverlap`] combined with [`OverlapPenalty`] and
-`QuickInsert` to quickly insert new bodies into the microstate or
-`QuickCompress` to quickly compress the system to a target density.
-In both cases, [`ApproximateShapeOverlap`] will allow partial overlaps
-that can be resolved by later trial moves.
-
-[`ApproximateShapeOverlap`] approximates the distance `r` that shape j
-must be moved to remove any overlaps. If the shapes are already separate,
-`r` is 0. Then it returns `isotropic.energy(-r)`. `resolution` sets the
-steps between `r` values.
-
-The overlap distance is *approximate* and expensive to evaluate. Do not
-use this potential for equilibration or sampling. It is suitable *only*
-for use during a brief initialization phase when `QuickInsert` is adding
-bodies or `QuickCompress` is compressing the system.
-
-[`OverlapPenalty`]: crate::pairwise::OverlapPenalty
-
-# Example
-
-```
-use hoomd_interaction::pairwise::{ApproximateShapeOverlap, OverlapPenalty};
-use hoomd_geometry::{Convex, shape::ConvexPolygon};
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let approximate_shape_overlap = ApproximateShapeOverlap::new(
-    Convex(ConvexPolygon::regular(6)),
-    OverlapPenalty::default(),
-    0.01.try_into()?);
-# Ok(())
-# }
-```
-*/
+/// Apply an isotropic potential evaluated at the approximate signed overlap distance.
+///
+/// Use [`ApproximateShapeOverlap`] combined with [`OverlapPenalty`] and
+/// `QuickInsert` to quickly insert new bodies into the microstate or
+/// `QuickCompress` to quickly compress the system to a target density.
+/// In both cases, [`ApproximateShapeOverlap`] will allow partial overlaps
+/// that can be resolved by later trial moves.
+///
+/// [`ApproximateShapeOverlap`] approximates the distance `r` that shape j
+/// must be moved to remove any overlaps. If the shapes are already separate,
+/// `r` is 0. Then it returns `isotropic.energy(-r)`. `resolution` sets the
+/// steps between `r` values.
+///
+/// The overlap distance is *approximate* and expensive to evaluate. Do not
+/// use this potential for equilibration or sampling. It is suitable *only*
+/// for use during a brief initialization phase when `QuickInsert` is adding
+/// bodies or `QuickCompress` is compressing the system.
+///
+/// [`OverlapPenalty`]: crate::pairwise::OverlapPenalty
+///
+/// # Example
+///
+/// ```
+/// use hoomd_geometry::{Convex, shape::ConvexPolygon};
+/// use hoomd_interaction::pairwise::{
+///     ApproximateShapeOverlap, OverlapPenalty,
+/// };
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let approximate_shape_overlap = ApproximateShapeOverlap::new(
+///     Convex(ConvexPolygon::regular(6)),
+///     OverlapPenalty::default(),
+///     0.01.try_into()?,
+/// );
+/// # Ok(())
+/// # }
+/// ```
 pub struct ApproximateShapeOverlap<E, A, B = A> {
     /// The site i's shape.
     pub shape_i: A,
@@ -62,44 +63,55 @@ where
     R: Rotation + Rotate<V>,
     A: IntersectsAt<B, V, R>,
 {
-    /** Evaluate the energy contribution from a pair of sites.
-
-    ```
-    use hoomd_interaction::{SitePairEnergy, pairwise::{Anisotropic, ApproximateShapeOverlap, OverlapPenalty}};
-    use hoomd_geometry::{Convex, shape::ConvexPolygon};
-    use hoomd_microstate::property::OrientedPoint;
-    use hoomd_vector::{Angle, Cartesian};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let approximate_shape_overlap = Anisotropic(ApproximateShapeOverlap::new(
-        Convex(ConvexPolygon::regular(6)),
-        OverlapPenalty::default(),
-        0.01.try_into()?));
-
-    let a = OrientedPoint { position: Cartesian::from([0.0, 0.0]),
-        orientation: Angle::default() };
-    let b = OrientedPoint { position: Cartesian::from([1.2, 0.0]),
-        orientation: Angle::default() };
-
-    let energy = approximate_shape_overlap.site_pair_energy(&a, &b);
-    assert!(energy >= 100.0);
-
-    let c = OrientedPoint { position: Cartesian::from([1.6, 0.0]),
-        orientation: Angle::default() };
-
-    let energy = approximate_shape_overlap.site_pair_energy(&a, &c);
-    assert!(energy >= 0.0);
-    assert!(energy < f64::INFINITY);
-
-    let d = OrientedPoint { position: Cartesian::from([2.0, 0.0]),
-        orientation: Angle::default() };
-
-    let energy = approximate_shape_overlap.site_pair_energy(&a, &d);
-    assert_eq!(energy, 0.0);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Evaluate the energy contribution from a pair of sites.
+    ///
+    /// ```
+    /// use hoomd_geometry::{Convex, shape::ConvexPolygon};
+    /// use hoomd_interaction::{
+    ///     SitePairEnergy,
+    ///     pairwise::{Anisotropic, ApproximateShapeOverlap, OverlapPenalty},
+    /// };
+    /// use hoomd_microstate::property::OrientedPoint;
+    /// use hoomd_vector::{Angle, Cartesian};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let approximate_shape_overlap = Anisotropic(ApproximateShapeOverlap::new(
+    ///     Convex(ConvexPolygon::regular(6)),
+    ///     OverlapPenalty::default(),
+    ///     0.01.try_into()?,
+    /// ));
+    ///
+    /// let a = OrientedPoint {
+    ///     position: Cartesian::from([0.0, 0.0]),
+    ///     orientation: Angle::default(),
+    /// };
+    /// let b = OrientedPoint {
+    ///     position: Cartesian::from([1.2, 0.0]),
+    ///     orientation: Angle::default(),
+    /// };
+    ///
+    /// let energy = approximate_shape_overlap.site_pair_energy(&a, &b);
+    /// assert!(energy >= 100.0);
+    ///
+    /// let c = OrientedPoint {
+    ///     position: Cartesian::from([1.6, 0.0]),
+    ///     orientation: Angle::default(),
+    /// };
+    ///
+    /// let energy = approximate_shape_overlap.site_pair_energy(&a, &c);
+    /// assert!(energy >= 0.0);
+    /// assert!(energy < f64::INFINITY);
+    ///
+    /// let d = OrientedPoint {
+    ///     position: Cartesian::from([2.0, 0.0]),
+    ///     orientation: Angle::default(),
+    /// };
+    ///
+    /// let energy = approximate_shape_overlap.site_pair_energy(&a, &d);
+    /// assert_eq!(energy, 0.0);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn energy(&self, r_ij: &V, o_ij: &R) -> f64 {
         let r = self.shape_i.approximate_separation_distance(
@@ -114,26 +126,28 @@ where
 }
 
 impl<E, G> ApproximateShapeOverlap<E, G> {
-    /** Construct a new approximate shape overlap potential.
-
-    `new()` sets both `shape_i` and `shape_j` to `shape`. Use struct
-    initialization syntax when you need to set these separately.
-
-    # Example
-
-    ```
-    use hoomd_interaction::pairwise::{ApproximateShapeOverlap, OverlapPenalty};
-    use hoomd_geometry::{Convex, shape::ConvexPolygon};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let approximate_shape_overlap = ApproximateShapeOverlap::new(
-        Convex(ConvexPolygon::regular(6)),
-        OverlapPenalty::default(),
-        0.01.try_into()?);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Construct a new approximate shape overlap potential.
+    ///
+    /// `new()` sets both `shape_i` and `shape_j` to `shape`. Use struct
+    /// initialization syntax when you need to set these separately.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_geometry::{Convex, shape::ConvexPolygon};
+    /// use hoomd_interaction::pairwise::{
+    ///     ApproximateShapeOverlap, OverlapPenalty,
+    /// };
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let approximate_shape_overlap = ApproximateShapeOverlap::new(
+    ///     Convex(ConvexPolygon::regular(6)),
+    ///     OverlapPenalty::default(),
+    ///     0.01.try_into()?,
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     pub fn new(shape: G, isotropic: E, resolution: PositiveReal) -> Self
     where

--- a/hoomd-interaction/src/pairwise/boxcar.rs
+++ b/hoomd-interaction/src/pairwise/boxcar.rs
@@ -1,53 +1,59 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement [`Boxcar`]
- */
+//! Implement [`Boxcar`]
 
 use super::IsotropicEnergy;
 
-/** Constant valued potential in a given range of `r` (_not differentiable_).
-
-```math
-U(r) = \begin{cases}
-0 & r \lt a \\
-\varepsilon & a \le r \lt b \\
-0 & r \ge b
-\end{cases}
-```
-
-Compute boxcar potential function. Some uses of this in the literature call it
-the "square well" potential.
-
-# Examples
-
-Basic usage:
-
-```
-use hoomd_interaction::pairwise::{IsotropicEnergy, Boxcar};
-
-let epsilon = 1.5;
-let (left,right) = (1.0, 2.5);
-
-let boxcar = Boxcar { epsilon, left, right };
-assert_eq!(boxcar.energy(0.0), 0.0);
-assert_eq!(boxcar.energy(1.0), 1.5);
-assert_eq!(boxcar.energy(2.0), 1.5);
-assert_eq!(boxcar.energy(2.5), 0.0);
-assert_eq!(boxcar.energy(1000.0), 0.0);
-```
-
-The parameters are public fields and may be accessed directly:
-
-```
-use hoomd_interaction::pairwise::{IsotropicEnergy, Boxcar};
-
-let mut boxcar = Boxcar { epsilon: 1.5, left: 1.0, right: 2.5 };
-boxcar.epsilon = -2.0;
-boxcar.left = 0.0;
-boxcar.right = 1.0;
-```
-*/
+/// Constant valued potential in a given range of `r` (_not differentiable_).
+///
+/// ```math
+/// U(r) = \begin{cases}
+/// 0 & r \lt a \\
+/// \varepsilon & a \le r \lt b \\
+/// 0 & r \ge b
+/// \end{cases}
+/// ```
+///
+/// Compute boxcar potential function. Some uses of this in the literature call it
+/// the "square well" potential.
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```
+/// use hoomd_interaction::pairwise::{Boxcar, IsotropicEnergy};
+///
+/// let epsilon = 1.5;
+/// let (left, right) = (1.0, 2.5);
+///
+/// let boxcar = Boxcar {
+///     epsilon,
+///     left,
+///     right,
+/// };
+/// assert_eq!(boxcar.energy(0.0), 0.0);
+/// assert_eq!(boxcar.energy(1.0), 1.5);
+/// assert_eq!(boxcar.energy(2.0), 1.5);
+/// assert_eq!(boxcar.energy(2.5), 0.0);
+/// assert_eq!(boxcar.energy(1000.0), 0.0);
+/// ```
+///
+/// The parameters are public fields and may be accessed directly:
+///
+/// ```
+/// use hoomd_interaction::pairwise::{Boxcar, IsotropicEnergy};
+///
+/// let mut boxcar = Boxcar {
+///     epsilon: 1.5,
+///     left: 1.0,
+///     right: 2.5,
+/// };
+/// boxcar.epsilon = -2.0;
+/// boxcar.left = 0.0;
+/// boxcar.right = 1.0;
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Boxcar {
     /// Energy scale *(\[energy\])*.

--- a/hoomd-interaction/src/pairwise/expanded.rs
+++ b/hoomd-interaction/src/pairwise/expanded.rs
@@ -1,33 +1,36 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement [`Expanded`]
- */
+//! Implement [`Expanded`]
 
 use super::{IsotropicEnergy, IsotropicForce};
 
-/** Expand another potential.
-
-```math
-U(r) = f(r - \delta)
-```
-
-# Example
-
-Expanded Lennard-Jones:
-```
-use hoomd_interaction::pairwise::{LennardJones, IsotropicEnergy, Expanded};
-use approx::{assert_abs_diff_eq, assert_relative_eq};
-
-let epsilon = 1.5;
-let sigma = 1.0;
-let delta = 0.75;
-let lj: LennardJones = LennardJones { epsilon, sigma };
-let expanded_lj = Expanded { f: lj, delta };
-
-assert_abs_diff_eq!(expanded_lj.energy(1.0), expanded_lj.f.energy(1.0 - 0.75));
-```
-*/
+/// Expand another potential.
+///
+/// ```math
+/// U(r) = f(r - \delta)
+/// ```
+///
+/// # Example
+///
+/// Expanded Lennard-Jones:
+/// ```
+/// use approx::{assert_abs_diff_eq, assert_relative_eq};
+/// use hoomd_interaction::pairwise::{
+///     Expanded, IsotropicEnergy, LennardJones,
+/// };
+///
+/// let epsilon = 1.5;
+/// let sigma = 1.0;
+/// let delta = 0.75;
+/// let lj: LennardJones = LennardJones { epsilon, sigma };
+/// let expanded_lj = Expanded { f: lj, delta };
+///
+/// assert_abs_diff_eq!(
+///     expanded_lj.energy(1.0),
+///     expanded_lj.f.energy(1.0 - 0.75)
+/// );
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 pub struct Expanded<F> {
     /// The original potential.
@@ -40,12 +43,11 @@ impl<F> Default for Expanded<F>
 where
     F: Default,
 {
-    /** Construct a shifted potential with default parameters
-
-    The defaults are:
-    * `f = F::default()`
-    * `delta = 0.0`
-    */
+    /// Construct a shifted potential with default parameters
+    ///
+    /// The defaults are:
+    /// `f = F::default()`
+    /// `delta = 0.0`
     #[inline]
     fn default() -> Self {
         Self {

--- a/hoomd-interaction/src/pairwise/hard_shape.rs
+++ b/hoomd-interaction/src/pairwise/hard_shape.rs
@@ -13,7 +13,7 @@ use hoomd_vector::{self, Rotate, Rotation, Vector};
 /// [`HardShape`] represents each site with a hard shape.
 ///
 /// The generic type names are:
-/// `G`: The [`shape`](hoomd_geometry::shape) type.
+/// * `G`: The [`shape`](hoomd_geometry::shape) type.
 ///
 /// # Example
 ///

--- a/hoomd-interaction/src/pairwise/hard_shape.rs
+++ b/hoomd-interaction/src/pairwise/hard_shape.rs
@@ -1,34 +1,32 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement `HardShape`
- */
+//! Implement `HardShape`
 
 use crate::SitePairOverlap;
 use hoomd_geometry::IntersectsAt;
 use hoomd_microstate::property::{Orientation, Position};
 use hoomd_vector::{self, Rotate, Rotation, Vector};
 
-/** Infinite energy when sites overlap, 0 when they don't (*not differentiable*).
-
-[`HardShape`] represents each site with a hard shape.
-
-The generic type names are:
-* `G`: The [`shape`](hoomd_geometry::shape) type.
-
-# Example
-
-```
-use hoomd_interaction::pairwise::HardShape;
-use hoomd_geometry::{Convex, shape::Rectangle};
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let square = Rectangle::with_equal_edges(1.0.try_into()?);
-let hard_shape = HardShape(Convex(square));
-# Ok(())
-# }
-```
-*/
+/// Infinite energy when sites overlap, 0 when they don't (*not differentiable*).
+///
+/// [`HardShape`] represents each site with a hard shape.
+///
+/// The generic type names are:
+/// `G`: The [`shape`](hoomd_geometry::shape) type.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_geometry::{Convex, shape::Rectangle};
+/// use hoomd_interaction::pairwise::HardShape;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let square = Rectangle::with_equal_edges(1.0.try_into()?);
+/// let hard_shape = HardShape(Convex(square));
+/// # Ok(())
+/// # }
+/// ```
 pub struct HardShape<G>(pub G);
 
 impl<S, G, V, R> SitePairOverlap<S> for HardShape<G>
@@ -38,39 +36,41 @@ where
     R: Rotation + Rotate<V>,
     G: IntersectsAt<G, V, R>,
 {
-    /** Test whether two sites overlap.
-
-    # Example
-
-    ```
-    use hoomd_interaction::{SitePairOverlap, pairwise::HardShape};
-    use hoomd_geometry::{Convex, shape::Rectangle};
-    use hoomd_microstate::property::OrientedPoint;
-    use hoomd_vector::{Angle, Cartesian};
-    use std::f64::consts::PI;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let square = Rectangle::with_equal_edges(1.0.try_into()?);
-    let hard_shape = HardShape(Convex(square));
-
-    let a = OrientedPoint { position: Cartesian::from([1.0, -1.0]),
-        orientation: Angle::from(PI / 2.0),
-    };
-    let b = OrientedPoint { position: Cartesian::from([2.0, 0.0]),
-        orientation: Angle::from(PI / 4.0),
-    };
-
-    assert!(!hard_shape.site_pair_overlap(&a, &b));
-
-    let c = OrientedPoint { position: Cartesian::from([1.5, -0.5]),
-        orientation: Angle::from(PI / 4.0),
-    };
-
-    assert!(hard_shape.site_pair_overlap(&a, &c));
-    # Ok(())
-    # }
-    ```
-    */
+    /// Test whether two sites overlap.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_geometry::{Convex, shape::Rectangle};
+    /// use hoomd_interaction::{SitePairOverlap, pairwise::HardShape};
+    /// use hoomd_microstate::property::OrientedPoint;
+    /// use hoomd_vector::{Angle, Cartesian};
+    /// use std::f64::consts::PI;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let square = Rectangle::with_equal_edges(1.0.try_into()?);
+    /// let hard_shape = HardShape(Convex(square));
+    ///
+    /// let a = OrientedPoint {
+    ///     position: Cartesian::from([1.0, -1.0]),
+    ///     orientation: Angle::from(PI / 2.0),
+    /// };
+    /// let b = OrientedPoint {
+    ///     position: Cartesian::from([2.0, 0.0]),
+    ///     orientation: Angle::from(PI / 4.0),
+    /// };
+    ///
+    /// assert!(!hard_shape.site_pair_overlap(&a, &b));
+    ///
+    /// let c = OrientedPoint {
+    ///     position: Cartesian::from([1.5, -0.5]),
+    ///     orientation: Angle::from(PI / 4.0),
+    /// };
+    ///
+    /// assert!(hard_shape.site_pair_overlap(&a, &c));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn site_pair_overlap(&self, a: &S, b: &S) -> bool {
         let (v_ij, o_ij) = hoomd_vector::pair_system_to_local(

--- a/hoomd-interaction/src/pairwise/harmonic.rs
+++ b/hoomd-interaction/src/pairwise/harmonic.rs
@@ -1,45 +1,45 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement [`Harmonic`]
- */
+//! Implement [`Harmonic`]
 
 use super::{IsotropicEnergy, IsotropicForce};
 
-/** Quadratic potential well centered at a given separation distance.
-
-```math
-U = \frac{1}{2} k (r - r_0)^2
-```
-
-Compute the harmonic potential and force as a function of `r` with
-equilibrium spring length `r_0`.
-
-# Examples
-
-```
-use hoomd_interaction::pairwise::{IsotropicEnergy, IsotropicForce, Harmonic};
-use approx::{assert_abs_diff_eq, assert_relative_eq};
-
-let k = 2.0;
-let r_0 = 0.0;
-
-let harmonic = Harmonic{ k, r_0 };
-assert_abs_diff_eq!(harmonic.energy(0.0), 0.0);
-assert_relative_eq!(harmonic.energy(1.0), 1.0);
-assert_abs_diff_eq!(harmonic.force(1.0), -2.0, epsilon=1e-12);
-```
-
-The parameters are public fields and may be accessed directly:
-
-```
-use hoomd_interaction::pairwise::Harmonic;
-
-let mut harmonic = Harmonic{ k: 1.0, r_0: 0.0};
-harmonic.k = 5.0;
-harmonic.r_0 = 1.0;
-```
-*/
+/// Quadratic potential well centered at a given separation distance.
+///
+/// ```math
+/// U = \frac{1}{2} k (r - r_0)^2
+/// ```
+///
+/// Compute the harmonic potential and force as a function of `r` with
+/// equilibrium spring length `r_0`.
+///
+/// # Examples
+///
+/// ```
+/// use approx::{assert_abs_diff_eq, assert_relative_eq};
+/// use hoomd_interaction::pairwise::{
+///     Harmonic, IsotropicEnergy, IsotropicForce,
+/// };
+///
+/// let k = 2.0;
+/// let r_0 = 0.0;
+///
+/// let harmonic = Harmonic { k, r_0 };
+/// assert_abs_diff_eq!(harmonic.energy(0.0), 0.0);
+/// assert_relative_eq!(harmonic.energy(1.0), 1.0);
+/// assert_abs_diff_eq!(harmonic.force(1.0), -2.0, epsilon = 1e-12);
+/// ```
+///
+/// The parameters are public fields and may be accessed directly:
+///
+/// ```
+/// use hoomd_interaction::pairwise::Harmonic;
+///
+/// let mut harmonic = Harmonic { k: 1.0, r_0: 0.0 };
+/// harmonic.k = 5.0;
+/// harmonic.r_0 = 1.0;
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Harmonic {
     /// Spring constant $`[\mathrm{energy}] [\mathrm{length}]^{-2}`$.

--- a/hoomd-interaction/src/pairwise/harmonic_repulsion.rs
+++ b/hoomd-interaction/src/pairwise/harmonic_repulsion.rs
@@ -1,68 +1,68 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement [`HarmonicRepulsion`]
- */
+//! Implement [`HarmonicRepulsion`]
 
 use super::{IsotropicEnergy, IsotropicForce};
 
-/** Repulsive half of a quadratic potential well.
-
-[`HarmonicRepulsion`] is the conservative part of the dissipative particle
-dynamics soft potential. The parameter `a` controls the strength of the
-potential and `r_cut` sets the distance at which the energy goes to 0.
-
-
-The potential produce the radially repulsive force between particles as:
-```math
-F(r) = \begin{cases}
--\frac{A}{r_\mathrm{cut}} \left( r - r_\mathrm{cut}\right) & r < r_\mathrm{cut} \\
-
-0 & r \ge r_\mathrm{cut}
-\end{cases}
-```
-
-resulting from the potential energy:
-```math
-U(r) = \begin{cases}
-\frac{1}{2} \frac{A}{r_\mathrm{cut}} \left(r - r_\mathrm{cut}\right)^2 & r \lt r_\mathrm{cut} \\
-
-0 & r \ge r_\mathrm{cut}
-\end{cases}
-```
-
-This potential forms the left half of a harmonic well centered at
-$`r = r_\mathrm{cut}`$ with a spring constant $`k = \frac{A}{r_\mathrm{cut}}`$.
-
-Note that this potential has a maximum value of $`A`$ at $`r=0`$ and is
-therefore allows particles to completely overlap.
-
-# Examples
-
-
-```
-use hoomd_interaction::pairwise::{IsotropicEnergy, IsotropicForce, HarmonicRepulsion};
-use approx::{assert_abs_diff_eq, assert_relative_eq};
-
-let a = 1.0;
-let r_cut = 1.0;
-
-let h_repsulsion = HarmonicRepulsion{ a, r_cut };
-assert_abs_diff_eq!(h_repsulsion.energy(1.5), 0.0);
-assert_relative_eq!(h_repsulsion.energy(0.5), 0.125);
-assert_abs_diff_eq!(h_repsulsion.force(0.5), 0.5, epsilon=1e-12);
-```
-
-The parameters are public fields and may be accessed directly:
-
-```
-use hoomd_interaction::pairwise::HarmonicRepulsion;
-
-let mut h_repulsion = HarmonicRepulsion{ a: 1.0, r_cut: 1.0};
-h_repulsion.a = 5.0;
-h_repulsion.r_cut = 0.75;
-```
-*/
+/// Repulsive half of a quadratic potential well.
+///
+/// [`HarmonicRepulsion`] is the conservative part of the dissipative particle
+/// dynamics soft potential. The parameter `a` controls the strength of the
+/// potential and `r_cut` sets the distance at which the energy goes to 0.
+///
+///
+/// The potential produce the radially repulsive force between particles as:
+/// ```math
+/// F(r) = \begin{cases}
+/// -\frac{A}{r_\mathrm{cut}} \left( r - r_\mathrm{cut}\right) & r < r_\mathrm{cut} \\
+///
+/// 0 & r \ge r_\mathrm{cut}
+/// \end{cases}
+/// ```
+///
+/// resulting from the potential energy:
+/// ```math
+/// U(r) = \begin{cases}
+/// \frac{1}{2} \frac{A}{r_\mathrm{cut}} \left(r - r_\mathrm{cut}\right)^2 & r \lt r_\mathrm{cut} \\
+///
+/// 0 & r \ge r_\mathrm{cut}
+/// \end{cases}
+/// ```
+///
+/// This potential forms the left half of a harmonic well centered at
+/// $`r = r_\mathrm{cut}`$ with a spring constant $`k = \frac{A}{r_\mathrm{cut}}`$.
+///
+/// Note that this potential has a maximum value of $`A`$ at $`r=0`$ and is
+/// therefore allows particles to completely overlap.
+///
+/// # Examples
+///
+///
+/// ```
+/// use approx::{assert_abs_diff_eq, assert_relative_eq};
+/// use hoomd_interaction::pairwise::{
+///     HarmonicRepulsion, IsotropicEnergy, IsotropicForce,
+/// };
+///
+/// let a = 1.0;
+/// let r_cut = 1.0;
+///
+/// let h_repsulsion = HarmonicRepulsion { a, r_cut };
+/// assert_abs_diff_eq!(h_repsulsion.energy(1.5), 0.0);
+/// assert_relative_eq!(h_repsulsion.energy(0.5), 0.125);
+/// assert_abs_diff_eq!(h_repsulsion.force(0.5), 0.5, epsilon = 1e-12);
+/// ```
+///
+/// The parameters are public fields and may be accessed directly:
+///
+/// ```
+/// use hoomd_interaction::pairwise::HarmonicRepulsion;
+///
+/// let mut h_repulsion = HarmonicRepulsion { a: 1.0, r_cut: 1.0 };
+/// h_repulsion.a = 5.0;
+/// h_repulsion.r_cut = 0.75;
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct HarmonicRepulsion {
     /// Potential strength $`[\mathrm{energy}] [\mathrm{length}]^{-1}`$.

--- a/hoomd-interaction/src/pairwise/isotropic.rs
+++ b/hoomd-interaction/src/pairwise/isotropic.rs
@@ -1,44 +1,52 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement Isotropic
- */
+//! Implement Isotropic
 
 use super::IsotropicEnergy;
 use crate::SitePairEnergy;
 use hoomd_microstate::property::Position;
 use hoomd_vector::Vector;
 
-/** Compute isotropic properties from a pair of sites
-
-[`Isotropic`] is a newtype that provides a single implementation to compute
-pairwise properties. It fills the gap between traits like [`SitePairEnergy`]
-which operates on site properties and [`IsotropicEnergy`] which is a function
-only of the separation distance.
-
-Use [`Isotropic`] with [`CutoffPair`](crate::CutoffPair) in MD and MC
-simulations.
-
-# Example
-
-```
-use hoomd_interaction::{SitePairEnergy, pairwise::{Isotropic, LennardJones}};
-use hoomd_microstate::property::Point;
-use hoomd_vector::Cartesian;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let a = Point { position: Cartesian::from([0.0, 0.0]) };
-let b = Point { position: Cartesian::from([0.0, 2.0 * 2.0_f64.powf(1.0/6.0)]) };
-
-let lennard_jones: LennardJones = LennardJones { epsilon: 1.5, sigma: 2.0 };
-let lennard_jones = Isotropic(lennard_jones);
-
-let energy = lennard_jones.site_pair_energy(&a, &b);
-assert_eq!(energy, -1.5);
-# Ok(())
-# }
-```
-*/
+/// Compute isotropic properties from a pair of sites
+///
+/// [`Isotropic`] is a newtype that provides a single implementation to compute
+/// pairwise properties. It fills the gap between traits like [`SitePairEnergy`]
+/// which operates on site properties and [`IsotropicEnergy`] which is a function
+/// only of the separation distance.
+///
+/// Use [`Isotropic`] with [`CutoffPair`](crate::CutoffPair) in MD and MC
+/// simulations.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::{
+///     SitePairEnergy,
+///     pairwise::{Isotropic, LennardJones},
+/// };
+/// use hoomd_microstate::property::Point;
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let a = Point {
+///     position: Cartesian::from([0.0, 0.0]),
+/// };
+/// let b = Point {
+///     position: Cartesian::from([0.0, 2.0 * 2.0_f64.powf(1.0 / 6.0)]),
+/// };
+///
+/// let lennard_jones: LennardJones = LennardJones {
+///     epsilon: 1.5,
+///     sigma: 2.0,
+/// };
+/// let lennard_jones = Isotropic(lennard_jones);
+///
+/// let energy = lennard_jones.site_pair_energy(&a, &b);
+/// assert_eq!(energy, -1.5);
+/// # Ok(())
+/// # }
+/// ```
 pub struct Isotropic<E>(pub E);
 
 impl<V, S, E> SitePairEnergy<S> for Isotropic<E>

--- a/hoomd-interaction/src/pairwise/lennard_jones.rs
+++ b/hoomd-interaction/src/pairwise/lennard_jones.rs
@@ -1,61 +1,77 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement [`LennardJones`]
- */
+//! Implement [`LennardJones`]
 
 use super::{IsotropicEnergy, IsotropicForce};
 
-/** Potential with a steep repulsive core and an attractive well.
-
-```math
-U(r) = 4 \varepsilon \left[ \left( \frac{\sigma}{r} \right)^{N} - \left( \frac{\sigma}{r} \right)^{M} \right]
-```
-
-Compute the Lennard-Jones (LJ) potential and force as a function of `r`.
-
-# Examples
-
-In basic usage, the exponents `N` and `M` default to 12 and 6, respectively:
-
-```
-use hoomd_interaction::pairwise::{IsotropicEnergy, IsotropicForce, LennardJones};
-use approx::{assert_abs_diff_eq, assert_relative_eq};
-
-let epsilon = 1.5;
-let sigma = 2.5;
-
-let lennard_jones: LennardJones = LennardJones { epsilon, sigma };
-assert_abs_diff_eq!(lennard_jones.energy(sigma), 0.0);
-assert_relative_eq!(lennard_jones.energy(2.0_f64.powf(1.0 / 6.0) * sigma), -epsilon);
-assert_abs_diff_eq!(lennard_jones.force(2.0_f64.powf(1.0 / 6.0) * sigma), 0.0, epsilon=1e-12);
-```
-
-You can choose any values for `N` and `M` _at compile time_:
-
-```
-use hoomd_interaction::pairwise::{IsotropicEnergy, IsotropicForce, LennardJones};
-use approx::{assert_abs_diff_eq, assert_relative_eq};
-
-let epsilon = 1.5;
-let sigma = 2.5;
-
-let lennard_jones: LennardJones<8,4> = LennardJones { epsilon, sigma };
-assert_abs_diff_eq!(lennard_jones.energy(sigma), 0.0);
-assert_relative_eq!(lennard_jones.energy(2.0_f64.powf(1.0 / 4.0) * sigma), -epsilon);
-assert_abs_diff_eq!(lennard_jones.force(2.0_f64.powf(1.0 / 4.0) * sigma), 0.0, epsilon=1e-12);
-```
-
-The parameters are public fields and may be accessed directly:
-
-```
-use hoomd_interaction::pairwise::{LennardJones};
-
-let mut lennard_jones: LennardJones = LennardJones::default();
-lennard_jones.epsilon = 1.5;
-lennard_jones.sigma = 3.0;
-```
-*/
+/// Potential with a steep repulsive core and an attractive well.
+///
+/// ```math
+/// U(r) = 4 \varepsilon \left[ \left( \frac{\sigma}{r} \right)^{N} - \left( \frac{\sigma}{r} \right)^{M} \right]
+/// ```
+///
+/// Compute the Lennard-Jones (LJ) potential and force as a function of `r`.
+///
+/// # Examples
+///
+/// In basic usage, the exponents `N` and `M` default to 12 and 6, respectively:
+///
+/// ```
+/// use approx::{assert_abs_diff_eq, assert_relative_eq};
+/// use hoomd_interaction::pairwise::{
+///     IsotropicEnergy, IsotropicForce, LennardJones,
+/// };
+///
+/// let epsilon = 1.5;
+/// let sigma = 2.5;
+///
+/// let lennard_jones: LennardJones = LennardJones { epsilon, sigma };
+/// assert_abs_diff_eq!(lennard_jones.energy(sigma), 0.0);
+/// assert_relative_eq!(
+///     lennard_jones.energy(2.0_f64.powf(1.0 / 6.0) * sigma),
+///     -epsilon
+/// );
+/// assert_abs_diff_eq!(
+///     lennard_jones.force(2.0_f64.powf(1.0 / 6.0) * sigma),
+///     0.0,
+///     epsilon = 1e-12
+/// );
+/// ```
+///
+/// You can choose any values for `N` and `M` _at compile time_:
+///
+/// ```
+/// use approx::{assert_abs_diff_eq, assert_relative_eq};
+/// use hoomd_interaction::pairwise::{
+///     IsotropicEnergy, IsotropicForce, LennardJones,
+/// };
+///
+/// let epsilon = 1.5;
+/// let sigma = 2.5;
+///
+/// let lennard_jones: LennardJones<8, 4> = LennardJones { epsilon, sigma };
+/// assert_abs_diff_eq!(lennard_jones.energy(sigma), 0.0);
+/// assert_relative_eq!(
+///     lennard_jones.energy(2.0_f64.powf(1.0 / 4.0) * sigma),
+///     -epsilon
+/// );
+/// assert_abs_diff_eq!(
+///     lennard_jones.force(2.0_f64.powf(1.0 / 4.0) * sigma),
+///     0.0,
+///     epsilon = 1e-12
+/// );
+/// ```
+///
+/// The parameters are public fields and may be accessed directly:
+///
+/// ```
+/// use hoomd_interaction::pairwise::LennardJones;
+///
+/// let mut lennard_jones: LennardJones = LennardJones::default();
+/// lennard_jones.epsilon = 1.5;
+/// lennard_jones.sigma = 3.0;
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LennardJones<const N: i32 = 12, const M: i32 = 6> {
     /// Energy scale *(\[energy\])*.
@@ -65,16 +81,15 @@ pub struct LennardJones<const N: i32 = 12, const M: i32 = 6> {
 }
 
 impl<const N: i32, const M: i32> Default for LennardJones<N, M> {
-    /** Construct a [`LennardJones`] with default parameters (epsilon=1.0, sigma=1.0)
-
-    # Example
-
-    ```
-    use hoomd_interaction::pairwise::LennardJones;
-
-    let lennard_jones: LennardJones = LennardJones::default();
-    ```
-    */
+    /// Construct a [`LennardJones`] with default parameters (epsilon=1.0, sigma=1.0)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_interaction::pairwise::LennardJones;
+    ///
+    /// let lennard_jones: LennardJones = LennardJones::default();
+    /// ```
     #[inline]
     fn default() -> Self {
         Self {

--- a/hoomd-interaction/src/pairwise/lennard_jones_gauss.rs
+++ b/hoomd-interaction/src/pairwise/lennard_jones_gauss.rs
@@ -1,48 +1,56 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement [`LennardJonesGauss`]
- */
+//! Implement [`LennardJonesGauss`]
 
 use super::{IsotropicEnergy, IsotropicForce};
 
-/** Double-well potential with a steep repulsive core
-
-```math
-U(r) = 1[\mathrm{energy}]\cdot\left[ \left(\frac{1[\mathrm{length}]}{r}\right)^{12} - 2\left(\frac{1[\mathrm{length}]}{r}\right)^{6}\right] - \varepsilon \exp \left(-\frac{(r-r_0)^2}{2\sigma^2}\right)
-```
-
-Compute the Lennard-Jones-Gauss (LJG) potential and force as a function of `r`.
-
-# Examples
-
-```
-use hoomd_interaction::pairwise::{IsotropicEnergy, IsotropicForce, LennardJonesGauss};
-use approx::{assert_abs_diff_eq, assert_relative_eq};
-
-let epsilon = 0.5;
-let sigma_squared = 0.5;
-let r_0 = 0.5_f64.powf(1.0 / 6.0);
-
-let lennard_jones_gauss: LennardJonesGauss = LennardJonesGauss { epsilon, sigma_squared, r_0 };
-assert_relative_eq!(lennard_jones_gauss.energy(0.5_f64.powf(1.0 / 6.0)), -epsilon, epsilon=1e-12);
-```
-
-The parameters are public fields and may be accessed directly:
-
-```
-use hoomd_interaction::pairwise::{LennardJonesGauss};
-
-let mut lennard_jones_gauss: LennardJonesGauss = LennardJonesGauss{
-    epsilon: 1.5,
-    sigma_squared: 0.02,
-    r_0:  3.2
-};
-lennard_jones_gauss.epsilon = 1.5;
-lennard_jones_gauss.sigma_squared = 0.02;
-lennard_jones_gauss.r_0 = 3.2;
-```
-*/
+/// Double-well potential with a steep repulsive core
+///
+/// ```math
+/// U(r) = 1[\mathrm{energy}]\cdot\left[ \left(\frac{1[\mathrm{length}]}{r}\right)^{12} - 2\left(\frac{1[\mathrm{length}]}{r}\right)^{6}\right] - \varepsilon \exp \left(-\frac{(r-r_0)^2}{2\sigma^2}\right)
+/// ```
+///
+/// Compute the Lennard-Jones-Gauss (LJG) potential and force as a function of `r`.
+///
+/// # Examples
+///
+/// ```
+/// use approx::{assert_abs_diff_eq, assert_relative_eq};
+/// use hoomd_interaction::pairwise::{
+///     IsotropicEnergy, IsotropicForce, LennardJonesGauss,
+/// };
+///
+/// let epsilon = 0.5;
+/// let sigma_squared = 0.5;
+/// let r_0 = 0.5_f64.powf(1.0 / 6.0);
+///
+/// let lennard_jones_gauss: LennardJonesGauss = LennardJonesGauss {
+///     epsilon,
+///     sigma_squared,
+///     r_0,
+/// };
+/// assert_relative_eq!(
+///     lennard_jones_gauss.energy(0.5_f64.powf(1.0 / 6.0)),
+///     -epsilon,
+///     epsilon = 1e-12
+/// );
+/// ```
+///
+/// The parameters are public fields and may be accessed directly:
+///
+/// ```
+/// use hoomd_interaction::pairwise::LennardJonesGauss;
+///
+/// let mut lennard_jones_gauss: LennardJonesGauss = LennardJonesGauss {
+///     epsilon: 1.5,
+///     sigma_squared: 0.02,
+///     r_0: 3.2,
+/// };
+/// lennard_jones_gauss.epsilon = 1.5;
+/// lennard_jones_gauss.sigma_squared = 0.02;
+/// lennard_jones_gauss.r_0 = 3.2;
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LennardJonesGauss {
     /// Scale of Gaussian, in units of energy

--- a/hoomd-interaction/src/pairwise/overlap_penalty.rs
+++ b/hoomd-interaction/src/pairwise/overlap_penalty.rs
@@ -1,43 +1,41 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement `OverlapPenalty`.
- */
+//! Implement `OverlapPenalty`.
 
 use super::IsotropicEnergy;
 
-/** Monotonically non-decreasing potential to push sites apart (*not differentiable*).
-
-[`OverlapPenalty`] is specifically designed to work with the `QuickInsert`
-and `QuickCompress` protocols to quickly prepare states with non-overlapping
-particles. Combine it with [`ApproximateShapeOverlap`] to compute an energy that
-penalizes hard particle overlaps.
-
-The potential has three regions:
-```math
-U(r) = \begin{cases}
-\infty & r < -d_\mathrm{max} \\
-\frac{1}{2} kr^2 + \varepsilon_\mathrm{shoulder} & r < 0 \\
-0 & r \ge 0
-\end{cases}
-```
-The first region describes a completely hard interaction when sites overlap
-too far. This prevents `QuickInsert` from creating too much strain with an
-insertion. The second part applies a harmonic potential that allows trial moves
-to gradually resolve overlaps. In the third region, sites are allowed to move
-freely when not overlapping. The shoulder potential prevents trial moves from
-creating new overlaps.
-
-[`ApproximateShapeOverlap`]: crate::pairwise::ApproximateShapeOverlap
-
-# Example
-
-```
-use hoomd_interaction::pairwise::OverlapPenalty;
-
-let overlap_penalty = OverlapPenalty::default();
-```
-*/
+/// Monotonically non-decreasing potential to push sites apart (*not differentiable*).
+///
+/// [`OverlapPenalty`] is specifically designed to work with the `QuickInsert`
+/// and `QuickCompress` protocols to quickly prepare states with non-overlapping
+/// particles. Combine it with [`ApproximateShapeOverlap`] to compute an energy that
+/// penalizes hard particle overlaps.
+///
+/// The potential has three regions:
+/// ```math
+/// U(r) = \begin{cases}
+/// \infty & r < -d_\mathrm{max} \\
+/// \frac{1}{2} kr^2 + \varepsilon_\mathrm{shoulder} & r < 0 \\
+/// 0 & r \ge 0
+/// \end{cases}
+/// ```
+/// The first region describes a completely hard interaction when sites overlap
+/// too far. This prevents `QuickInsert` from creating too much strain with an
+/// insertion. The second part applies a harmonic potential that allows trial moves
+/// to gradually resolve overlaps. In the third region, sites are allowed to move
+/// freely when not overlapping. The shoulder potential prevents trial moves from
+/// creating new overlaps.
+///
+/// [`ApproximateShapeOverlap`]: crate::pairwise::ApproximateShapeOverlap
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::pairwise::OverlapPenalty;
+///
+/// let overlap_penalty = OverlapPenalty::default();
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct OverlapPenalty {
     /// Spring stiffness $`[\mathrm{energy}] [\mathrm{length}]^{-2}`$.
@@ -51,26 +49,25 @@ pub struct OverlapPenalty {
 }
 
 impl Default for OverlapPenalty {
-    /** Default overlap penalty parameters.
-
-    The default values are tuned for use with `QuickInsert` and `QuickCompress`
-    applied to systems of spherical particles with diameter approximately 1.
-
-    * $`k = 1000`$
-    * $`d_\mathrm{max} = 0.2`$
-    * $`\varepsilon_\mathrm{shoulder} = 100`$
-
-    Call [`OverlapPenalty::scaled_default`] to initialize with values scaled
-    for use with non-unit diameter sites.
-
-    # Example
-
-    ```
-    use hoomd_interaction::pairwise::OverlapPenalty;
-
-    let overlap_penalty = OverlapPenalty::default();
-    ```
-    */
+    /// Default overlap penalty parameters.
+    ///
+    /// The default values are tuned for use with `QuickInsert` and `QuickCompress`
+    /// applied to systems of spherical particles with diameter approximately 1.
+    ///
+    /// $`k = 1000`$
+    /// $`d_\mathrm{max} = 0.2`$
+    /// $`\varepsilon_\mathrm{shoulder} = 100`$
+    ///
+    /// Call [`OverlapPenalty::scaled_default`] to initialize with values scaled
+    /// for use with non-unit diameter sites.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_interaction::pairwise::OverlapPenalty;
+    ///
+    /// let overlap_penalty = OverlapPenalty::default();
+    /// ```
     #[inline]
     fn default() -> Self {
         Self {
@@ -82,21 +79,20 @@ impl Default for OverlapPenalty {
 }
 
 impl OverlapPenalty {
-    /** Default overlap penalty parameters for a given diameter.
-
-    Construct an [`OverlapPenalty`] with default parameters scaled to suit
-    a site with the given diameter.
-
-    # Example
-
-    ```
-    use hoomd_interaction::pairwise::OverlapPenalty;
-
-    let overlap_penalty = OverlapPenalty::scaled_default(2.0);
-
-    assert_eq!(overlap_penalty.maximum_allowed_overlap, 0.4);
-    ```
-    */
+    /// Default overlap penalty parameters for a given diameter.
+    ///
+    /// Construct an [`OverlapPenalty`] with default parameters scaled to suit
+    /// a site with the given diameter.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_interaction::pairwise::OverlapPenalty;
+    ///
+    /// let overlap_penalty = OverlapPenalty::scaled_default(2.0);
+    ///
+    /// assert_eq!(overlap_penalty.maximum_allowed_overlap, 0.4);
+    /// ```
     #[must_use]
     #[inline]
     pub fn scaled_default(diameter: f64) -> Self {

--- a/hoomd-interaction/src/pairwise/overlap_penalty.rs
+++ b/hoomd-interaction/src/pairwise/overlap_penalty.rs
@@ -54,9 +54,9 @@ impl Default for OverlapPenalty {
     /// The default values are tuned for use with `QuickInsert` and `QuickCompress`
     /// applied to systems of spherical particles with diameter approximately 1.
     ///
-    /// $`k = 1000`$
-    /// $`d_\mathrm{max} = 0.2`$
-    /// $`\varepsilon_\mathrm{shoulder} = 100`$
+    /// * $`k = 1000`$
+    /// * $`d_\mathrm{max} = 0.2`$
+    /// * $`\varepsilon_\mathrm{shoulder} = 100`$
     ///
     /// Call [`OverlapPenalty::scaled_default`] to initialize with values scaled
     /// for use with non-unit diameter sites.

--- a/hoomd-interaction/src/pairwise/shifted.rs
+++ b/hoomd-interaction/src/pairwise/shifted.rs
@@ -1,47 +1,51 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement [`Shifted`]
- */
+//! Implement [`Shifted`]
 
 use super::{IsotropicEnergy, IsotropicForce};
 
-/** Shift another potential to 0 at a given `r`.
-
-```math
-U(r) = f(r) - f(r_\mathrm{shift})
-```
-
-# Example
-
-Shifted Lennard-Jones:
-```
-use hoomd_interaction::pairwise::{LennardJones, IsotropicEnergy, Shifted};
-use approx::{assert_abs_diff_eq, assert_relative_eq};
-
-let epsilon = 1.5;
-let sigma = 1.0;
-let r_shift = 2.5;
-let lj: LennardJones = LennardJones { epsilon, sigma };
-let shifted_lj = Shifted { f: lj, r_shift };
-
-assert_abs_diff_eq!(shifted_lj.energy(r_shift), 0.0);
-assert_relative_eq!(shifted_lj.energy(2.0_f64.powf(1.0 / 6.0) * sigma), -epsilon - lj.energy(r_shift));
-```
-
-Fields can be accessed directly, including those of the original potential `f`:
-```
-use hoomd_interaction::pairwise::{LennardJones, Shifted};
-
-let epsilon = 1.5;
-let sigma = 1.0;
-let r_shift = 2.5;
-let mut shifted_lj = Shifted{ f: LennardJones::<12,6> { epsilon, sigma }, r_shift };
-
-shifted_lj.r_shift = 3.0;
-shifted_lj.f.sigma = 1.2;
-```
-*/
+/// Shift another potential to 0 at a given `r`.
+///
+/// ```math
+/// U(r) = f(r) - f(r_\mathrm{shift})
+/// ```
+///
+/// # Example
+///
+/// Shifted Lennard-Jones:
+/// ```
+/// use approx::{assert_abs_diff_eq, assert_relative_eq};
+/// use hoomd_interaction::pairwise::{IsotropicEnergy, LennardJones, Shifted};
+///
+/// let epsilon = 1.5;
+/// let sigma = 1.0;
+/// let r_shift = 2.5;
+/// let lj: LennardJones = LennardJones { epsilon, sigma };
+/// let shifted_lj = Shifted { f: lj, r_shift };
+///
+/// assert_abs_diff_eq!(shifted_lj.energy(r_shift), 0.0);
+/// assert_relative_eq!(
+///     shifted_lj.energy(2.0_f64.powf(1.0 / 6.0) * sigma),
+///     -epsilon - lj.energy(r_shift)
+/// );
+/// ```
+///
+/// Fields can be accessed directly, including those of the original potential `f`:
+/// ```
+/// use hoomd_interaction::pairwise::{LennardJones, Shifted};
+///
+/// let epsilon = 1.5;
+/// let sigma = 1.0;
+/// let r_shift = 2.5;
+/// let mut shifted_lj = Shifted {
+///     f: LennardJones::<12, 6> { epsilon, sigma },
+///     r_shift,
+/// };
+///
+/// shifted_lj.r_shift = 3.0;
+/// shifted_lj.f.sigma = 1.2;
+/// ```
 #[derive(Clone, Debug, PartialEq)]
 pub struct Shifted<F> {
     /// The original potential.
@@ -54,20 +58,19 @@ impl<F> Default for Shifted<F>
 where
     F: Default,
 {
-    /** Construct a shifted potential with default parameters
-
-    The defaults are:
-    * `f = F::default()`
-    * `r_shift = 0.0`
-
-    # Example
-
-    ```
-    use hoomd_interaction::pairwise::{LennardJones, Shifted};
-
-    let shifted_lj = Shifted::<LennardJones>::default();
-    ```
-    */
+    /// Construct a shifted potential with default parameters
+    ///
+    /// The defaults are:
+    /// `f = F::default()`
+    /// `r_shift = 0.0`
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_interaction::pairwise::{LennardJones, Shifted};
+    ///
+    /// let shifted_lj = Shifted::<LennardJones>::default();
+    /// ```
     #[inline]
     fn default() -> Self {
         Self {

--- a/hoomd-interaction/src/pairwise/weeks_chandler_anderson.rs
+++ b/hoomd-interaction/src/pairwise/weeks_chandler_anderson.rs
@@ -1,51 +1,55 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement [`WeeksChandlerAnderson`]
- */
+//! Implement [`WeeksChandlerAnderson`]
 
 use super::{IsotropicEnergy, IsotropicForce, LennardJones};
 
-/** Potential with a steep repulsive core.
-
-```math
-U(r) = \begin{cases}
-4 \varepsilon \left[ \left( \frac{\sigma}{r} \right)^{12} - \left( \frac{\sigma}{r} \right)^{6} \right] + \varepsilon & r \lt 2^{1/6} \sigma \\
-
-0 & r \ge 2^{1/6} \sigma
-\end{cases}
-```
-
-Compute the Weeks-Chandler-Anderson (WCA) potential and force as a function of `r`.
-
-# Examples
-
-Basic usage:
-
-```
-use hoomd_interaction::pairwise::{IsotropicEnergy, IsotropicForce, WeeksChandlerAnderson};
-use approx::{assert_abs_diff_eq, assert_relative_eq};
-
-let epsilon = 1.5;
-let sigma = 2.5;
-
-let wca = WeeksChandlerAnderson { epsilon, sigma };
-assert_relative_eq!(wca.energy(sigma), epsilon);
-assert_abs_diff_eq!(wca.energy(2.0*sigma), 0.0);
-assert_relative_eq!(wca.energy(2.0_f64.powf(1.0/6.0) * sigma), 0.0);
-assert_abs_diff_eq!(wca.force(2.0_f64.powf(1.0/6.0) * sigma), 0.0, epsilon=1e-12);
-```
-
-The parameters are public fields and may be accessed directly:
-
-```
-use hoomd_interaction::pairwise::WeeksChandlerAnderson;
-
-let mut wca = WeeksChandlerAnderson::default();
-wca.epsilon = 1.5;
-wca.sigma = 3.0;
-```
-*/
+/// Potential with a steep repulsive core.
+///
+/// ```math
+/// U(r) = \begin{cases}
+/// 4 \varepsilon \left[ \left( \frac{\sigma}{r} \right)^{12} - \left( \frac{\sigma}{r} \right)^{6} \right] + \varepsilon & r \lt 2^{1/6} \sigma \\
+///
+/// 0 & r \ge 2^{1/6} \sigma
+/// \end{cases}
+/// ```
+///
+/// Compute the Weeks-Chandler-Anderson (WCA) potential and force as a function of `r`.
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```
+/// use approx::{assert_abs_diff_eq, assert_relative_eq};
+/// use hoomd_interaction::pairwise::{
+///     IsotropicEnergy, IsotropicForce, WeeksChandlerAnderson,
+/// };
+///
+/// let epsilon = 1.5;
+/// let sigma = 2.5;
+///
+/// let wca = WeeksChandlerAnderson { epsilon, sigma };
+/// assert_relative_eq!(wca.energy(sigma), epsilon);
+/// assert_abs_diff_eq!(wca.energy(2.0 * sigma), 0.0);
+/// assert_relative_eq!(wca.energy(2.0_f64.powf(1.0 / 6.0) * sigma), 0.0);
+/// assert_abs_diff_eq!(
+///     wca.force(2.0_f64.powf(1.0 / 6.0) * sigma),
+///     0.0,
+///     epsilon = 1e-12
+/// );
+/// ```
+///
+/// The parameters are public fields and may be accessed directly:
+///
+/// ```
+/// use hoomd_interaction::pairwise::WeeksChandlerAnderson;
+///
+/// let mut wca = WeeksChandlerAnderson::default();
+/// wca.epsilon = 1.5;
+/// wca.sigma = 3.0;
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WeeksChandlerAnderson {
     /// Energy scale *(\[energy\])*.
@@ -55,16 +59,15 @@ pub struct WeeksChandlerAnderson {
 }
 
 impl Default for WeeksChandlerAnderson {
-    /** Construct a [`WeeksChandlerAnderson`] with default parameters (epsilon=1.0, sigma=1.0)
-
-    # Example
-
-    ```
-    use hoomd_interaction::pairwise::WeeksChandlerAnderson;
-
-    let wca = WeeksChandlerAnderson::default();
-    ```
-    */
+    /// Construct a [`WeeksChandlerAnderson`] with default parameters (epsilon=1.0, sigma=1.0)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_interaction::pairwise::WeeksChandlerAnderson;
+    ///
+    /// let wca = WeeksChandlerAnderson::default();
+    /// ```
     #[inline]
     fn default() -> Self {
         WeeksChandlerAnderson {

--- a/hoomd-interaction/src/pairwise/xplor.rs
+++ b/hoomd-interaction/src/pairwise/xplor.rs
@@ -33,7 +33,6 @@ use super::{IsotropicEnergy, IsotropicForce};
 /// let r_cut = 2.5 * sigma;
 /// let r_smooth = 1.5 * sigma;
 /// let xplor_lj = Xplor { f: LennardJones::<12,6> { epsilon, sigma }, r_cut, r_smooth };
-
 #[derive(Clone, Debug, PartialEq)]
 pub struct Xplor<F> {
     /// The original potential.

--- a/hoomd-interaction/src/pairwise/xplor.rs
+++ b/hoomd-interaction/src/pairwise/xplor.rs
@@ -1,40 +1,38 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement [`WeeksChandlerAnderson`]
- */
+//! Implement [`WeeksChandlerAnderson`]
 
 use super::{IsotropicEnergy, IsotropicForce};
 
-/** Smoothly shift a potential (and its force) to 0 at some `r_cut`, beginning at `r_smooth`.
-
-```math
-U(r) = S(r) \cdot f(r)
-```
-where:
-```math
-S(r) =
-\begin{cases}
-1 & r < r_{\mathrm{on}} \\
-\frac{(r_{\mathrm{cut}}^2 - r^2)^2 \cdot
-(r_{\mathrm{cut}}^2 + 2r^2 -
-3r_{\mathrm{on}}^2)}{(r_{\mathrm{cut}}^2 -
-r_{\mathrm{on}}^2)^3}
-& r_{\mathrm{on}} < r \le r_{\mathrm{cut}} \\
-0 & r \ge r_{\mathrm{cut}} \\
-\end{cases}
-```
-# Example
-
-```
-use hoomd_interaction::pairwise::{LennardJones, Xplor};
-
-let epsilon = 1.5;
-let sigma = 1.0;
-let r_cut = 2.5 * sigma;
-let r_smooth = 1.5 * sigma;
-let xplor_lj = Xplor { f: LennardJones::<12,6> { epsilon, sigma }, r_cut, r_smooth };
-*/
+/// Smoothly shift a potential (and its force) to 0 at some `r_cut`, beginning at `r_smooth`.
+///
+/// ```math
+/// U(r) = S(r) \cdot f(r)
+/// ```
+/// where:
+/// ```math
+/// S(r) =
+/// \begin{cases}
+/// 1 & r < r_{\mathrm{on}} \\
+/// \frac{(r_{\mathrm{cut}}^2 - r^2)^2 \cdot
+/// (r_{\mathrm{cut}}^2 + 2r^2 -
+/// 3r_{\mathrm{on}}^2)}{(r_{\mathrm{cut}}^2 -
+/// r_{\mathrm{on}}^2)^3}
+/// & r_{\mathrm{on}} < r \le r_{\mathrm{cut}} \\
+/// 0 & r \ge r_{\mathrm{cut}} \\
+/// \end{cases}
+/// ```
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::pairwise::{LennardJones, Xplor};
+///
+/// let epsilon = 1.5;
+/// let sigma = 1.0;
+/// let r_cut = 2.5 * sigma;
+/// let r_smooth = 1.5 * sigma;
+/// let xplor_lj = Xplor { f: LennardJones::<12,6> { epsilon, sigma }, r_cut, r_smooth };
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Xplor<F> {

--- a/hoomd-interaction/src/single.rs
+++ b/hoomd-interaction/src/single.rs
@@ -1,85 +1,90 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement `Single`
- */
+//! Implement `Single`
 
 use crate::{DeltaEnergyInsert, DeltaEnergyOne, DeltaEnergyRemove, SiteEnergy, TotalEnergy};
 use hoomd_microstate::{Body, Microstate, Transform, boundary::Wrap, property::Position};
 
-/** Interactions between sites and external fields.
-
-Given an inner type that implements [`SiteEnergy`], [`Single`] represents:
-
-```math
-U_\mathrm{total} = \sum_{i=0}^{N-1} U\left( s_i \right)
-```
-where $`s_i`$ is the full set of site properties for site i.
-
-For the inner type, use one from [`external`] or your own custom type.
-
-[`external`]: crate::external
-
-Use [`SingleOverlap`] instead of [`Single`] for purely hard interactions.
-
-[`SingleOverlap`]: crate::SingleOverlap
-
-# Example
-
-```
-use hoomd_interaction::{Single, TotalEnergy, external::Linear};
-use hoomd_microstate::{Microstate, Body, property::Point};
-use hoomd_vector::Cartesian;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = Microstate::new();
-microstate.extend_bodies([Body::point(Cartesian::from([1.0, 0.0])),
-                          Body::point(Cartesian::from([-1.0, 2.0]))])?;
-
-let linear = Single(Linear{ alpha: 1.0,
-    plane_origin: Cartesian::default(),
-    plane_normal: [0.0, 1.0].try_into()? });
-
-let total_energy = linear.total_energy(&microstate);
-assert_eq!(total_energy, 2.0);
-# Ok(())
-# }
-```
-*/
+/// Interactions between sites and external fields.
+///
+/// Given an inner type that implements [`SiteEnergy`], [`Single`] represents:
+///
+/// ```math
+/// U_\mathrm{total} = \sum_{i=0}^{N-1} U\left( s_i \right)
+/// ```
+/// where $`s_i`$ is the full set of site properties for site i.
+///
+/// For the inner type, use one from [`external`] or your own custom type.
+///
+/// [`external`]: crate::external
+///
+/// Use [`SingleOverlap`] instead of [`Single`] for purely hard interactions.
+///
+/// [`SingleOverlap`]: crate::SingleOverlap
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::{Single, TotalEnergy, external::Linear};
+/// use hoomd_microstate::{Body, Microstate, property::Point};
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.extend_bodies([
+///     Body::point(Cartesian::from([1.0, 0.0])),
+///     Body::point(Cartesian::from([-1.0, 2.0])),
+/// ])?;
+///
+/// let linear = Single(Linear {
+///     alpha: 1.0,
+///     plane_origin: Cartesian::default(),
+///     plane_normal: [0.0, 1.0].try_into()?,
+/// });
+///
+/// let total_energy = linear.total_energy(&microstate);
+/// assert_eq!(total_energy, 2.0);
+/// # Ok(())
+/// # }
+/// ```
 pub struct Single<E>(pub E);
 
 impl<B, S, C, E> TotalEnergy<Microstate<B, S, C>> for Single<E>
 where
     E: SiteEnergy<S>,
 {
-    /** Compute the total energy of the microstate contributed by functions of a single site.
-
-    The sum over sites differs from HOOMD-blue where external energies are
-    evaluated only at the body centers. In general, hoomd-rs interactions apply
-    to sites. Use a custom implementation to compute energies over body centers.
-
-    # Example
-
-    ```
-    use hoomd_interaction::{Single, TotalEnergy, external::Linear};
-    use hoomd_microstate::{Microstate, Body, property::Point};
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut microstate = Microstate::new();
-    microstate.extend_bodies([Body::point(Cartesian::from([1.0, 0.0])),
-                              Body::point(Cartesian::from([-1.0, 2.0]))])?;
-
-    let linear = Single(Linear{ alpha: 1.0,
-        plane_origin: Cartesian::default(),
-        plane_normal: [0.0, 1.0].try_into()? });
-
-    let total_energy = linear.total_energy(&microstate);
-    assert_eq!(total_energy, 2.0);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Compute the total energy of the microstate contributed by functions of a single site.
+    ///
+    /// The sum over sites differs from HOOMD-blue where external energies are
+    /// evaluated only at the body centers. In general, hoomd-rs interactions apply
+    /// to sites. Use a custom implementation to compute energies over body centers.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_interaction::{Single, TotalEnergy, external::Linear};
+    /// use hoomd_microstate::{Body, Microstate, property::Point};
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut microstate = Microstate::new();
+    /// microstate.extend_bodies([
+    ///     Body::point(Cartesian::from([1.0, 0.0])),
+    ///     Body::point(Cartesian::from([-1.0, 2.0])),
+    /// ])?;
+    ///
+    /// let linear = Single(Linear {
+    ///     alpha: 1.0,
+    ///     plane_origin: Cartesian::default(),
+    ///     plane_normal: [0.0, 1.0].try_into()?,
+    /// });
+    ///
+    /// let total_energy = linear.total_energy(&microstate);
+    /// assert_eq!(total_energy, 2.0);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn total_energy(&self, microstate: &Microstate<B, S, C>) -> f64 {
         microstate
@@ -89,30 +94,34 @@ where
     }
 }
 
-/** Evaluate the change in energy contributed by `Single` when a single body is updated.
-
-# Example
-
-```
-use hoomd_interaction::{DeltaEnergyOne, Single, external::Linear};
-use hoomd_microstate::{Microstate, Body, property::Point};
-use hoomd_vector::Cartesian;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = Microstate::new();
-microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])))?;
-
-let linear = Single(Linear{ alpha: 1.0,
-    plane_origin: Cartesian::default(),
-    plane_normal: [0.0, 1.0].try_into()? });
-
-let delta_energy = linear.delta_energy_one(&microstate, 0,
-    &Body::point([0.0, -1.0].into()));
-assert_eq!(delta_energy, -1.0);
-# Ok(())
-# }
-```
-*/
+/// Evaluate the change in energy contributed by `Single` when a single body is updated.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::{DeltaEnergyOne, Single, external::Linear};
+/// use hoomd_microstate::{Body, Microstate, property::Point};
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])))?;
+///
+/// let linear = Single(Linear {
+///     alpha: 1.0,
+///     plane_origin: Cartesian::default(),
+///     plane_normal: [0.0, 1.0].try_into()?,
+/// });
+///
+/// let delta_energy = linear.delta_energy_one(
+///     &microstate,
+///     0,
+///     &Body::point([0.0, -1.0].into()),
+/// );
+/// assert_eq!(delta_energy, -1.0);
+/// # Ok(())
+/// # }
+/// ```
 impl<V, B, S, C, E> DeltaEnergyOne<B, S, C> for Single<E>
 where
     E: SiteEnergy<S>,
@@ -146,30 +155,31 @@ where
     }
 }
 
-/** Evaluate the change in energy contributed by `Single` when a single body is inserted.
-
-# Example
-
-```
-use hoomd_interaction::{DeltaEnergyInsert, Single, external::Linear};
-use hoomd_microstate::{Microstate, Body, property::Point};
-use hoomd_vector::Cartesian;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = Microstate::new();
-microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])))?;
-
-let linear = Single(Linear{ alpha: 1.0,
-    plane_origin: Cartesian::default(),
-    plane_normal: [0.0, 1.0].try_into()? });
-
-let delta_energy = linear.delta_energy_insert(&microstate,
-    &Body::point([0.0, -1.0].into()));
-assert_eq!(delta_energy, -1.0);
-# Ok(())
-# }
-```
-*/
+/// Evaluate the change in energy contributed by `Single` when a single body is inserted.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::{DeltaEnergyInsert, Single, external::Linear};
+/// use hoomd_microstate::{Body, Microstate, property::Point};
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])))?;
+///
+/// let linear = Single(Linear {
+///     alpha: 1.0,
+///     plane_origin: Cartesian::default(),
+///     plane_normal: [0.0, 1.0].try_into()?,
+/// });
+///
+/// let delta_energy = linear
+///     .delta_energy_insert(&microstate, &Body::point([0.0, -1.0].into()));
+/// assert_eq!(delta_energy, -1.0);
+/// # Ok(())
+/// # }
+/// ```
 impl<V, B, S, C, E> DeltaEnergyInsert<B, S, C> for Single<E>
 where
     E: SiteEnergy<S>,
@@ -198,29 +208,30 @@ where
     }
 }
 
-/** Evaluate the change in energy contributed by `Single` when a single body is removed.
-
-# Example
-
-```
-use hoomd_interaction::{DeltaEnergyRemove, Single, external::Linear};
-use hoomd_microstate::{Microstate, Body, property::Point};
-use hoomd_vector::Cartesian;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = Microstate::new();
-microstate.add_body(Body::point(Cartesian::from([0.0, 1.0])))?;
-
-let linear = Single(Linear{ alpha: 1.0,
-    plane_origin: Cartesian::default(),
-    plane_normal: [0.0, 1.0].try_into()? });
-
-let delta_energy = linear.delta_energy_remove(&microstate, 0);
-assert_eq!(delta_energy, -1.0);
-# Ok(())
-# }
-```
-*/
+/// Evaluate the change in energy contributed by `Single` when a single body is removed.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::{DeltaEnergyRemove, Single, external::Linear};
+/// use hoomd_microstate::{Body, Microstate, property::Point};
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.add_body(Body::point(Cartesian::from([0.0, 1.0])))?;
+///
+/// let linear = Single(Linear {
+///     alpha: 1.0,
+///     plane_origin: Cartesian::default(),
+///     plane_normal: [0.0, 1.0].try_into()?,
+/// });
+///
+/// let delta_energy = linear.delta_energy_remove(&microstate, 0);
+/// assert_eq!(delta_energy, -1.0);
+/// # Ok(())
+/// # }
+/// ```
 impl<B, S, C, E> DeltaEnergyRemove<B, S, C> for Single<E>
 where
     E: SiteEnergy<S>,

--- a/hoomd-interaction/src/single_overlap.rs
+++ b/hoomd-interaction/src/single_overlap.rs
@@ -22,7 +22,7 @@ use hoomd_microstate::{Body, Microstate, Transform, boundary::Wrap, property::Po
 /// $`U\left( s_i \right)`$ is $`\infty`$ when the site overlaps with an external
 /// object and 0 when it does not.
 ///
-/// hoomd-rs** currently does not provide any types that implement
+/// **hoomd-rs** currently does not provide any types that implement
 /// [`SiteOverlap`]. Provide your own custom type.
 ///
 /// [`Single`]: crate::Single

--- a/hoomd-interaction/src/single_overlap.rs
+++ b/hoomd-interaction/src/single_overlap.rs
@@ -1,99 +1,98 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement `SingleOverlap`
- */
+//! Implement `SingleOverlap`
 
 use crate::{DeltaEnergyInsert, DeltaEnergyOne, DeltaEnergyRemove, SiteOverlap, TotalEnergy};
 use hoomd_microstate::{Body, Microstate, Transform, boundary::Wrap, property::Position};
 
-/** Hard overlaps between sites and external objects.
-
-Use [`SingleOverlap`] instead of [`Single`] for hard interactions.
-[`SingleOverlap`] does not need to compute the initial energy and it can
-short-circuit energy evaluations when the first overlap is detected. Both of
-these lead to improved performance.
-
-Given an inner type that implements [`SiteOverlap`], [`SingleOverlap`] represents:
-
-```math
-U_\mathrm{total} = \sum_{i=0}^{N-1} U\left( s_i \right)
-```
-where $`s_i`$ is the full set of site properties for site i and
-$`U\left( s_i \right)`$ is $`\infty`$ when the site overlaps with an external
-object and 0 when it does not.
-
-**hoomd-rs** currently does not provide any types that implement
-[`SiteOverlap`]. Provide your own custom type.
-
-[`Single`]: crate::Single
-
-# Example
-
-```
-use hoomd_interaction::{SingleOverlap, SiteOverlap, TotalEnergy};
-use hoomd_microstate::{Microstate, Body, property::Point};
-use hoomd_vector::Cartesian;
-
-struct Wall;
-
-impl SiteOverlap<Point<Cartesian<2>>> for Wall
-{
-    fn site_overlap(&self, site_properties: &Point<Cartesian<2>>) -> bool {
-        site_properties.position[1].abs() < 1.0
-    }
-}
-
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut microstate = Microstate::new();
-    microstate.extend_bodies([Body::point(Cartesian::from([1.0, 1.25])),
-                              Body::point(Cartesian::from([-1.0, 2.0]))])?;
-
-    let wall = SingleOverlap(Wall);
-
-    let total_energy = wall.total_energy(&microstate);
-    assert_eq!(total_energy, 0.0);
-    Ok(())
-}
-```
-*/
+/// Hard overlaps between sites and external objects.
+///
+/// Use [`SingleOverlap`] instead of [`Single`] for hard interactions.
+/// [`SingleOverlap`] does not need to compute the initial energy and it can
+/// short-circuit energy evaluations when the first overlap is detected. Both of
+/// these lead to improved performance.
+///
+/// Given an inner type that implements [`SiteOverlap`], [`SingleOverlap`] represents:
+///
+/// ```math
+/// U_\mathrm{total} = \sum_{i=0}^{N-1} U\left( s_i \right)
+/// ```
+/// where $`s_i`$ is the full set of site properties for site i and
+/// $`U\left( s_i \right)`$ is $`\infty`$ when the site overlaps with an external
+/// object and 0 when it does not.
+///
+/// hoomd-rs** currently does not provide any types that implement
+/// [`SiteOverlap`]. Provide your own custom type.
+///
+/// [`Single`]: crate::Single
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::{SingleOverlap, SiteOverlap, TotalEnergy};
+/// use hoomd_microstate::{Body, Microstate, property::Point};
+/// use hoomd_vector::Cartesian;
+///
+/// struct Wall;
+///
+/// impl SiteOverlap<Point<Cartesian<2>>> for Wall {
+///     fn site_overlap(&self, site_properties: &Point<Cartesian<2>>) -> bool {
+///         site_properties.position[1].abs() < 1.0
+///     }
+/// }
+///
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let mut microstate = Microstate::new();
+///     microstate.extend_bodies([
+///         Body::point(Cartesian::from([1.0, 1.25])),
+///         Body::point(Cartesian::from([-1.0, 2.0])),
+///     ])?;
+///
+///     let wall = SingleOverlap(Wall);
+///
+///     let total_energy = wall.total_energy(&microstate);
+///     assert_eq!(total_energy, 0.0);
+///     Ok(())
+/// }
+/// ```
 pub struct SingleOverlap<E>(pub E);
 
 impl<B, S, C, E> TotalEnergy<Microstate<B, S, C>> for SingleOverlap<E>
 where
     E: SiteOverlap<S>,
 {
-    /** Compute the total energy of the microstate contributed by functions of a single site.
-
-    # Example
-
-    ```
-    use hoomd_interaction::{SingleOverlap, SiteOverlap, TotalEnergy};
-    use hoomd_microstate::{Microstate, Body, property::Point};
-    use hoomd_vector::Cartesian;
-
-    struct Wall;
-
-    impl SiteOverlap<Point<Cartesian<2>>> for Wall
-    {
-        fn site_overlap(&self, site_properties: &Point<Cartesian<2>>) -> bool {
-            site_properties.position[1].abs() < 1.0
-        }
-    }
-
-    fn main() -> Result<(), Box<dyn std::error::Error>> {
-        let mut microstate = Microstate::new();
-        microstate.extend_bodies([Body::point(Cartesian::from([1.0, 1.25])),
-                                  Body::point(Cartesian::from([-1.0, 2.0]))])?;
-
-        let wall = SingleOverlap(Wall);
-
-        let total_energy = wall.total_energy(&microstate);
-        assert_eq!(total_energy, 0.0);
-        Ok(())
-    }
-    ```
-    */
+    /// Compute the total energy of the microstate contributed by functions of a single site.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_interaction::{SingleOverlap, SiteOverlap, TotalEnergy};
+    /// use hoomd_microstate::{Body, Microstate, property::Point};
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// struct Wall;
+    ///
+    /// impl SiteOverlap<Point<Cartesian<2>>> for Wall {
+    ///     fn site_overlap(&self, site_properties: &Point<Cartesian<2>>) -> bool {
+    ///         site_properties.position[1].abs() < 1.0
+    ///     }
+    /// }
+    ///
+    /// fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let mut microstate = Microstate::new();
+    ///     microstate.extend_bodies([
+    ///         Body::point(Cartesian::from([1.0, 1.25])),
+    ///         Body::point(Cartesian::from([-1.0, 2.0])),
+    ///     ])?;
+    ///
+    ///     let wall = SingleOverlap(Wall);
+    ///
+    ///     let total_energy = wall.total_energy(&microstate);
+    ///     assert_eq!(total_energy, 0.0);
+    ///     Ok(())
+    /// }
+    /// ```
     #[inline]
     fn total_energy(&self, microstate: &Microstate<B, S, C>) -> f64 {
         for site in microstate.sites() {
@@ -106,38 +105,41 @@ where
     }
 }
 
-/** Evaluate the change in energy contributed by `SingleOverlap` when a single body is updated.
-
-# Example
-
-```
-use hoomd_interaction::{DeltaEnergyOne, SingleOverlap, SiteOverlap};
-use hoomd_microstate::{Microstate, Body, property::Point};
-use hoomd_vector::Cartesian;
-
-struct Wall;
-
-impl SiteOverlap<Point<Cartesian<2>>> for Wall
-{
-    fn site_overlap(&self, site_properties: &Point<Cartesian<2>>) -> bool {
-        site_properties.position[1].abs() < 1.0
-    }
-}
-
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut microstate = Microstate::new();
-    microstate.extend_bodies([Body::point(Cartesian::from([1.0, 1.25])),
-                              Body::point(Cartesian::from([-1.0, 2.0]))])?;
-
-    let wall = SingleOverlap(Wall);
-
-    let delta_energy = wall.delta_energy_one(&microstate, 0,
-        &Body::point([0.0, -0.5].into()));
-    assert_eq!(delta_energy, f64::INFINITY);
-Ok(())
-}
-```
-*/
+/// Evaluate the change in energy contributed by `SingleOverlap` when a single body is updated.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::{DeltaEnergyOne, SingleOverlap, SiteOverlap};
+/// use hoomd_microstate::{Body, Microstate, property::Point};
+/// use hoomd_vector::Cartesian;
+///
+/// struct Wall;
+///
+/// impl SiteOverlap<Point<Cartesian<2>>> for Wall {
+///     fn site_overlap(&self, site_properties: &Point<Cartesian<2>>) -> bool {
+///         site_properties.position[1].abs() < 1.0
+///     }
+/// }
+///
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let mut microstate = Microstate::new();
+///     microstate.extend_bodies([
+///         Body::point(Cartesian::from([1.0, 1.25])),
+///         Body::point(Cartesian::from([-1.0, 2.0])),
+///     ])?;
+///
+///     let wall = SingleOverlap(Wall);
+///
+///     let delta_energy = wall.delta_energy_one(
+///         &microstate,
+///         0,
+///         &Body::point([0.0, -0.5].into()),
+///     );
+///     assert_eq!(delta_energy, f64::INFINITY);
+///     Ok(())
+/// }
+/// ```
 impl<V, B, S, C, E> DeltaEnergyOne<B, S, C> for SingleOverlap<E>
 where
     E: SiteOverlap<S>,
@@ -170,38 +172,38 @@ where
     }
 }
 
-/** Evaluate the change in energy contributed by `SingleOverlap` when a single body is inserted.
-
-# Example
-
-```
-use hoomd_interaction::{DeltaEnergyInsert, SingleOverlap, SiteOverlap};
-use hoomd_microstate::{Microstate, Body, property::Point};
-use hoomd_vector::Cartesian;
-
-struct Wall;
-
-impl SiteOverlap<Point<Cartesian<2>>> for Wall
-{
-    fn site_overlap(&self, site_properties: &Point<Cartesian<2>>) -> bool {
-        site_properties.position[1].abs() < 1.0
-    }
-}
-
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut microstate = Microstate::new();
-    microstate.extend_bodies([Body::point(Cartesian::from([1.0, 1.25])),
-                              Body::point(Cartesian::from([-1.0, 2.0]))])?;
-
-    let wall = SingleOverlap(Wall);
-
-    let delta_energy = wall.delta_energy_insert(&microstate,
-        &Body::point([0.0, -0.5].into()));
-    assert_eq!(delta_energy, f64::INFINITY);
-Ok(())
-}
-```
-*/
+/// Evaluate the change in energy contributed by `SingleOverlap` when a single body is inserted.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::{DeltaEnergyInsert, SingleOverlap, SiteOverlap};
+/// use hoomd_microstate::{Body, Microstate, property::Point};
+/// use hoomd_vector::Cartesian;
+///
+/// struct Wall;
+///
+/// impl SiteOverlap<Point<Cartesian<2>>> for Wall {
+///     fn site_overlap(&self, site_properties: &Point<Cartesian<2>>) -> bool {
+///         site_properties.position[1].abs() < 1.0
+///     }
+/// }
+///
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let mut microstate = Microstate::new();
+///     microstate.extend_bodies([
+///         Body::point(Cartesian::from([1.0, 1.25])),
+///         Body::point(Cartesian::from([-1.0, 2.0])),
+///     ])?;
+///
+///     let wall = SingleOverlap(Wall);
+///
+///     let delta_energy = wall
+///         .delta_energy_insert(&microstate, &Body::point([0.0, -0.5].into()));
+///     assert_eq!(delta_energy, f64::INFINITY);
+///     Ok(())
+/// }
+/// ```
 impl<V, B, S, C, E> DeltaEnergyInsert<B, S, C> for SingleOverlap<E>
 where
     E: SiteOverlap<S>,
@@ -233,37 +235,37 @@ where
     }
 }
 
-/** Evaluate the change in energy contributed by `SingleOverlap` when a single body is removed.
-
-# Example
-
-```
-use hoomd_interaction::{DeltaEnergyRemove, SingleOverlap, SiteOverlap};
-use hoomd_microstate::{Microstate, Body, property::Point};
-use hoomd_vector::Cartesian;
-
-struct Wall;
-
-impl SiteOverlap<Point<Cartesian<2>>> for Wall
-{
-    fn site_overlap(&self, site_properties: &Point<Cartesian<2>>) -> bool {
-        site_properties.position[1].abs() < 1.0
-    }
-}
-
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut microstate = Microstate::new();
-    microstate.extend_bodies([Body::point(Cartesian::from([1.0, 1.25])),
-                              Body::point(Cartesian::from([-1.0, 2.0]))])?;
-
-    let wall = SingleOverlap(Wall);
-
-    let delta_energy = wall.delta_energy_remove(&microstate, 0);
-    assert_eq!(delta_energy, 0.0);
-    Ok(())
-}
-```
-*/
+/// Evaluate the change in energy contributed by `SingleOverlap` when a single body is removed.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::{DeltaEnergyRemove, SingleOverlap, SiteOverlap};
+/// use hoomd_microstate::{Body, Microstate, property::Point};
+/// use hoomd_vector::Cartesian;
+///
+/// struct Wall;
+///
+/// impl SiteOverlap<Point<Cartesian<2>>> for Wall {
+///     fn site_overlap(&self, site_properties: &Point<Cartesian<2>>) -> bool {
+///         site_properties.position[1].abs() < 1.0
+///     }
+/// }
+///
+/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let mut microstate = Microstate::new();
+///     microstate.extend_bodies([
+///         Body::point(Cartesian::from([1.0, 1.25])),
+///         Body::point(Cartesian::from([-1.0, 2.0])),
+///     ])?;
+///
+///     let wall = SingleOverlap(Wall);
+///
+///     let delta_energy = wall.delta_energy_remove(&microstate, 0);
+///     assert_eq!(delta_energy, 0.0);
+///     Ok(())
+/// }
+/// ```
 impl<B, S, C, E> DeltaEnergyRemove<B, S, C> for SingleOverlap<E>
 where
     E: SiteOverlap<S>,

--- a/hoomd-interaction/src/zero.rs
+++ b/hoomd-interaction/src/zero.rs
@@ -9,7 +9,7 @@ use hoomd_microstate::{Body, Microstate};
 
 /// Set the energy of any system to 0.
 ///
-/// hoomd-rs* uses [`Zero`] in minimal examples that demonstrate MC simulations.
+/// *hoomd-rs* uses [`Zero`] in minimal examples that demonstrate MC simulations.
 /// It returns 0 for all energies and delta energies.
 pub struct Zero;
 

--- a/hoomd-interaction/src/zero.rs
+++ b/hoomd-interaction/src/zero.rs
@@ -1,18 +1,16 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement `Zero`
- */
+//! Implement `Zero`
 
 use super::{DeltaEnergyInsert, DeltaEnergyOne, DeltaEnergyRemove, TotalEnergy};
 
 use hoomd_microstate::{Body, Microstate};
 
-/** Set the energy of any system to 0.
-
-*hoomd-rs* uses [`Zero`] in minimal examples that demonstrate MC simulations.
-It returns 0 for all energies and delta energies.
-*/
+/// Set the energy of any system to 0.
+///
+/// hoomd-rs* uses [`Zero`] in minimal examples that demonstrate MC simulations.
+/// It returns 0 for all energies and delta energies.
 pub struct Zero;
 
 impl<M> TotalEnergy<M> for Zero {

--- a/hoomd-mc/src/lib.rs
+++ b/hoomd-mc/src/lib.rs
@@ -41,8 +41,8 @@ pub use uniform_in::UniformIn;
 /// See [`Sweep`] or any of the other implementations of `Trial` for code examples.
 ///
 /// The generic type names are:
-/// `M`: The [`Microstate`](hoomd_microstate::Microstate) type.
-/// `H`: The Hamiltonian type.
+/// * `M`: The [`Microstate`](hoomd_microstate::Microstate) type.
+/// * `H`: The Hamiltonian type.
 pub trait Trial<M, H> {
     /// Represent the number of accepted and rejected individual trial moves.
     ///
@@ -74,7 +74,7 @@ pub trait Trial<M, H> {
 /// as defined in [Manousiouthakis & Deem](https://doi.org/10.1063/1.477973).
 ///
 /// The generic type names are:
-/// `B`: The [`Body::properties`](hoomd_microstate::Body) type.
+/// * `B`: The [`Body::properties`](hoomd_microstate::Body) type.
 pub trait LocalTrial<B> {
     /// Propose a new configuration for the given body properties.
     #[must_use]

--- a/hoomd-mc/src/lib.rs
+++ b/hoomd-mc/src/lib.rs
@@ -8,10 +8,9 @@
     html_logo_url = "https://hoomd-blue.readthedocs.io/en/latest/_static/hoomdblue-logo-favicon.svg"
 )]
 
-/*! Apply the Metropolis Monte Carlo simulation method to systems of particles.
-
-TODO: Expand documentation.
- */
+//! Apply the Metropolis Monte Carlo simulation method to systems of particles.
+//!
+//! TODO: Expand documentation.
 
 use rand::Rng;
 use std::ops::AddAssign;
@@ -28,98 +27,95 @@ pub use sweep::Sweep;
 pub use translate::Translate;
 pub use uniform_in::UniformIn;
 
-/** Propose trial moves in the microstate, evaluate the changes in energy and accept or reject accordingly.
-
-`Trial` describes a type that applies trial moves to microstates. Specifically,
-the method `apply` will attempt one or more individual trial moves to the
-microstate. For each individual move, it evaluates the change in energy with
-the given `hamiltonian`, then accepts or rejects the trial based on the `state`
-parameters.
-
-Each type of trial move in *hoomd-rs* implements the `Trial` trait so that they
-may be used as generic arguments in higher level functions.
-
-See [`Sweep`] or any of the other implementations of `Trial` for code examples.
-
-The generic type names are:
-* `M`: The [`Microstate`](hoomd_microstate::Microstate) type.
-* `H`: The Hamiltonian type.
-*/
+/// Propose trial moves in the microstate, evaluate the changes in energy and accept or reject accordingly.
+///
+/// `Trial` describes a type that applies trial moves to microstates. Specifically,
+/// the method `apply` will attempt one or more individual trial moves to the
+/// microstate. For each individual move, it evaluates the change in energy with
+/// the given `hamiltonian`, then accepts or rejects the trial based on the `state`
+/// parameters.
+///
+/// Each type of trial move in *hoomd-rs* implements the `Trial` trait so that they
+/// may be used as generic arguments in higher level functions.
+///
+/// See [`Sweep`] or any of the other implementations of `Trial` for code examples.
+///
+/// The generic type names are:
+/// `M`: The [`Microstate`](hoomd_microstate::Microstate) type.
+/// `H`: The Hamiltonian type.
 pub trait Trial<M, H> {
-    /** Represent the number of accepted and rejected individual trial moves.
-
-    Most implementations of `Trial` will use [`crate::Count`] directly. Some
-    may provide more granular detail broken down by move type.
-    */
+    /// Represent the number of accepted and rejected individual trial moves.
+    ///
+    /// Most implementations of `Trial` will use [`crate::Count`] directly. Some
+    /// may provide more granular detail broken down by move type.
     type Count;
 
     /// Represent the macrostate parameter(s) used when evaluating move acceptance.
     type Macrostate;
 
-    /** Apply the trial move(s).
-
-    A given type that implements `Trial` may perform one or many trial moves
-    in a single call to `apply`. The returned value informs the caller how many
-    trial moves were accepted and rejected (possibly broken down by type).
-    */
+    /// Apply the trial move(s).
+    ///
+    /// A given type that implements `Trial` may perform one or many trial moves
+    /// in a single call to `apply`. The returned value informs the caller how many
+    /// trial moves were accepted and rejected (possibly broken down by type).
     fn apply(&self, microstate: &mut M, hamiltonian: &H, state: &Self::Macrostate) -> Self::Count;
 }
 
-/** Propose a new configuration for given body properties.
-
-A *local* trial move is one applied to a specific body in the microstate.
-Implementations of [`Trial`], such as [`Sweep`], apply a given local move
-to one or more bodies in the microstate.
-
-Use one of the provided local trials to [`Translate`] and/or `Rotate` (TODO: make link)
-bodies or implement your own custom [`LocalTrial`].
-
-Local trial moves **MUST** satisfy *local detailed balance*,
-as defined in [Manousiouthakis & Deem](https://doi.org/10.1063/1.477973).
-
-The generic type names are:
-* `B`: The [`Body::properties`](hoomd_microstate::Body) type.
-*/
+/// Propose a new configuration for given body properties.
+///
+/// A *local* trial move is one applied to a specific body in the microstate.
+/// Implementations of [`Trial`], such as [`Sweep`], apply a given local move
+/// to one or more bodies in the microstate.
+///
+/// Use one of the provided local trials to [`Translate`] and/or `Rotate` (TODO: make link)
+/// bodies or implement your own custom [`LocalTrial`].
+///
+/// Local trial moves **MUST** satisfy *local detailed balance*,
+/// as defined in [Manousiouthakis & Deem](https://doi.org/10.1063/1.477973).
+///
+/// The generic type names are:
+/// `B`: The [`Body::properties`](hoomd_microstate::Body) type.
 pub trait LocalTrial<B> {
     /// Propose a new configuration for the given body properties.
     #[must_use]
     fn propose<R: Rng>(&self, rng: &mut R, body_properties: B) -> B;
 }
 
-/** Accepted and rejected trial moves.
-
-A [`Trial`] reports the number moves it accepts and rejects via `Count`
-(or some variation on `Count`). `Count` implements [`AddAssign`] and convenience
-methods that compute often used properties, like the acceptance rate.
-
-# Example
-
-Count the total number of trial moves performed over a number of sweeps:
-```
-use hoomd_interaction::Zero;
-use hoomd_mc::{Count, Sweep, Translate, Trial};
-use hoomd_microstate::{Body, Microstate, property::Position};
-use hoomd_vector::Cartesian;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = Microstate::new();
-microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
-let d = 0.1;
-let translate = Translate { maximum_distance: d.try_into()? };
-let translate_sweep = Sweep(translate);
-
-let mut count = Count::default();
-
-for _ in 0..1_000 {
-    count += translate_sweep.apply(&mut microstate, &Zero, &1.0);
-    microstate.increment_step();
-}
-
-assert_eq!(count.total(), 1_000);
-# Ok(())
-# }
-```
-*/
+/// Accepted and rejected trial moves.
+///
+/// A [`Trial`] reports the number moves it accepts and rejects via `Count`
+/// (or some variation on `Count`). `Count` implements [`AddAssign`] and convenience
+/// methods that compute often used properties, like the acceptance rate.
+///
+/// # Example
+///
+/// Count the total number of trial moves performed over a number of sweeps:
+/// ```
+/// use hoomd_interaction::Zero;
+/// use hoomd_mc::{Count, Sweep, Translate, Trial};
+/// use hoomd_microstate::{Body, Microstate, property::Position};
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
+/// let d = 0.1;
+/// let translate = Translate {
+///     maximum_distance: d.try_into()?,
+/// };
+/// let translate_sweep = Sweep(translate);
+///
+/// let mut count = Count::default();
+///
+/// for _ in 0..1_000 {
+///     count += translate_sweep.apply(&mut microstate, &Zero, &1.0);
+///     microstate.increment_step();
+/// }
+///
+/// assert_eq!(count.total(), 1_000);
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct Count {
     /// The number of accepted moves.
@@ -129,51 +125,55 @@ pub struct Count {
 }
 
 impl Count {
-    /** The total number of trial moves.
-
-    # Example
-
-    ```
-    use hoomd_mc::Count;
-
-    let count = Count { accepted: 2_000, rejected: 8_000 };
-    let total = count.total();
-
-    assert_eq!(total, 10_000);
-    ```
-    */
+    /// The total number of trial moves.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_mc::Count;
+    ///
+    /// let count = Count {
+    ///     accepted: 2_000,
+    ///     rejected: 8_000,
+    /// };
+    /// let total = count.total();
+    ///
+    /// assert_eq!(total, 10_000);
+    /// ```
     #[inline]
     #[must_use]
     pub fn total(&self) -> u64 {
         self.accepted + self.rejected
     }
 
-    /** The fraction of moves that were accepted.
-
-    The acceptance ratio is the ratio of accepted moves to total moves.
-    `acceptance_ratio` returns `Some(ratio)` when the number of total moves is
-    nonzero and `None` when there are 0 moves.
-
-    # Example
-
-    ```
-    use hoomd_mc::Count;
-
-    let count = Count { accepted: 2_000, rejected: 8_000 };
-    let acceptance_ratio = count.acceptance_ratio();
-
-    assert_eq!(acceptance_ratio, Some(0.2));
-    ```
-
-    ```
-    use hoomd_mc::Count;
-
-    let count = Count::default();
-    let acceptance_ratio = count.acceptance_ratio();
-
-    assert_eq!(acceptance_ratio, None);
-    ```
-    */
+    /// The fraction of moves that were accepted.
+    ///
+    /// The acceptance ratio is the ratio of accepted moves to total moves.
+    /// `acceptance_ratio` returns `Some(ratio)` when the number of total moves is
+    /// nonzero and `None` when there are 0 moves.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_mc::Count;
+    ///
+    /// let count = Count {
+    ///     accepted: 2_000,
+    ///     rejected: 8_000,
+    /// };
+    /// let acceptance_ratio = count.acceptance_ratio();
+    ///
+    /// assert_eq!(acceptance_ratio, Some(0.2));
+    /// ```
+    ///
+    /// ```
+    /// use hoomd_mc::Count;
+    ///
+    /// let count = Count::default();
+    /// let acceptance_ratio = count.acceptance_ratio();
+    ///
+    /// assert_eq!(acceptance_ratio, None);
+    /// ```
     #[inline]
     #[must_use]
     pub fn acceptance_ratio(&self) -> Option<f64> {

--- a/hoomd-mc/src/quick_insert.rs
+++ b/hoomd-mc/src/quick_insert.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement `QuickInsert`
- */
+//! Implement `QuickInsert`
 
 use super::Count;
 use hoomd_interaction::{DeltaEnergyInsert, TotalEnergy};
@@ -23,73 +22,72 @@ enum State {
     Complete,
 }
 
-/** Quickly add bodies to the microstate with random configurations.
-
-[`QuickInsert`] allows you to *quickly* insert many bodies into the microstate.
-It does so by *breaking detailed balance*, so you should use it only during
-the initialization phase of your simulation where you prepare a microstate
-for later equilibration. The [`QuickInsert`] protocol is an alternate to the
-`QuickCompress` protocol with the advantage that you can keep the boundary and
-any of your barriers fixed while randomly inserting particles. The disadvantage
-is that [`QuickInsert`] cannot achieve densities as high as `QuickCompress`.
-
-[`QuickInsert`] works only with hard particle potentials that go to infinity
-when overlapping. It works best with the [`OverlapPenalty`] potential that
-allows sites to overlap a small amount and for trial moves to partially reduce
-that overlap.
-
-As a **protocol**, [`QuickInsert`] is more than just a trial move. A
-[`QuickInsert`] instance stores internal state to track its progress. Therefore,
-you should only use a given [`QuickInsert`] on one [`Microstate`]. After
-initialization, a [`QuickInsert`] knows the *target* number of bodies it should
-add a distribution that places those bodies in the simulation boundary. New
-[`QuickInsert`] instances start in the running state.
-
-When you [`apply`] a running [`QuickInsert`] to a microstate, it:
-1. Checks the total energy of the given Hamiltonian.
-2. If the total energy is zero *and there are still bodies to insert*, generate
-   a random body and attempt to insert it into the microstate. Reject any
-   insertion that would result in an infinite energy. Accept in all other cases.
-3. Repeat step 2 until inserted bodies overlap with others `allowed_overlaps`
-   times, the target number of bodies have been inserted, or a total of `target`
-   attempts have been made during this call, whichever comes first.
-
-When *both* `target` bodies have been inserted *and* the energy is
-0, [`QuickInsert`] transitions to the complete state. When complete,
-[`is_complete`] returns `true` and [`apply`] does nothing.
-
-For spherical particles, [`QuickInsert`] combined with [`OverlapPenalty`]
-can achieve a packing fraction of 56% in 3D and 72% in 2D. You might achieve
-slightly higher densities if you are willing to run many steps, though
-`QuickCompress` is a better solution.
-
-The generic type names are:
-* `D`: The body distribution.
-
-[`apply`]: Self::apply
-[`is_complete`]: Self::is_complete
-[`OverlapPenalty`]: hoomd_interaction::pairwise::OverlapPenalty
-
-# Example
-
-```
-use hoomd_geometry::shape::Rectangle;
-use hoomd_mc::{QuickInsert, UniformIn};
-use hoomd_microstate::property::Point;
-use hoomd_vector::Cartesian;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let rectangle = Rectangle::with_equal_edges(10.0.try_into()?);
-
-let distribution = UniformIn {
-    boundary: rectangle,
-    template_sites: vec![Point::<Cartesian<2>>::default()],
-};
-let mut quick_insert = QuickInsert::new(distribution, 256);
-# Ok(())
-# }
-```
-*/
+/// Quickly add bodies to the microstate with random configurations.
+///
+/// [`QuickInsert`] allows you to *quickly* insert many bodies into the microstate.
+/// It does so by *breaking detailed balance*, so you should use it only during
+/// the initialization phase of your simulation where you prepare a microstate
+/// for later equilibration. The [`QuickInsert`] protocol is an alternate to the
+/// `QuickCompress` protocol with the advantage that you can keep the boundary and
+/// any of your barriers fixed while randomly inserting particles. The disadvantage
+/// is that [`QuickInsert`] cannot achieve densities as high as `QuickCompress`.
+///
+/// [`QuickInsert`] works only with hard particle potentials that go to infinity
+/// when overlapping. It works best with the [`OverlapPenalty`] potential that
+/// allows sites to overlap a small amount and for trial moves to partially reduce
+/// that overlap.
+///
+/// As a **protocol**, [`QuickInsert`] is more than just a trial move. A
+/// [`QuickInsert`] instance stores internal state to track its progress. Therefore,
+/// you should only use a given [`QuickInsert`] on one [`Microstate`]. After
+/// initialization, a [`QuickInsert`] knows the *target* number of bodies it should
+/// add a distribution that places those bodies in the simulation boundary. New
+/// [`QuickInsert`] instances start in the running state.
+///
+/// When you [`apply`] a running [`QuickInsert`] to a microstate, it:
+/// 1. Checks the total energy of the given Hamiltonian.
+/// 2. If the total energy is zero *and there are still bodies to insert*, generate
+/// a random body and attempt to insert it into the microstate. Reject any
+/// insertion that would result in an infinite energy. Accept in all other cases.
+/// 3. Repeat step 2 until inserted bodies overlap with others `allowed_overlaps`
+/// times, the target number of bodies have been inserted, or a total of `target`
+/// attempts have been made during this call, whichever comes first.
+///
+/// When *both* `target` bodies have been inserted *and* the energy is
+/// 0, [`QuickInsert`] transitions to the complete state. When complete,
+/// [`is_complete`] returns `true` and [`apply`] does nothing.
+///
+/// For spherical particles, [`QuickInsert`] combined with [`OverlapPenalty`]
+/// can achieve a packing fraction of 56% in 3D and 72% in 2D. You might achieve
+/// slightly higher densities if you are willing to run many steps, though
+/// `QuickCompress` is a better solution.
+///
+/// The generic type names are:
+/// `D`: The body distribution.
+///
+/// [`apply`]: Self::apply
+/// [`is_complete`]: Self::is_complete
+/// [`OverlapPenalty`]: hoomd_interaction::pairwise::OverlapPenalty
+///
+/// # Example
+///
+/// ```
+/// use hoomd_geometry::shape::Rectangle;
+/// use hoomd_mc::{QuickInsert, UniformIn};
+/// use hoomd_microstate::property::Point;
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let rectangle = Rectangle::with_equal_edges(10.0.try_into()?);
+///
+/// let distribution = UniformIn {
+///     boundary: rectangle,
+///     template_sites: vec![Point::<Cartesian<2>>::default()],
+/// };
+/// let mut quick_insert = QuickInsert::new(distribution, 256);
+/// # Ok(())
+/// # }
+/// ```
 pub struct QuickInsert<D> {
     /// Sample random bodies to insert.
     distribution: D,
@@ -108,33 +106,32 @@ pub struct QuickInsert<D> {
 }
 
 impl<D> QuickInsert<D> {
-    /** Build a new quick insert protocol.
-
-    After construction, the `QuickInsert` starts in a running state. On
-    successive calls to `apply`, it will attempt to insert `target` bodies into
-    the microstate randomly sampled from the given `distribution`. The default
-    number of `allowed_overlaps` is `target/8`.
-
-    # Example
-
-    ```
-    use hoomd_geometry::shape::Rectangle;
-    use hoomd_mc::{QuickInsert, UniformIn};
-    use hoomd_microstate::property::Point;
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rectangle = Rectangle::with_equal_edges(10.0.try_into()?);
-
-    let distribution = UniformIn {
-        boundary: rectangle,
-        template_sites: vec![Point::<Cartesian<2>>::default()],
-    };
-    let quick_insert = QuickInsert::new(distribution, 256);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Build a new quick insert protocol.
+    ///
+    /// After construction, the `QuickInsert` starts in a running state. On
+    /// successive calls to `apply`, it will attempt to insert `target` bodies into
+    /// the microstate randomly sampled from the given `distribution`. The default
+    /// number of `allowed_overlaps` is `target/8`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_geometry::shape::Rectangle;
+    /// use hoomd_mc::{QuickInsert, UniformIn};
+    /// use hoomd_microstate::property::Point;
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let rectangle = Rectangle::with_equal_edges(10.0.try_into()?);
+    ///
+    /// let distribution = UniformIn {
+    ///     boundary: rectangle,
+    ///     template_sites: vec![Point::<Cartesian<2>>::default()],
+    /// };
+    /// let quick_insert = QuickInsert::new(distribution, 256);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     pub fn new(distribution: D, target: usize) -> Self {
         Self {
@@ -146,125 +143,124 @@ impl<D> QuickInsert<D> {
         }
     }
 
-    /** Check if the quick insert protocol is complete.
-
-    `QuickInsert` completes after it has inserted all `target` bodies **and**
-    the total energy of the system is less than or equal to 0. When using the
-    recommended `OverlapPenalty` potential, this means that that there are no
-    overlaps between any particles.
-
-    # Example
-
-    ```
-    use hoomd_geometry::shape::Rectangle;
-    use hoomd_mc::{QuickInsert, UniformIn};
-    use hoomd_microstate::property::Point;
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rectangle = Rectangle::with_equal_edges(10.0.try_into()?);
-
-    let distribution = UniformIn {
-        boundary: rectangle,
-        template_sites: vec![Point::<Cartesian<2>>::default()],
-    };
-    let quick_insert = QuickInsert::new(distribution, 256);
-
-    let complete = quick_insert.is_complete();
-    assert!(!complete);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Check if the quick insert protocol is complete.
+    ///
+    /// `QuickInsert` completes after it has inserted all `target` bodies **and**
+    /// the total energy of the system is less than or equal to 0. When using the
+    /// recommended `OverlapPenalty` potential, this means that that there are no
+    /// overlaps between any particles.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_geometry::shape::Rectangle;
+    /// use hoomd_mc::{QuickInsert, UniformIn};
+    /// use hoomd_microstate::property::Point;
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let rectangle = Rectangle::with_equal_edges(10.0.try_into()?);
+    ///
+    /// let distribution = UniformIn {
+    ///     boundary: rectangle,
+    ///     template_sites: vec![Point::<Cartesian<2>>::default()],
+    /// };
+    /// let quick_insert = QuickInsert::new(distribution, 256);
+    ///
+    /// let complete = quick_insert.is_complete();
+    /// assert!(!complete);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     pub fn is_complete(&self) -> bool {
         self.state == State::Complete
     }
 
-    /** The target number of bodies to insert.
-
-    # Example
-
-    ```
-    use hoomd_geometry::shape::Rectangle;
-    use hoomd_mc::{QuickInsert, UniformIn};
-    use hoomd_microstate::property::Point;
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rectangle = Rectangle::with_equal_edges(10.0.try_into()?);
-
-    let distribution = UniformIn {
-        boundary: rectangle,
-        template_sites: vec![Point::<Cartesian<2>>::default()],
-    };
-    let quick_insert = QuickInsert::new(distribution, 256);
-
-    let target = quick_insert.target();
-    assert_eq!(target, 256);
-    # Ok(())
-    # }
-    ```
-    */
+    /// The target number of bodies to insert.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_geometry::shape::Rectangle;
+    /// use hoomd_mc::{QuickInsert, UniformIn};
+    /// use hoomd_microstate::property::Point;
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let rectangle = Rectangle::with_equal_edges(10.0.try_into()?);
+    ///
+    /// let distribution = UniformIn {
+    ///     boundary: rectangle,
+    ///     template_sites: vec![Point::<Cartesian<2>>::default()],
+    /// };
+    /// let quick_insert = QuickInsert::new(distribution, 256);
+    ///
+    /// let target = quick_insert.target();
+    /// assert_eq!(target, 256);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     pub fn target(&self) -> usize {
         self.target
     }
 
-    /** Apply the quick insert protocol to a microstate.
-
-    Combine [`QuickInsert::apply`] with local trial moves that translate and/or
-    rotate bodies by small amounts to relieve the stress caused by inserting
-    overlapping sites.
-
-    # Example
-
-    ```
-    use hoomd_geometry::shape::Rectangle;
-    use hoomd_interaction::{CutoffPair, pairwise::{Expanded, Isotropic, OverlapPenalty}};
-    use hoomd_mc::{QuickInsert, Translate, Sweep, Trial, UniformIn};
-    use hoomd_microstate::{Body, MicrostateBuilder, boundary::Periodic, property::Point};
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rectangle = Rectangle::with_equal_edges(10.0.try_into()?);
-
-    let distribution = UniformIn {
-        boundary: rectangle,
-        template_sites: vec![Point::default()],
-    };
-    let mut quick_insert = QuickInsert::new(distribution, 256);
-
-    let translate = Translate {
-        maximum_distance: 0.1.try_into()?,
-    };
-    let translate_sweep = Sweep(translate);
-
-    let cutoff_pair = CutoffPair {
-        r_cut: 1.0,
-        evaluator: Isotropic(Expanded {
-            delta: 1.0,
-            f: OverlapPenalty::default(),
-        }),
-    };
-
-    let mut microstate =
-        MicrostateBuilder::with_boundary(Periodic::new(1.0, rectangle)?)
-            .bodies([Body::point(Cartesian::from([0.0, 0.0]))])
-            .try_build()?;
-
-    quick_insert.apply(
-        &mut microstate,
-        &cutoff_pair,
-    );
-
-    translate_sweep.apply(&mut microstate, &cutoff_pair, &1.0);
-
-    assert!(microstate.bodies().len() > 1);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Apply the quick insert protocol to a microstate.
+    ///
+    /// Combine [`QuickInsert::apply`] with local trial moves that translate and/or
+    /// rotate bodies by small amounts to relieve the stress caused by inserting
+    /// overlapping sites.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_geometry::shape::Rectangle;
+    /// use hoomd_interaction::{
+    ///     CutoffPair,
+    ///     pairwise::{Expanded, Isotropic, OverlapPenalty},
+    /// };
+    /// use hoomd_mc::{QuickInsert, Sweep, Translate, Trial, UniformIn};
+    /// use hoomd_microstate::{
+    ///     Body, MicrostateBuilder, boundary::Periodic, property::Point,
+    /// };
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let rectangle = Rectangle::with_equal_edges(10.0.try_into()?);
+    ///
+    /// let distribution = UniformIn {
+    ///     boundary: rectangle,
+    ///     template_sites: vec![Point::default()],
+    /// };
+    /// let mut quick_insert = QuickInsert::new(distribution, 256);
+    ///
+    /// let translate = Translate {
+    ///     maximum_distance: 0.1.try_into()?,
+    /// };
+    /// let translate_sweep = Sweep(translate);
+    ///
+    /// let cutoff_pair = CutoffPair {
+    ///     r_cut: 1.0,
+    ///     evaluator: Isotropic(Expanded {
+    ///         delta: 1.0,
+    ///         f: OverlapPenalty::default(),
+    ///     }),
+    /// };
+    ///
+    /// let mut microstate =
+    ///     MicrostateBuilder::with_boundary(Periodic::new(1.0, rectangle)?)
+    ///         .bodies([Body::point(Cartesian::from([0.0, 0.0]))])
+    ///         .try_build()?;
+    ///
+    /// quick_insert.apply(&mut microstate, &cutoff_pair);
+    ///
+    /// translate_sweep.apply(&mut microstate, &cutoff_pair, &1.0);
+    ///
+    /// assert!(microstate.bodies().len() > 1);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     pub fn apply<V, B, S, C, H>(
         &mut self,

--- a/hoomd-mc/src/quick_insert.rs
+++ b/hoomd-mc/src/quick_insert.rs
@@ -47,11 +47,11 @@ enum State {
 /// When you [`apply`] a running [`QuickInsert`] to a microstate, it:
 /// 1. Checks the total energy of the given Hamiltonian.
 /// 2. If the total energy is zero *and there are still bodies to insert*, generate
-/// a random body and attempt to insert it into the microstate. Reject any
-/// insertion that would result in an infinite energy. Accept in all other cases.
+///    a random body and attempt to insert it into the microstate. Reject any
+///    insertion that would result in an infinite energy. Accept in all other cases.
 /// 3. Repeat step 2 until inserted bodies overlap with others `allowed_overlaps`
-/// times, the target number of bodies have been inserted, or a total of `target`
-/// attempts have been made during this call, whichever comes first.
+///    times, the target number of bodies have been inserted, or a total of `target`
+///    attempts have been made during this call, whichever comes first.
 ///
 /// When *both* `target` bodies have been inserted *and* the energy is
 /// 0, [`QuickInsert`] transitions to the complete state. When complete,
@@ -63,7 +63,7 @@ enum State {
 /// `QuickCompress` is a better solution.
 ///
 /// The generic type names are:
-/// `D`: The body distribution.
+/// * `D`: The body distribution.
 ///
 /// [`apply`]: Self::apply
 /// [`is_complete`]: Self::is_complete

--- a/hoomd-mc/src/rotate.rs
+++ b/hoomd-mc/src/rotate.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement Rotate
- */
+//! Implement Rotate
 
 use super::LocalTrial;
 use hoomd_microstate::property::Orientation;
@@ -14,32 +13,33 @@ use rand::{
     distr::{Distribution, Uniform},
 };
 
-/** Change the orientation of a body by a small amount.
-
-[`Rotate`] proposes local trial moves that rotate the orientation of a body
-by a small amount. The [`maximum_rotation`] parameter sets the largest possible
-rotation.
-
-For the 2D [`Angle`], [`maximum_rotation`] is measured in radians and the
-rotation is uniformly chosen between `-maximum_rotation` and `maximum_rotation`.
-
-TODO: document 3d maximum.
-
-[`maximum_rotation`]: Self::maximum_rotation
-
-# Example
-
-```
-use hoomd_mc::Rotate;
-use hoomd_vector::Angle;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let a = 0.1;
-let rotate = Rotate { maximum_rotation: a.try_into()? };
-# Ok(())
-# }
-```
-*/
+/// Change the orientation of a body by a small amount.
+///
+/// [`Rotate`] proposes local trial moves that rotate the orientation of a body
+/// by a small amount. The [`maximum_rotation`] parameter sets the largest possible
+/// rotation.
+///
+/// For the 2D [`Angle`], [`maximum_rotation`] is measured in radians and the
+/// rotation is uniformly chosen between `-maximum_rotation` and `maximum_rotation`.
+///
+/// TODO: document 3d maximum.
+///
+/// [`maximum_rotation`]: Self::maximum_rotation
+///
+/// # Example
+///
+/// ```
+/// use hoomd_mc::Rotate;
+/// use hoomd_vector::Angle;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let a = 0.1;
+/// let rotate = Rotate {
+///     maximum_rotation: a.try_into()?,
+/// };
+/// # Ok(())
+/// # }
+/// ```
 pub struct Rotate {
     /// Limit the maximum rotation applied during a single trial move.
     pub maximum_rotation: PositiveReal,
@@ -49,30 +49,31 @@ impl<B> LocalTrial<B> for Rotate
 where
     B: Orientation<Rotation = Angle>,
 {
-    /** Randomly translate a body's orientation.
-
-    # Example
-
-    ```
-    use hoomd_mc::{LocalTrial, Rotate};
-    use hoomd_microstate::property::OrientedPoint;
-    use hoomd_vector::{Angle, Cartesian};
-    use rand::{rngs::StdRng, Rng, SeedableRng};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = StdRng::seed_from_u64(1);
-    let body_properties = OrientedPoint {
-        position: Cartesian::from([0.0, 0.0]),
-        orientation: Angle::from(0.0),
-    };
-    let rotate = Rotate { maximum_rotation: 0.1.try_into()? };
-
-    let new_body_properties = rotate.propose(&mut rng, body_properties);
-    assert!(new_body_properties.orientation.theta.abs() < 0.1);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Randomly translate a body's orientation.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_mc::{LocalTrial, Rotate};
+    /// use hoomd_microstate::property::OrientedPoint;
+    /// use hoomd_vector::{Angle, Cartesian};
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut rng = StdRng::seed_from_u64(1);
+    /// let body_properties = OrientedPoint {
+    ///     position: Cartesian::from([0.0, 0.0]),
+    ///     orientation: Angle::from(0.0),
+    /// };
+    /// let rotate = Rotate {
+    ///     maximum_rotation: 0.1.try_into()?,
+    /// };
+    ///
+    /// let new_body_properties = rotate.propose(&mut rng, body_properties);
+    /// assert!(new_body_properties.orientation.theta.abs() < 0.1);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn propose<R: Rng>(&self, rng: &mut R, body_properties: B) -> B {
         let mut trial = body_properties;

--- a/hoomd-mc/src/sweep.rs
+++ b/hoomd-mc/src/sweep.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement Sweep
- */
+//! Implement Sweep
 
 use super::{Count, LocalTrial, Trial};
 use hoomd_interaction::DeltaEnergyOne;
@@ -14,42 +13,43 @@ use hoomd_microstate::{
 
 use rand::Rng;
 
-/** Apply a local trial move to each body in the microstate.
-
-Each trial move is accepted when:
-```math
-r < \exp\left(\frac{-\Delta H}{kT}\right)
-```
-where `r` is a random value uniformly distributed in `[0,1)`, $`\Delta H`$ is
-the change in energy computed by the given `hamiltonian` and $`kT`$ is the given
-`state` value (the last argument to `apply`).
-
-# Example
-
-```
-use hoomd_interaction::Zero;
-use hoomd_mc::{Sweep, Translate, Trial};
-use hoomd_microstate::{Body, Microstate, property::Position};
-use hoomd_vector::Cartesian;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = Microstate::new();
-microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
-let d = 0.1;
-let translate = Translate { maximum_distance: d.try_into()? };
-let translate_sweep = Sweep(translate);
-
-let hamiltonian = Zero;
-let kt = 1.0;
-
-for _ in 0..1_000 {
-    translate_sweep.apply(&mut microstate, &hamiltonian, &kt);
-    microstate.increment_step();
-}
-# Ok(())
-# }
-```
-*/
+/// Apply a local trial move to each body in the microstate.
+///
+/// Each trial move is accepted when:
+/// ```math
+/// r < \exp\left(\frac{-\Delta H}{kT}\right)
+/// ```
+/// where `r` is a random value uniformly distributed in `[0,1)`, $`\Delta H`$ is
+/// the change in energy computed by the given `hamiltonian` and $`kT`$ is the given
+/// `state` value (the last argument to `apply`).
+///
+/// # Example
+///
+/// ```
+/// use hoomd_interaction::Zero;
+/// use hoomd_mc::{Sweep, Translate, Trial};
+/// use hoomd_microstate::{Body, Microstate, property::Position};
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
+/// let d = 0.1;
+/// let translate = Translate {
+///     maximum_distance: d.try_into()?,
+/// };
+/// let translate_sweep = Sweep(translate);
+///
+/// let hamiltonian = Zero;
+/// let kt = 1.0;
+///
+/// for _ in 0..1_000 {
+///     translate_sweep.apply(&mut microstate, &hamiltonian, &kt);
+///     microstate.increment_step();
+/// }
+/// # Ok(())
+/// # }
+/// ```
 pub struct Sweep<L>(pub L);
 
 impl<V, B, S, C, L, H> Trial<Microstate<B, S, C>, H> for Sweep<L>

--- a/hoomd-mc/src/translate.rs
+++ b/hoomd-mc/src/translate.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement Translate
- */
+//! Implement Translate
 
 use super::LocalTrial;
 use hoomd_microstate::property::Position;
@@ -11,25 +10,26 @@ use hoomd_vector::{Vector, distribution::Ball};
 
 use rand::{Rng, distr::Distribution};
 
-/** Move the position of a body by a small distance.
-
-`Translate` proposes local trial moves that translate the position of a body
-in space by a random vector up a given maximum length, given by a
-[`PositiveReal`](hoomd_utility::valid::PositiveReal).
-
-# Example
-
-```
-use hoomd_mc::Translate;
-use hoomd_vector::Cartesian;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let d = 0.1;
-let translate = Translate { maximum_distance: d.try_into()? };
-# Ok(())
-# }
-```
-*/
+/// Move the position of a body by a small distance.
+///
+/// `Translate` proposes local trial moves that translate the position of a body
+/// in space by a random vector up a given maximum length, given by a
+/// [`PositiveReal`](hoomd_utility::valid::PositiveReal).
+///
+/// # Example
+///
+/// ```
+/// use hoomd_mc::Translate;
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let d = 0.1;
+/// let translate = Translate {
+///     maximum_distance: d.try_into()?,
+/// };
+/// # Ok(())
+/// # }
+/// ```
 pub struct Translate {
     /// The maximum distance a body can be translated in one trial move.
     pub maximum_distance: PositiveReal,
@@ -41,28 +41,29 @@ where
     V: Vector,
     Ball: Distribution<V>,
 {
-    /** Randomly translate a body's position.
-
-    # Example
-
-    ```
-    use hoomd_mc::{LocalTrial, Translate};
-    use hoomd_microstate::property::Point;
-    use hoomd_vector::{Cartesian, InnerProduct};
-    use rand::{rngs::StdRng, Rng, SeedableRng};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = StdRng::seed_from_u64(1);
-    let body_properties = Point::new(Cartesian::from([0.0, 0.0]));
-    let d = 1.0;
-    let translate = Translate { maximum_distance: d.try_into()? };
-
-    let new_body_properties = translate.propose(&mut rng, body_properties);
-    assert!(new_body_properties.position.norm() < 1.0);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Randomly translate a body's position.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_mc::{LocalTrial, Translate};
+    /// use hoomd_microstate::property::Point;
+    /// use hoomd_vector::{Cartesian, InnerProduct};
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut rng = StdRng::seed_from_u64(1);
+    /// let body_properties = Point::new(Cartesian::from([0.0, 0.0]));
+    /// let d = 1.0;
+    /// let translate = Translate {
+    ///     maximum_distance: d.try_into()?,
+    /// };
+    ///
+    /// let new_body_properties = translate.propose(&mut rng, body_properties);
+    /// assert!(new_body_properties.position.norm() < 1.0);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn propose<R: Rng>(&self, rng: &mut R, body_properties: B) -> B {
         let mut trial = body_properties;

--- a/hoomd-mc/src/uniform_in.rs
+++ b/hoomd-mc/src/uniform_in.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement `UniformIn`
- */
+//! Implement `UniformIn`
 
 use hoomd_microstate::{
     Body,
@@ -14,70 +13,74 @@ use rand::{
     distr::{Distribution, StandardUniform},
 };
 
-/** Generate bodies uniformly in the given boundary condition.
-
-Give [`UniformIn`] a template vector of sites and it will randomly generate
-bodies uniformly distributed in the given boundary. Each generated body will
-have the same sites (cloned from `template_sites`) and random body properties
-sampled in the given `boundary`.
-
-# Example
-
-Place points at random locations in the boundary:
-```
-use hoomd_geometry::{IsPointInside, shape::Rectangle};
-use hoomd_mc::UniformIn;
-use hoomd_microstate::{Body, boundary::Closed, property::Point};
-use hoomd_vector::Cartesian;
-
-use rand::{SeedableRng, rngs::StdRng, distr::Distribution};
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let rectangle = Closed(Rectangle::with_equal_edges(5.0.try_into()?));
-let mut rng = StdRng::seed_from_u64(1);
-
-let uniform_in = UniformIn {
-    boundary: rectangle,
-    template_sites: vec![Point::new(Cartesian::from([0.0, 0.0]))],
-};
-
-let body: Body<Point<Cartesian<2>>, Point<Cartesian<2>>> = uniform_in.sample(&mut rng);
-assert!(rectangle.0.is_point_inside(&body.properties.position));
-# Ok(())
-# }
-```
-
-Place oriented bodies at random locations in the boundary and give them random
-orientations:
-```
-use rand::{SeedableRng, rngs::StdRng, distr::Distribution};
-use std::f64::consts::PI;
-
-use hoomd_geometry::{IsPointInside, shape::Rectangle};
-use hoomd_mc::UniformIn;
-use hoomd_microstate::{Body, boundary::Closed, property::{OrientedPoint, Point}};
-use hoomd_vector::{Angle, Cartesian};
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let rectangle = Closed(Rectangle::with_equal_edges(5.0.try_into()?));
-let mut rng = StdRng::seed_from_u64(1);
-
-let uniform_in = UniformIn {
-    boundary: rectangle,
-    template_sites: vec![
-        Point::new(Cartesian::from([-1.0, 0.0])),
-        Point::new(Cartesian::from([1.0, 0.0])),
-    ],
-};
-
-let body: Body<OrientedPoint<Cartesian<2>, Angle>, Point<Cartesian<2>>> =
-    uniform_in.sample(&mut rng);
-assert!(rectangle.0.is_point_inside(&body.properties.position));
-assert!(body.properties.orientation.theta < 2.0 * PI);
-# Ok(())
-# }
-```
-*/
+/// Generate bodies uniformly in the given boundary condition.
+///
+/// Give [`UniformIn`] a template vector of sites and it will randomly generate
+/// bodies uniformly distributed in the given boundary. Each generated body will
+/// have the same sites (cloned from `template_sites`) and random body properties
+/// sampled in the given `boundary`.
+///
+/// # Example
+///
+/// Place points at random locations in the boundary:
+/// ```
+/// use hoomd_geometry::{IsPointInside, shape::Rectangle};
+/// use hoomd_mc::UniformIn;
+/// use hoomd_microstate::{Body, boundary::Closed, property::Point};
+/// use hoomd_vector::Cartesian;
+///
+/// use rand::{SeedableRng, distr::Distribution, rngs::StdRng};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let rectangle = Closed(Rectangle::with_equal_edges(5.0.try_into()?));
+/// let mut rng = StdRng::seed_from_u64(1);
+///
+/// let uniform_in = UniformIn {
+///     boundary: rectangle,
+///     template_sites: vec![Point::new(Cartesian::from([0.0, 0.0]))],
+/// };
+///
+/// let body: Body<Point<Cartesian<2>>, Point<Cartesian<2>>> =
+///     uniform_in.sample(&mut rng);
+/// assert!(rectangle.0.is_point_inside(&body.properties.position));
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Place oriented bodies at random locations in the boundary and give them random
+/// orientations:
+/// ```
+/// use rand::{SeedableRng, distr::Distribution, rngs::StdRng};
+/// use std::f64::consts::PI;
+///
+/// use hoomd_geometry::{IsPointInside, shape::Rectangle};
+/// use hoomd_mc::UniformIn;
+/// use hoomd_microstate::{
+///     Body,
+///     boundary::Closed,
+///     property::{OrientedPoint, Point},
+/// };
+/// use hoomd_vector::{Angle, Cartesian};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let rectangle = Closed(Rectangle::with_equal_edges(5.0.try_into()?));
+/// let mut rng = StdRng::seed_from_u64(1);
+///
+/// let uniform_in = UniformIn {
+///     boundary: rectangle,
+///     template_sites: vec![
+///         Point::new(Cartesian::from([-1.0, 0.0])),
+///         Point::new(Cartesian::from([1.0, 0.0])),
+///     ],
+/// };
+///
+/// let body: Body<OrientedPoint<Cartesian<2>, Angle>, Point<Cartesian<2>>> =
+///     uniform_in.sample(&mut rng);
+/// assert!(rectangle.0.is_point_inside(&body.properties.position));
+/// assert!(body.properties.orientation.theta < 2.0 * PI);
+/// # Ok(())
+/// # }
+/// ```
 pub struct UniformIn<S, C> {
     /// Generate bodies inside this boundary.
     pub boundary: C,
@@ -86,12 +89,11 @@ pub struct UniformIn<S, C> {
     pub template_sites: Vec<S>,
 }
 
-/** Randomly place point bodies in a given boundary.
-
-`sample` chooses the *body's* position randomly in the given boundary. Sites,
-therefore, may be placed outside the boundary. Callers should reject insertions
-appropriately when `add_body` fails.
-*/
+/// Randomly place point bodies in a given boundary.
+///
+/// `sample` chooses the *body's* position randomly in the given boundary. Sites,
+/// therefore, may be placed outside the boundary. Callers should reject insertions
+/// appropriately when `add_body` fails.
 impl<V, S, C> Distribution<Body<Point<V>, S>> for UniformIn<S, C>
 where
     S: Clone,
@@ -107,13 +109,12 @@ where
     }
 }
 
-/** Randomly place oriented bodies in a given boundary.
-
-`sample` chooses the *body's* position randomly in the given boundary and also
-assigns a *uniform random orientation*. Sites, therefore, may be placed outside
-the boundary. Callers should reject insertions appropriately when `add_body`
-fails.
-*/
+/// Randomly place oriented bodies in a given boundary.
+///
+/// `sample` chooses the *body's* position randomly in the given boundary and also
+/// assigns a *uniform random orientation*. Sites, therefore, may be placed outside
+/// the boundary. Callers should reject insertions appropriately when `add_body`
+/// fails.
 impl<V, O, S, C> Distribution<Body<OrientedPoint<V, O>, S>> for UniformIn<S, C>
 where
     S: Clone,

--- a/hoomd-microstate/src/boundary.rs
+++ b/hoomd-microstate/src/boundary.rs
@@ -1,25 +1,24 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Traits that describe boundary conditions and a selection of types that implement them.
-
-See the [crate-level documentation](crate) for an overview of how boundary
-conditions interact with [`Microstate`](crate::Microstate) and model methods.
-
-*hoomd-rs* provides the boundary types [`Open`], [`Closed`], and [`Periodic`].
-* [`Open`] boundaries allow bodies and sites to exist anywhere in space.
-* [`Closed`] boundaries limit bodies and sites to the inside of a shape and
-  are not periodic in any direction.
-* [`Periodic`] boundaries limit bodies and sites to the inside of a shape,
-  wrap particles anywhere outside that shape back inside, and place ghosts
-  following the periodic tiling of the shape.
-
-The documentation of [`Closed`] and [`Periodic`] describes the shapes that
-they each implement. If the shape you want is not supported, you can write
-a custom shape type and implement `IsInside` so that it will work with
-[`Closed`]. To implement a custom periodic boundary, create your custom
-type and implement both [`Wrap`] and [`GenerateGhosts`] for it.
- */
+//! Traits that describe boundary conditions and a selection of types that implement them.
+//!
+//! See the [crate-level documentation](crate) for an overview of how boundary
+//! conditions interact with [`Microstate`](crate::Microstate) and model methods.
+//!
+//! hoomd-rs* provides the boundary types [`Open`], [`Closed`], and [`Periodic`].
+//! [`Open`] boundaries allow bodies and sites to exist anywhere in space.
+//! [`Closed`] boundaries limit bodies and sites to the inside of a shape and
+//! are not periodic in any direction.
+//! [`Periodic`] boundaries limit bodies and sites to the inside of a shape,
+//! wrap particles anywhere outside that shape back inside, and place ghosts
+//! following the periodic tiling of the shape.
+//!
+//! The documentation of [`Closed`] and [`Periodic`] describes the shapes that
+//! they each implement. If the shape you want is not supported, you can write
+//! a custom shape type and implement `IsInside` so that it will work with
+//! [`Closed`]. To implement a custom periodic boundary, create your custom
+//! type and implement both [`Wrap`] and [`GenerateGhosts`] for it.
 
 use thiserror::Error;
 use tinyvec::ArrayVec;
@@ -50,89 +49,83 @@ pub(crate) const MAX_GHOSTS: usize = 8;
 // Ideally, MAX_GHOSTS would be associated with the boundary type, but that is
 // not currently possible in Rust.
 
-/** Attempt to move any body/site properties back into the simulation boundary.
-
-[`Wrap`] and [`GenerateGhosts`] together define the behavior of simulation
-boundary conditions.
-
-The **boundary** defines the subset of points where bodies and sites are
-allowed. The [`wrap`] method takes a given body or site properties that
-is anywhere in space and attempts to wrap it back into the boundary. This
-process succeeds when the boundary is periodic and fails when it is not
-(some boundaries may be periodic in some directions and not in others).
-
-The generic type name is:
-* `P`: The [`Body::properties`](crate::Body) or [`Site::properties`](crate::Site) type.
-
-[`wrap`]: Self::wrap
-*/
+/// Attempt to move any body/site properties back into the simulation boundary.
+///
+/// [`Wrap`] and [`GenerateGhosts`] together define the behavior of simulation
+/// boundary conditions.
+///
+/// The **boundary** defines the subset of points where bodies and sites are
+/// allowed. The [`wrap`] method takes a given body or site properties that
+/// is anywhere in space and attempts to wrap it back into the boundary. This
+/// process succeeds when the boundary is periodic and fails when it is not
+/// (some boundaries may be periodic in some directions and not in others).
+///
+/// The generic type name is:
+/// `P`: The [`Body::properties`](crate::Body) or [`Site::properties`](crate::Site) type.
+///
+/// [`wrap`]: Self::wrap
 pub trait Wrap<P> {
-    /** Transform body/point properties into the boundary.
-
-    `wrap` takes a body or site properties with a position that may be outside
-    the boundary. It attempts to wrap that position back inside following the
-    boundary's periodicity. `wrap` returns [`Ok(properties)`](Ok) when this
-    process is successful.
-
-    # Errors
-
-    `wrap` returns [`Error::CannotWrapProperties`] when it is not possible
-    to wrap the body into the boundary. For example, when the position is
-    outside the radius of a cylinder that is only periodic along its axis.
-    */
+    /// Transform body/point properties into the boundary.
+    ///
+    /// `wrap` takes a body or site properties with a position that may be outside
+    /// the boundary. It attempts to wrap that position back inside following the
+    /// boundary's periodicity. `wrap` returns [`Ok(properties)`](Ok) when this
+    /// process is successful.
+    ///
+    /// # Errors
+    ///
+    /// `wrap` returns [`Error::CannotWrapProperties`] when it is not possible
+    /// to wrap the body into the boundary. For example, when the position is
+    /// outside the radius of a cylinder that is only periodic along its axis.
     fn wrap(&self, properties: P) -> Result<P, Error>;
 }
 
-/** Place periodic images of sites within the interaction range.
-
-[`Wrap`] and [`GenerateGhosts`] together define the behavior of simulation
-boundary conditions.
-
-The **boundary** defines the subset of points where bodies and sites are
-allowed. [`generate_ghosts`] places 0 or more sites that are periodic images
-of the given site **and** within the maximum interaction range of the boundary.
-[`Closed`] boundary conditions place no ghosts. [`Periodic`] boundary conditions
-may place 0, 1, 2, or more ghosts depending on the location of the site. For
-example sites in the center of a cubic box will have 0 ghosts, those near the
-center of a face will have 1, those near an edge will have 2, and those near a
-vertex will have 3.
-
-To avoid costly dynamic memory allocations, [`generate_ghosts`] returns an
-array-backed storage with a hard-coded maximum size of `MAX_GHOSTS`.
-
-[`generate_ghosts`]: Self::generate_ghosts
-*/
+/// Place periodic images of sites within the interaction range.
+///
+/// [`Wrap`] and [`GenerateGhosts`] together define the behavior of simulation
+/// boundary conditions.
+///
+/// The **boundary** defines the subset of points where bodies and sites are
+/// allowed. [`generate_ghosts`] places 0 or more sites that are periodic images
+/// of the given site **and** within the maximum interaction range of the boundary.
+/// [`Closed`] boundary conditions place no ghosts. [`Periodic`] boundary conditions
+/// may place 0, 1, 2, or more ghosts depending on the location of the site. For
+/// example sites in the center of a cubic box will have 0 ghosts, those near the
+/// center of a face will have 1, those near an edge will have 2, and those near a
+/// vertex will have 3.
+///
+/// To avoid costly dynamic memory allocations, [`generate_ghosts`] returns an
+/// array-backed storage with a hard-coded maximum size of `MAX_GHOSTS`.
+///
+/// [`generate_ghosts`]: Self::generate_ghosts
 pub trait GenerateGhosts<S> {
-    /** The largest interaction distance between sites.
-
-    The maximum interaction range is the largest distance between two
-    interacting sites. [`Microstate`](crate::Microstate) will place ghosts
-    within this range outside periodic boundaries.
-    */
+    /// The largest interaction distance between sites.
+    ///
+    /// The maximum interaction range is the largest distance between two
+    /// interacting sites. [`Microstate`](crate::Microstate) will place ghosts
+    /// within this range outside periodic boundaries.
     fn maximum_interaction_range(&self) -> f64;
 
-    /** Place periodic images of sites within the interaction range.
-
-    Given `site_properties` inside the boundary, `generate_ghosts` places
-    periodic images of that site. It must place all ghosts needed to compute
-    interactions with other sites in the given [`maximum_interaction_range`].
-
-    [`maximum_interaction_range`]: Self::maximum_interaction_range
-    */
+    /// Place periodic images of sites within the interaction range.
+    ///
+    /// Given `site_properties` inside the boundary, `generate_ghosts` places
+    /// periodic images of that site. It must place all ghosts needed to compute
+    /// interactions with other sites in the given [`maximum_interaction_range`].
+    ///
+    /// [`maximum_interaction_range`]: Self::maximum_interaction_range
     fn generate_ghosts(&self, _site_properties: &S) -> ArrayVec<[S; MAX_GHOSTS]>;
 }
 
-/** Compute the largest value of the maximum interaction range.
-
-In *hoomd-rs*, sites interact only with the *minimum images* of other sites.
-In periodic boundary conditions, there is a maximum allowable interaction
-range beyond which sites would start interacting with multiple images. The
-[`MaximumAllowableInteractionRange`] trait computes that distance for a given
-shape.
-
-[`Periodic`] uses [`MaximumAllowableInteractionRange`] to trigger an error when
-the caller requires an interaction range larger than is possible.
-*/
+/// Compute the largest value of the maximum interaction range.
+///
+/// In *hoomd-rs*, sites interact only with the *minimum images* of other sites.
+/// In periodic boundary conditions, there is a maximum allowable interaction
+/// range beyond which sites would start interacting with multiple images. The
+/// [`MaximumAllowableInteractionRange`] trait computes that distance for a given
+/// shape.
+///
+/// [`Periodic`] uses [`MaximumAllowableInteractionRange`] to trigger an error when
+/// the caller requires an interaction range larger than is possible.
 pub trait MaximumAllowableInteractionRange {
     /// The largest value that the maximum interaction range can take.
     fn maximum_allowable_interaction_range(&self) -> f64;

--- a/hoomd-microstate/src/boundary.rs
+++ b/hoomd-microstate/src/boundary.rs
@@ -7,12 +7,12 @@
 //! conditions interact with [`Microstate`](crate::Microstate) and model methods.
 //!
 //! hoomd-rs* provides the boundary types [`Open`], [`Closed`], and [`Periodic`].
-//! [`Open`] boundaries allow bodies and sites to exist anywhere in space.
-//! [`Closed`] boundaries limit bodies and sites to the inside of a shape and
-//! are not periodic in any direction.
-//! [`Periodic`] boundaries limit bodies and sites to the inside of a shape,
-//! wrap particles anywhere outside that shape back inside, and place ghosts
-//! following the periodic tiling of the shape.
+//! * [`Open`] boundaries allow bodies and sites to exist anywhere in space.
+//! * [`Closed`] boundaries limit bodies and sites to the inside of a shape and
+//!   are not periodic in any direction.
+//! * [`Periodic`] boundaries limit bodies and sites to the inside of a shape,
+//!   wrap particles anywhere outside that shape back inside, and place ghosts
+//!   following the periodic tiling of the shape.
 //!
 //! The documentation of [`Closed`] and [`Periodic`] describes the shapes that
 //! they each implement. If the shape you want is not supported, you can write
@@ -61,7 +61,7 @@ pub(crate) const MAX_GHOSTS: usize = 8;
 /// (some boundaries may be periodic in some directions and not in others).
 ///
 /// The generic type name is:
-/// `P`: The [`Body::properties`](crate::Body) or [`Site::properties`](crate::Site) type.
+/// * `P`: The [`Body::properties`](crate::Body) or [`Site::properties`](crate::Site) type.
 ///
 /// [`wrap`]: Self::wrap
 pub trait Wrap<P> {

--- a/hoomd-microstate/src/boundary/closed.rs
+++ b/hoomd-microstate/src/boundary/closed.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement Closed
- */
+//! Implement Closed
 
 use rand::{Rng, distr::Distribution};
 use tinyvec::ArrayVec;
@@ -11,12 +10,11 @@ use super::{Error, GenerateGhosts, MAX_GHOSTS, Wrap};
 use crate::property::Position;
 use hoomd_geometry::IsPointInside;
 
-/** Restrict points to the inside of a shape.
-
-[`Closed`] is a newtype that wraps a shape. It prevents bodies and sites from
-existing outside the shape. Bodies and sites are never wrapped, and there are no
-ghost sites.
-*/
+/// Restrict points to the inside of a shape.
+///
+/// [`Closed`] is a newtype that wraps a shape. It prevents bodies and sites from
+/// existing outside the shape. Bodies and sites are never wrapped, and there are no
+/// ghost sites.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Closed<T>(pub T);
 
@@ -54,25 +52,26 @@ impl<T, V> Distribution<V> for Closed<T>
 where
     T: Distribution<V>,
 {
-    /** Generate points uniformly distributed in the wrapped shape.
-
-    # Example
-
-    ```
-    use hoomd_geometry::{IsPointInside, shape::Sphere};
-    use hoomd_microstate::boundary::Closed;
-    use rand::{SeedableRng, rngs::StdRng, distr::Distribution};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let sphere = Closed(Sphere { radius: 5.0.try_into()? });
-    let mut rng = StdRng::seed_from_u64(1);
-
-    let point = sphere.sample(&mut rng);
-    assert!(sphere.0.is_point_inside(&point));
-    # Ok(())
-    # }
-    ```
-    */
+    /// Generate points uniformly distributed in the wrapped shape.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_geometry::{IsPointInside, shape::Sphere};
+    /// use hoomd_microstate::boundary::Closed;
+    /// use rand::{SeedableRng, distr::Distribution, rngs::StdRng};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let sphere = Closed(Sphere {
+    ///     radius: 5.0.try_into()?,
+    /// });
+    /// let mut rng = StdRng::seed_from_u64(1);
+    ///
+    /// let point = sphere.sample(&mut rng);
+    /// assert!(sphere.0.is_point_inside(&point));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> V {
         self.0.sample(rng)

--- a/hoomd-microstate/src/boundary/open.rs
+++ b/hoomd-microstate/src/boundary/open.rs
@@ -1,18 +1,16 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement Open
- */
+//! Implement Open
 
 use tinyvec::ArrayVec;
 
 use super::{Error, GenerateGhosts, MAX_GHOSTS, Wrap};
 
-/** Allow bodies and sites to exist anywhere in space.
-
-Every point lies inside `Open` boundary conditions, bodies and sites
-are never wrapped, and there are no ghost sites.
-*/
+/// Allow bodies and sites to exist anywhere in space.
+///
+/// Every point lies inside `Open` boundary conditions, bodies and sites
+/// are never wrapped, and there are no ghost sites.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Open;
 

--- a/hoomd-microstate/src/boundary/periodic.rs
+++ b/hoomd-microstate/src/boundary/periodic.rs
@@ -22,8 +22,8 @@ mod cuboid;
 /// and closed in others.
 ///
 /// [`Periodic`] is implemented for the following shapes:
-/// [`Cuboid<2>`] also known as [`Rectangle`]
-/// [`Cuboid<3>`]
+/// * [`Cuboid<2>`] (also known as [`Rectangle`])
+/// * [`Cuboid<3>`]
 ///
 /// [`Cuboid<2>`]: hoomd_geometry::shape::Cuboid
 /// [`Cuboid<3>`]: hoomd_geometry::shape::Cuboid

--- a/hoomd-microstate/src/boundary/periodic.rs
+++ b/hoomd-microstate/src/boundary/periodic.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement periodic boundary conditions. */
+//! Implement periodic boundary conditions.
 
 use rand::{Rng, distr::Distribution};
 
@@ -9,39 +9,39 @@ use super::{Error, MaximumAllowableInteractionRange};
 
 mod cuboid;
 
-/** Describe a simulation space that repeats in one or more directions.
-
-[`Periodic`] is a newtype that wraps a shape. Use it to set the `boundary`
-for a [`Microstate`].
-
-When bodies or sites exit the shape through one of the periodic sides of the
-shape, they are wrapped to the other side. Similarly, sites that are within
-the interaction range of one of the periodic sides appear as ghost sites just
-outside the opposite side. Depending on the shape type `T`, `Periodic<T>` might
-implement fully periodic boundaries or ones that are periodic in some directions
-and closed in others.
-
-[`Periodic`] is implemented for the following shapes:
-* [`Cuboid<2>`] also known as [`Rectangle`]
-* [`Cuboid<3>`]
-
-[`Cuboid<2>`]: hoomd_geometry::shape::Cuboid
-[`Cuboid<3>`]: hoomd_geometry::shape::Cuboid
-[`Rectangle`]: hoomd_geometry::shape::Rectangle
-[`Microstate`]: crate::Microstate
-
-# Example
-
-```
-use hoomd_geometry::shape::Rectangle;
-use hoomd_microstate::boundary::Periodic;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let periodic = Periodic::new(2.5, Rectangle::with_equal_edges(10.0.try_into()?))?;
-# Ok(())
-# }
-```
-*/
+/// Describe a simulation space that repeats in one or more directions.
+///
+/// [`Periodic`] is a newtype that wraps a shape. Use it to set the `boundary`
+/// for a [`Microstate`].
+///
+/// When bodies or sites exit the shape through one of the periodic sides of the
+/// shape, they are wrapped to the other side. Similarly, sites that are within
+/// the interaction range of one of the periodic sides appear as ghost sites just
+/// outside the opposite side. Depending on the shape type `T`, `Periodic<T>` might
+/// implement fully periodic boundaries or ones that are periodic in some directions
+/// and closed in others.
+///
+/// [`Periodic`] is implemented for the following shapes:
+/// [`Cuboid<2>`] also known as [`Rectangle`]
+/// [`Cuboid<3>`]
+///
+/// [`Cuboid<2>`]: hoomd_geometry::shape::Cuboid
+/// [`Cuboid<3>`]: hoomd_geometry::shape::Cuboid
+/// [`Rectangle`]: hoomd_geometry::shape::Rectangle
+/// [`Microstate`]: crate::Microstate
+///
+/// # Example
+///
+/// ```
+/// use hoomd_geometry::shape::Rectangle;
+/// use hoomd_microstate::boundary::Periodic;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let periodic =
+///     Periodic::new(2.5, Rectangle::with_equal_edges(10.0.try_into()?))?;
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Periodic<T> {
     /// The largest interaction distance between two sites.
@@ -55,25 +55,25 @@ impl<T> Periodic<T>
 where
     T: MaximumAllowableInteractionRange,
 {
-    /** Construct a new periodic boundary condition.
-
-    # Errors
-
-    [`Error::InteractionRangeTooLarge`] when `maximum_interaction_range` is
-    larger than the maximum allowable interaction range by the shape.
-
-    # Example
-
-    ```
-    use hoomd_geometry::shape::Rectangle;
-    use hoomd_microstate::boundary::Periodic;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let periodic = Periodic::new(2.5, Rectangle::with_equal_edges(10.0.try_into()?))?;
-    # Ok(())
-    # }
-    ```
-    */
+    /// Construct a new periodic boundary condition.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::InteractionRangeTooLarge`] when `maximum_interaction_range` is
+    /// larger than the maximum allowable interaction range by the shape.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_geometry::shape::Rectangle;
+    /// use hoomd_microstate::boundary::Periodic;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let periodic =
+    ///     Periodic::new(2.5, Rectangle::with_equal_edges(10.0.try_into()?))?;
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     pub fn new(maximum_interaction_range: f64, shape: T) -> Result<Self, Error> {
         if maximum_interaction_range > shape.maximum_allowable_interaction_range() {
@@ -91,22 +91,22 @@ where
 }
 
 impl<T> Periodic<T> {
-    /** Access the boundary's shape.
-
-    # Example
-
-    ```
-    use hoomd_geometry::shape::Rectangle;
-    use hoomd_microstate::boundary::Periodic;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let periodic = Periodic::new(2.5, Rectangle::with_equal_edges(10.0.try_into()?))?;
-
-    assert_eq!(periodic.shape().edge_lengths[0].get(), 10.0);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Access the boundary's shape.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_geometry::shape::Rectangle;
+    /// use hoomd_microstate::boundary::Periodic;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let periodic =
+    ///     Periodic::new(2.5, Rectangle::with_equal_edges(10.0.try_into()?))?;
+    ///
+    /// assert_eq!(periodic.shape().edge_lengths[0].get(), 10.0);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     pub fn shape(&self) -> &T {
         &self.shape
@@ -117,27 +117,28 @@ impl<T, V> Distribution<V> for Periodic<T>
 where
     T: Distribution<V>,
 {
-    /** Generate points uniformly distributed in the wrapped shape.
-
-    # Example
-
-    ```
-    use rand::{SeedableRng, rngs::StdRng, distr::Distribution};
-
-    use hoomd_geometry::{IsPointInside, shape::Cuboid};
-    use hoomd_microstate::boundary::Periodic;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let cuboid = Cuboid { edge_lengths: [6.0.try_into()?, 8.0.try_into()?] };
-    let periodic = Periodic::new(2.5, cuboid)?;
-    let mut rng = StdRng::seed_from_u64(1);
-
-    let point = periodic.sample(&mut rng);
-    assert!(periodic.shape().is_point_inside(&point));
-    # Ok(())
-    # }
-    ```
-    */
+    /// Generate points uniformly distributed in the wrapped shape.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rand::{SeedableRng, distr::Distribution, rngs::StdRng};
+    ///
+    /// use hoomd_geometry::{IsPointInside, shape::Cuboid};
+    /// use hoomd_microstate::boundary::Periodic;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let cuboid = Cuboid {
+    ///     edge_lengths: [6.0.try_into()?, 8.0.try_into()?],
+    /// };
+    /// let periodic = Periodic::new(2.5, cuboid)?;
+    /// let mut rng = StdRng::seed_from_u64(1);
+    ///
+    /// let point = periodic.sample(&mut rng);
+    /// assert!(periodic.shape().is_point_inside(&point));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> V {
         self.shape.sample(rng)

--- a/hoomd-microstate/src/boundary/periodic/cuboid.rs
+++ b/hoomd-microstate/src/boundary/periodic/cuboid.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement periodic boundary conditions for cuboids in cartesian space. */
+//! Implement periodic boundary conditions for cuboids in cartesian space.
 
 use tinyvec::ArrayVec;
 
@@ -16,28 +16,29 @@ use hoomd_utility::valid::PositiveReal;
 use hoomd_vector::Cartesian;
 
 impl<const N: usize> MaximumAllowableInteractionRange for Cuboid<N> {
-    /** The largest value that the maximum interaction range can take.
-
-    For a cuboid, the maximum is
-    ```math
-    \frac{L_\mathrm{min}}{2}
-    ```
-    where $`L_\mathrm{min}`$ is the smallest edge length.
-
-    # Example
-
-    ```
-    use hoomd_geometry::shape::Cuboid;
-    use hoomd_microstate::boundary::MaximumAllowableInteractionRange;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let rectangular_prism = Cuboid {edge_lengths: [2.0.try_into()?, 3.0.try_into()?, 9.0.try_into()?]};
-
-    assert_eq!(rectangular_prism.maximum_allowable_interaction_range(), 1.0);
-    # Ok(())
-    # }
-    ```
-    */
+    /// The largest value that the maximum interaction range can take.
+    ///
+    /// For a cuboid, the maximum is
+    /// ```math
+    /// \frac{L_\mathrm{min}}{2}
+    /// ```
+    /// where $`L_\mathrm{min}`$ is the smallest edge length.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_geometry::shape::Cuboid;
+    /// use hoomd_microstate::boundary::MaximumAllowableInteractionRange;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let rectangular_prism = Cuboid {
+    ///     edge_lengths: [2.0.try_into()?, 3.0.try_into()?, 9.0.try_into()?],
+    /// };
+    ///
+    /// assert_eq!(rectangular_prism.maximum_allowable_interaction_range(), 1.0);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn maximum_allowable_interaction_range(&self) -> f64 {
         let minimum_l = self
@@ -54,25 +55,28 @@ impl<const N: usize, P> Wrap<P> for Periodic<Cuboid<N>>
 where
     P: Position<Vector = Cartesian<N>>,
 {
-    /** Wrap any cartesian vector to the inside of the given cuboid.
-
-    # Example
-
-    ```
-    use hoomd_geometry::shape::Rectangle;
-    use hoomd_microstate::{boundary::{Periodic, Wrap}, property::Point};
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let periodic = Periodic::new(2.5, Rectangle::with_equal_edges(10.0.try_into()?))?;
-    let point = Point::new(Cartesian::from([6.0, -15.0]));
-
-    let wrapped_point = periodic.wrap(point)?;
-    assert_eq!(wrapped_point.position, [-4.0, -5.0].into());
-    # Ok(())
-    # }
-    ```
-    */
+    /// Wrap any cartesian vector to the inside of the given cuboid.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_geometry::shape::Rectangle;
+    /// use hoomd_microstate::{
+    ///     boundary::{Periodic, Wrap},
+    ///     property::Point,
+    /// };
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let periodic =
+    ///     Periodic::new(2.5, Rectangle::with_equal_edges(10.0.try_into()?))?;
+    /// let point = Point::new(Cartesian::from([6.0, -15.0]));
+    ///
+    /// let wrapped_point = periodic.wrap(point)?;
+    /// assert_eq!(wrapped_point.position, [-4.0, -5.0].into());
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn wrap(&self, properties: P) -> Result<P, Error> {
         let mut properties = properties;
@@ -98,11 +102,10 @@ where
         self.maximum_interaction_range
     }
 
-    /** Place periodic images of sites near the edge of the periodic boundary.
-
-    For 2D cuboids, `generate_ghosts` places ghosts near the 4 edges and 4
-    vertices.
-    */
+    /// Place periodic images of sites near the edge of the periodic boundary.
+    ///
+    /// For 2D cuboids, `generate_ghosts` places ghosts near the 4 edges and 4
+    /// vertices.
     #[inline]
     fn generate_ghosts(&self, site_properties: &S) -> ArrayVec<[S; MAX_GHOSTS]> {
         let mut result = ArrayVec::new();
@@ -165,11 +168,10 @@ where
         self.maximum_interaction_range
     }
 
-    /** Place periodic images of sites near the edge of the periodic boundary.
-
-    For 3D cuboids, `generate_ghosts` places ghosts near the 6 faces, 12 edges,
-    and 8 vertices.
-    */
+    /// Place periodic images of sites near the edge of the periodic boundary.
+    ///
+    /// For 3D cuboids, `generate_ghosts` places ghosts near the 6 faces, 12 edges,
+    /// and 8 vertices.
     #[inline]
     fn generate_ghosts(&self, site_properties: &S) -> ArrayVec<[S; MAX_GHOSTS]> {
         let mut result = ArrayVec::new();

--- a/hoomd-microstate/src/lib.rs
+++ b/hoomd-microstate/src/lib.rs
@@ -146,7 +146,6 @@
 //! ## Spatial searches
 //!
 //! TODO: Implement spatial search, then document.
-//!
 
 pub mod boundary;
 mod microstate;

--- a/hoomd-microstate/src/lib.rs
+++ b/hoomd-microstate/src/lib.rs
@@ -92,7 +92,7 @@
 //! ## Tags
 //!
 //! The elements of [`Microstate::bodies`] and [`Microstate::sites`] are stored in
-//! no particular order** to allow efficient addition and removal of bodies and
+//! **no particular order** to allow efficient addition and removal of bodies and
 //! for the possibility sorting to improve cache coherency. Callers are welcome
 //! to iterate over these data structures when computing order-independent overall
 //! properties. However, a caller should never maintain indices into these vectors.

--- a/hoomd-microstate/src/lib.rs
+++ b/hoomd-microstate/src/lib.rs
@@ -8,146 +8,145 @@
     html_logo_url = "https://hoomd-blue.readthedocs.io/en/latest/_static/hoomdblue-logo-favicon.svg"
 )]
 
-/*! Store and manage the simulation state.
-
-# Microstate
-
-[`Microstate`] facilitates simulations of particle systems. It is the central
-data structure used by MC, MD, and supporting calculations implemented in
-`hoomd-rs`. [`Microstate`] holds a set of bodies that exist in a space defined
-by the boundary conditions. The degrees of freedom consist of the properties of
-the bodies and the parameters of the boundary conditions.
-
-[`Microstate`] also stores many auxiliary data structures and implements
-convenience methods to facilitate the efficient implementation of simulation
-models. These include a set of all interaction sites in the system frame
-of reference, ghost sites near the periodic boundaries, and spatial data
-structures.
-
-## Step, substep and seed
-
-[`Microstate`] tracks the current simulation step ([`Microstate::step`]),
-substep ([`Microstate::substep`]), and seed ([`Microstate::seed`])
-that allow models to generate uncorrelated random number streams via
-[`Microstate::counter`].
-
-The **step** is the current step in the simulation as defined by the user.
-For example, a single step could be one MD timestep or the application
-of a set of MC moves. Users should call [`Microstate::increment_step`]
-after each step in the model is completed. The **substep** is a running
-counter tracking the number of operations called so far during the current
-step. Model methods in *hoomd-rs* (such as the MC trial move `apply`) call
-[`increment_substep`](Microstate::increment_substep) internally. Users should
-call it at the end of any custom methods that implement new substeps.
-**A failure to call [`increment_substep`](Microstate::increment_substep)
-will cause the reuse of the same random numbers from one substep to the next!**
-
-The **seed** allows users to select independent random number streams for
-simulations that would otherwise be identical. It may only be set once on
-creation by [`MicrostateBuilder::seed`].
-
-## Bodies and sites
-
-[`Microstate`] differentiates between the degrees of freedom of the system and
-points where interactions take place. Each [`Body`] in the microstate has one
-or more interaction sites ([`Site`]). The bodies have degrees of freedom that
-are evolved by the simulation model, which defines how bodies interact through
-their sites. The properties of the sites *in the system frame* are a function
-of the body's properties and the site properties *in the body frame*. In a
-particle-only simulation model each body has one site at the origin in the body
-frame. In a simulation of squares, each body might be made up of four sites on
-the vertices. In both cases, the net force on the body is the sum of the forces
-applied to all of its sites.
-
-In [`Microstate`], the body properties (the generic type `B` throughout) and the
-site properties (the generic type `S`) do not need to be the same. For example,
-a body might have mass, position and velocity while that body's sites have
-position and type.
-
-The `property` module provides a number of property types. It also defines
-traits that you can use to implement custom property types. At a minimum, *both
-`B` and `S` MUST implement [`property::Position`]* so that [`Microstate`] can
-place your body's and sites inside the boundary conditions and maintain spatial
-data structures. Some model methods (such as shape overlap energies) will
-require other traits (such as [`property::Orientation`]). The `property` module
-documentation provides more details on using the types it provides and how to
-define custom types.
-
-[`Microstate::add_body`] and [`Microstate::extend_bodies`] add new bodies (and
-their sites) to the microstate. Similarly, [`Microstate::remove_body`] removes a
-body (and all associated sites). [`Microstate::update_body_properties`] modifies
-the properties of a given body and correspondingly the properties of all sites
-associated with that body. All these methods have a cost proportional to the
-number of sites in the body.
-
-[`Microstate::bodies`] provides direct (immutable) access to the bodies in
-the microstate, including their properties and sites in the body frame. While
-some algorithms may find this useful, many model algorithms instead operate
-on site properties in the system frame. [`Microstate::sites`] provides direct
-(immutable) access to a slice of all sites in the system frame for this
-purpose. Any method that adds, removes, or changes a body immediately updates
-[`Microstate::sites`] accordingly. [`Microstate::iter_body_sites`] iterates over
-all the sites (in the system frame) associated with a given body.
-
-## Tags
-
-The elements of [`Microstate::bodies`] and [`Microstate::sites`] are stored in
-**no particular order** to allow efficient addition and removal of bodies and
-for the possibility sorting to improve cache coherency. Callers are welcome
-to iterate over these data structures when computing order-independent overall
-properties. However, a caller should never maintain indices into these vectors.
-Instead, the caller should store the appropriate **tag** when it needs to
-persistently refer to a specific body or site.
-
-Elements in [`Microstate::bodies`] have the type [`Tagged<Body>`].
-The [`item`](Tagged::item) field holds the body itself while the
-[`tag`](Tagged::tag) field is a unique identifier that identifies this
-specific body. The tag will remain the same even when [`Microstate::bodies`] is
-reordered. Use [`Microstate::body_indices`] to find the current index of a body
-with a given tag.
-
-Elements in [`Microstate::sites`] have the type [`Site<S>`]. As with bodies,
-each site has a unique [`site_tag`](Site::site_tag) that remains the same even
-when sites are reordered. Each site also has a [`body_tag`](Site::body_tag) that
-identifies which body the site is part of. Use [`Microstate::site_indices`]
-to find the current index of a site with a given site tag and
-[`Microstate::iter_body_sites`] to find all the sites associated with a given
-body *index*.
-
-## Boundary conditions
-
-The positions of all bodies and all sites **must** be inside the microstate's
-boundary at all times. Periodic boundaries can wrap positions outside to a
-corresponding point on the inside. When a boundary is aperiodic (or partially
-aperiodic), the wrapping process may fail. MC models reject trial moves that
-cannot be wrapped. MD models fail with an error should bodies or sites move in a
-way that cannot be wrapped.
-
-[`Microstate`] is generic on the type of boundary condition. The [`boundary`]
-module implements standard types and explains how you can provide custom
-implementations.
-
-## Ghost sites
-
-Periodic boundary conditions place **ghost sites** within a given **maximum
-interaction range** outside the boundary. These ghost sites are images of real
-sites that are inside the boundary. Access all of the ghosts with the
-[`ghosts`] method. [`iter_sites_near`] will find both primary and ghost sites
-as it searches for sites near the requested point.
-
-When using [`Open`] or [`Closed`] boundary conditions, [`ghosts`] will always
-be empty.
-
-[`ghosts`]: Microstate::ghosts
-[`iter_sites_near`]: Microstate::iter_sites_near
-[`Open`]: crate::boundary::Open
-[`Closed`]: crate::boundary::Closed
-
-## Spatial searches
-
-TODO: Implement spatial search, then document.
-
-*/
+//! Store and manage the simulation state.
+//!
+//! # Microstate
+//!
+//! [`Microstate`] facilitates simulations of particle systems. It is the central
+//! data structure used by MC, MD, and supporting calculations implemented in
+//! `hoomd-rs`. [`Microstate`] holds a set of bodies that exist in a space defined
+//! by the boundary conditions. The degrees of freedom consist of the properties of
+//! the bodies and the parameters of the boundary conditions.
+//!
+//! [`Microstate`] also stores many auxiliary data structures and implements
+//! convenience methods to facilitate the efficient implementation of simulation
+//! models. These include a set of all interaction sites in the system frame
+//! of reference, ghost sites near the periodic boundaries, and spatial data
+//! structures.
+//!
+//! ## Step, substep and seed
+//!
+//! [`Microstate`] tracks the current simulation step ([`Microstate::step`]),
+//! substep ([`Microstate::substep`]), and seed ([`Microstate::seed`])
+//! that allow models to generate uncorrelated random number streams via
+//! [`Microstate::counter`].
+//!
+//! The **step** is the current step in the simulation as defined by the user.
+//! For example, a single step could be one MD timestep or the application
+//! of a set of MC moves. Users should call [`Microstate::increment_step`]
+//! after each step in the model is completed. The **substep** is a running
+//! counter tracking the number of operations called so far during the current
+//! step. Model methods in *hoomd-rs* (such as the MC trial move `apply`) call
+//! [`increment_substep`](Microstate::increment_substep) internally. Users should
+//! call it at the end of any custom methods that implement new substeps.
+//! A failure to call [`increment_substep`](Microstate::increment_substep)
+//! will cause the reuse of the same random numbers from one substep to the next!**
+//!
+//! The **seed** allows users to select independent random number streams for
+//! simulations that would otherwise be identical. It may only be set once on
+//! creation by [`MicrostateBuilder::seed`].
+//!
+//! ## Bodies and sites
+//!
+//! [`Microstate`] differentiates between the degrees of freedom of the system and
+//! points where interactions take place. Each [`Body`] in the microstate has one
+//! or more interaction sites ([`Site`]). The bodies have degrees of freedom that
+//! are evolved by the simulation model, which defines how bodies interact through
+//! their sites. The properties of the sites *in the system frame* are a function
+//! of the body's properties and the site properties *in the body frame*. In a
+//! particle-only simulation model each body has one site at the origin in the body
+//! frame. In a simulation of squares, each body might be made up of four sites on
+//! the vertices. In both cases, the net force on the body is the sum of the forces
+//! applied to all of its sites.
+//!
+//! In [`Microstate`], the body properties (the generic type `B` throughout) and the
+//! site properties (the generic type `S`) do not need to be the same. For example,
+//! a body might have mass, position and velocity while that body's sites have
+//! position and type.
+//!
+//! The `property` module provides a number of property types. It also defines
+//! traits that you can use to implement custom property types. At a minimum, *both
+//! `B` and `S` MUST implement [`property::Position`]* so that [`Microstate`] can
+//! place your body's and sites inside the boundary conditions and maintain spatial
+//! data structures. Some model methods (such as shape overlap energies) will
+//! require other traits (such as [`property::Orientation`]). The `property` module
+//! documentation provides more details on using the types it provides and how to
+//! define custom types.
+//!
+//! [`Microstate::add_body`] and [`Microstate::extend_bodies`] add new bodies (and
+//! their sites) to the microstate. Similarly, [`Microstate::remove_body`] removes a
+//! body (and all associated sites). [`Microstate::update_body_properties`] modifies
+//! the properties of a given body and correspondingly the properties of all sites
+//! associated with that body. All these methods have a cost proportional to the
+//! number of sites in the body.
+//!
+//! [`Microstate::bodies`] provides direct (immutable) access to the bodies in
+//! the microstate, including their properties and sites in the body frame. While
+//! some algorithms may find this useful, many model algorithms instead operate
+//! on site properties in the system frame. [`Microstate::sites`] provides direct
+//! (immutable) access to a slice of all sites in the system frame for this
+//! purpose. Any method that adds, removes, or changes a body immediately updates
+//! [`Microstate::sites`] accordingly. [`Microstate::iter_body_sites`] iterates over
+//! all the sites (in the system frame) associated with a given body.
+//!
+//! ## Tags
+//!
+//! The elements of [`Microstate::bodies`] and [`Microstate::sites`] are stored in
+//! no particular order** to allow efficient addition and removal of bodies and
+//! for the possibility sorting to improve cache coherency. Callers are welcome
+//! to iterate over these data structures when computing order-independent overall
+//! properties. However, a caller should never maintain indices into these vectors.
+//! Instead, the caller should store the appropriate **tag** when it needs to
+//! persistently refer to a specific body or site.
+//!
+//! Elements in [`Microstate::bodies`] have the type [`Tagged<Body>`].
+//! The [`item`](Tagged::item) field holds the body itself while the
+//! [`tag`](Tagged::tag) field is a unique identifier that identifies this
+//! specific body. The tag will remain the same even when [`Microstate::bodies`] is
+//! reordered. Use [`Microstate::body_indices`] to find the current index of a body
+//! with a given tag.
+//!
+//! Elements in [`Microstate::sites`] have the type [`Site<S>`]. As with bodies,
+//! each site has a unique [`site_tag`](Site::site_tag) that remains the same even
+//! when sites are reordered. Each site also has a [`body_tag`](Site::body_tag) that
+//! identifies which body the site is part of. Use [`Microstate::site_indices`]
+//! to find the current index of a site with a given site tag and
+//! [`Microstate::iter_body_sites`] to find all the sites associated with a given
+//! body *index*.
+//!
+//! ## Boundary conditions
+//!
+//! The positions of all bodies and all sites **must** be inside the microstate's
+//! boundary at all times. Periodic boundaries can wrap positions outside to a
+//! corresponding point on the inside. When a boundary is aperiodic (or partially
+//! aperiodic), the wrapping process may fail. MC models reject trial moves that
+//! cannot be wrapped. MD models fail with an error should bodies or sites move in a
+//! way that cannot be wrapped.
+//!
+//! [`Microstate`] is generic on the type of boundary condition. The [`boundary`]
+//! module implements standard types and explains how you can provide custom
+//! implementations.
+//!
+//! ## Ghost sites
+//!
+//! Periodic boundary conditions place **ghost sites** within a given **maximum
+//! interaction range** outside the boundary. These ghost sites are images of real
+//! sites that are inside the boundary. Access all of the ghosts with the
+//! [`ghosts`] method. [`iter_sites_near`] will find both primary and ghost sites
+//! as it searches for sites near the requested point.
+//!
+//! When using [`Open`] or [`Closed`] boundary conditions, [`ghosts`] will always
+//! be empty.
+//!
+//! [`ghosts`]: Microstate::ghosts
+//! [`iter_sites_near`]: Microstate::iter_sites_near
+//! [`Open`]: crate::boundary::Open
+//! [`Closed`]: crate::boundary::Closed
+//!
+//! ## Spatial searches
+//!
+//! TODO: Implement spatial search, then document.
+//!
 
 pub mod boundary;
 mod microstate;
@@ -158,40 +157,43 @@ use property::Point;
 
 use thiserror::Error;
 
-/** Interactions in `hoomd-rs` apply between sites.
-
-A [`Site`] (often called an *atom* or a *particle* in other codes) has a
-`tag` that uniquely identities it in the [`Microstate`] and is associated
-with a given `body` (see [`Body`]). All interactions in `hoomd-rs` occur
-on or between sites as a function of their `properties` which has the
-generic type `S`. At a minimum, [`Microstate`] assumes that `S` implements
-[`Position`](property::Position). `S` is generic so that users can build custom
-types that store orientation, charge, mass, color, or whatever other fields are
-needed to implement their model.
-
-Add sites to the [`Microstate`] as members of bodies ([`Body`]).
-
-# Example
-
-Find the center of all interaction sites in a [`Microstate`]:
-```
-use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
-use hoomd_vector::{Vector, Cartesian};
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let microstate = MicrostateBuilder::new()
-    .bodies([Body::point(Cartesian::from([1.0, 0.0])),
-             Body::point(Cartesian::from([-1.0, 2.0]))])
-    .try_build()?;
-
-let average_site_position = microstate.sites()
-    .iter()
-    .map(|site| site.properties.position)
-    .sum::<Cartesian<2>>() / (microstate.sites().len() as f64);
-# Ok(())
-# }
-```
-*/
+/// Interactions in `hoomd-rs` apply between sites.
+///
+/// A [`Site`] (often called an *atom* or a *particle* in other codes) has a
+/// `tag` that uniquely identities it in the [`Microstate`] and is associated
+/// with a given `body` (see [`Body`]). All interactions in `hoomd-rs` occur
+/// on or between sites as a function of their `properties` which has the
+/// generic type `S`. At a minimum, [`Microstate`] assumes that `S` implements
+/// [`Position`](property::Position). `S` is generic so that users can build custom
+/// types that store orientation, charge, mass, color, or whatever other fields are
+/// needed to implement their model.
+///
+/// Add sites to the [`Microstate`] as members of bodies ([`Body`]).
+///
+/// # Example
+///
+/// Find the center of all interaction sites in a [`Microstate`]:
+/// ```
+/// use hoomd_microstate::{Body, Microstate, MicrostateBuilder};
+/// use hoomd_vector::{Cartesian, Vector};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let microstate = MicrostateBuilder::new()
+///     .bodies([
+///         Body::point(Cartesian::from([1.0, 0.0])),
+///         Body::point(Cartesian::from([-1.0, 2.0])),
+///     ])
+///     .try_build()?;
+///
+/// let average_site_position = microstate
+///     .sites()
+///     .iter()
+///     .map(|site| site.properties.position)
+///     .sum::<Cartesian<2>>()
+///     / (microstate.sites().len() as f64);
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Site<S> {
     /// Every site in a [`Microstate`] has a unique value in `site_tag`.
@@ -202,41 +204,40 @@ pub struct Site<S> {
     pub properties: S,
 }
 
-/** A collection of interaction sites that can be placed in a [`Microstate`].
-
-The [`Body`] `properties` have a generic type that includes all the body's
-degrees of freedom and any other fields needed to implement the user's
-model. Bodies interact indirectly via one or more `sites`. The `sites` vector
-stores the properties of the body's sites in the body frame. The body field
-`properties` stores the body's degrees of freedom (such as position and
-orientation) in the system frame. [`Transform`] describes how a given body
-transforms its sites from the body frame to the system frame.
-
-In typical cases, such as those implemented in `hoomd-rs`, [`Body`] describes
-a rigid collection of sites that transform together. However, creative
-implementations of [`Transform`] could achieve other behaviors.
-
-Use the properties defined in [`property`] to construct bodies that meet
-the needs of your model.
-
-# Examples
-
-Construct body with a single interaction site at one point:
-```
-use hoomd_microstate::Body;
-use hoomd_vector::Cartesian;
-
-let body = Body::point(Cartesian::from([-3.0, 5.0]));
-```
-
-TODO: Construct a body with an oriented point.
-TODO: Construct an oriented body with several point interaction sites.
-
-# Custom body and site properties
-
-The [`property`] module documentation shows you how to define custom body
-and site property types.
-*/
+/// A collection of interaction sites that can be placed in a [`Microstate`].
+///
+/// The [`Body`] `properties` have a generic type that includes all the body's
+/// degrees of freedom and any other fields needed to implement the user's
+/// model. Bodies interact indirectly via one or more `sites`. The `sites` vector
+/// stores the properties of the body's sites in the body frame. The body field
+/// `properties` stores the body's degrees of freedom (such as position and
+/// orientation) in the system frame. [`Transform`] describes how a given body
+/// transforms its sites from the body frame to the system frame.
+///
+/// In typical cases, such as those implemented in `hoomd-rs`, [`Body`] describes
+/// a rigid collection of sites that transform together. However, creative
+/// implementations of [`Transform`] could achieve other behaviors.
+///
+/// Use the properties defined in [`property`] to construct bodies that meet
+/// the needs of your model.
+///
+/// # Examples
+///
+/// Construct body with a single interaction site at one point:
+/// ```
+/// use hoomd_microstate::Body;
+/// use hoomd_vector::Cartesian;
+///
+/// let body = Body::point(Cartesian::from([-3.0, 5.0]));
+/// ```
+///
+/// TODO: Construct a body with an oriented point.
+/// TODO: Construct an oriented body with several point interaction sites.
+///
+/// # Custom body and site properties
+///
+/// The [`property`] module documentation shows you how to define custom body
+/// and site property types.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Body<B, S = B> {
     /// The body's degrees of freedom.
@@ -246,26 +247,25 @@ pub struct Body<B, S = B> {
 }
 
 impl<V> Body<Point<V>, Point<V>> {
-    /** Construct a point particle.
-
-    A point particle is a [`Body`] with a single interaction site at the body's
-    origin. The body and site property types are identical and have only a
-    `position` field. Use point particles for simulations of monodisperse hard
-    spheres, identical particles with pairwise interactions, or any time you
-    need a [`Microstate`] that consists only of point particles.
-
-    # Example
-
-    ```
-    use hoomd_microstate::Body;
-    use hoomd_vector::Cartesian;
-
-    let body = Body::point(Cartesian::from([-3.0, 5.0]));
-    assert_eq!(body.properties.position, [-3.0, 5.0].into());
-    assert_eq!(body.sites.len(), 1);
-    assert_eq!(body.sites[0].position, [0.0, 0.0].into());
-    ```
-    */
+    /// Construct a point particle.
+    ///
+    /// A point particle is a [`Body`] with a single interaction site at the body's
+    /// origin. The body and site property types are identical and have only a
+    /// `position` field. Use point particles for simulations of monodisperse hard
+    /// spheres, identical particles with pairwise interactions, or any time you
+    /// need a [`Microstate`] that consists only of point particles.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_microstate::Body;
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// let body = Body::point(Cartesian::from([-3.0, 5.0]));
+    /// assert_eq!(body.properties.position, [-3.0, 5.0].into());
+    /// assert_eq!(body.sites.len(), 1);
+    /// assert_eq!(body.sites[0].position, [0.0, 0.0].into());
+    /// ```
     #[inline]
     #[must_use]
     pub fn point(position: V) -> Self
@@ -279,18 +279,16 @@ impl<V> Body<Point<V>, Point<V>> {
     }
 }
 
-/** Take [`Site`] properties in the body frame into the system frame.
-
-See the [`property`] module-level documentation for an example
-that implements [`Transform`] for a custom type.
-*/
+/// Take [`Site`] properties in the body frame into the system frame.
+///
+/// See the [`property`] module-level documentation for an example
+/// that implements [`Transform`] for a custom type.
 pub trait Transform<S> {
-    /** Transform site properties.
-
-    Given `site_properties` in the body frame, `transform` returns the
-    corresponding site properties in the system frame relative to the
-    body properties in `&self`.
-    */
+    /// Transform site properties.
+    ///
+    /// Given `site_properties` in the body frame, `transform` returns the
+    /// corresponding site properties in the system frame relative to the
+    /// body properties in `&self`.
     #[must_use]
     fn transform(&self, site_properties: &S) -> S;
 }

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -124,9 +124,9 @@ impl<T> VecWithTags<T> {
 /// for additional details.
 ///
 /// The generic type names are:
-/// `B`: The [`Body::properties`](crate::Body) type.
-/// `S`: The [`Site::properties`](crate::Site) type.
-/// `C`: The [`boundary`](crate::boundary) condition type.
+/// * `B`: The [`Body::properties`](crate::Body) type.
+/// * `S`: The [`Site::properties`](crate::Site) type.
+/// * `C`: The [`boundary`](crate::boundary) condition type.
 ///
 /// ## Constructing Microstate
 ///
@@ -932,7 +932,6 @@ impl<B, S, C> Microstate<B, S, C> {
     /// Body::point(Cartesian::from([-1.0, 2.0]))])
     /// .try_build()?;
     ///
-    /// The initial index order is equivalent to the tag order.
     /// assert_eq!(microstate.bodies()[0].tag, 0);
     /// assert_eq!(microstate.bodies()[1].tag, 1);
     /// # Ok(())
@@ -972,9 +971,9 @@ impl<B, S, C> Microstate<B, S, C> {
     /// [`Microstate::bodies`].
     ///
     /// `body_indices()[tag]` is:
-    /// [`None`] when there is no body with the given tag in the microstate.
-    /// [`Some(index)`](Option::Some) when the body with the given tag is in the
-    /// microstate. `index` is the index of the body in [`Microstate::bodies`].
+    /// * [`None`] when there is no body with the given tag in the microstate.
+    /// * [`Some(index)`](Option::Some) when the body with the given tag is in the
+    ///   microstate. `index` is the index of the body in [`Microstate::bodies`].
     ///
     /// # Example
     ///
@@ -1042,7 +1041,6 @@ impl<B, S, C> Microstate<B, S, C> {
     /// Body::point(Cartesian::from([-1.0, 2.0]))])
     /// .try_build()?;
     ///
-    /// The initial index order is equivalent to the tag order.
     /// assert_eq!(microstate.sites()[0].site_tag, 0);
     /// assert_eq!(microstate.sites()[0].body_tag, 0);
     ///

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -923,14 +923,16 @@ impl<B, S, C> Microstate<B, S, C> {
     /// Identify the tag of a body at a given index:
     ///
     /// ```
-    /// use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
+    /// use hoomd_microstate::{Body, Microstate, MicrostateBuilder};
     /// use hoomd_vector::Cartesian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let microstate = MicrostateBuilder::new()
-    /// .bodies([Body::point(Cartesian::from([1.0, 0.0])),
-    /// Body::point(Cartesian::from([-1.0, 2.0]))])
-    /// .try_build()?;
+    ///     .bodies([
+    ///         Body::point(Cartesian::from([1.0, 0.0])),
+    ///         Body::point(Cartesian::from([-1.0, 2.0])),
+    ///     ])
+    ///     .try_build()?;
     ///
     /// assert_eq!(microstate.bodies()[0].tag, 0);
     /// assert_eq!(microstate.bodies()[1].tag, 1);
@@ -1032,14 +1034,16 @@ impl<B, S, C> Microstate<B, S, C> {
     /// Identify the site and body tags of a site at a given index:
     ///
     /// ```
-    /// use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
+    /// use hoomd_microstate::{Body, Microstate, MicrostateBuilder};
     /// use hoomd_vector::Cartesian;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let microstate = MicrostateBuilder::new()
-    /// .bodies([Body::point(Cartesian::from([1.0, 0.0])),
-    /// Body::point(Cartesian::from([-1.0, 2.0]))])
-    /// .try_build()?;
+    ///     .bodies([
+    ///         Body::point(Cartesian::from([1.0, 0.0])),
+    ///         Body::point(Cartesian::from([-1.0, 2.0])),
+    ///     ])
+    ///     .try_build()?;
     ///
     /// assert_eq!(microstate.sites()[0].site_tag, 0);
     /// assert_eq!(microstate.sites()[0].body_tag, 0);

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement [`Microstate`] and related types.
- */
+//! Implement [`Microstate`] and related types.
 
 use std::{cmp::Reverse, collections::BinaryHeap};
 use tinyvec::ArrayVec;
@@ -16,8 +15,7 @@ use crate::{
 use hoomd_utility::random::Counter;
 use hoomd_vector::Vector;
 
-/** Track a unique identifier for an item in [`Microstate`].
-*/
+/// Track a unique identifier for an item in [`Microstate`].
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Tagged<T> {
     /// The unique identifier.
@@ -26,15 +24,14 @@ pub struct Tagged<T> {
     pub item: T,
 }
 
-/** A dense vector with O(1) remove complexity.
-
-Each item pushed to the vector is given a tag (in monotonically increasing
-order). Access items by tag when identity matters and by index order when it
-doesn't.
-
-Items are removed using `swap_remove`. Removed tags are reused when adding new
-items.
-*/
+/// A dense vector with O(1) remove complexity.
+///
+/// Each item pushed to the vector is given a tag (in monotonically increasing
+/// order). Access items by tag when identity matters and by index order when it
+/// doesn't.
+///
+/// Items are removed using `swap_remove`. Removed tags are reused when adding new
+/// items.
 #[derive(Clone)]
 struct VecWithTags<T> {
     /// Items in index order.
@@ -120,52 +117,53 @@ impl<T> VecWithTags<T> {
     }
 }
 
-/** Store and manage all the degrees of freedom of a single microstate in phase space.
-
-[`Microstate`] implements the main logic of the crate. See the [crate-level
-documentation](crate) for a full overview and the method-specific documentation
-for additional details.
-
-The generic type names are:
-* `B`: The [`Body::properties`](crate::Body) type.
-* `S`: The [`Site::properties`](crate::Site) type.
-* `C`: The [`boundary`](crate::boundary) condition type.
-
-## Constructing Microstate
-
-You will find many examples in this documentation using [`Microstate::new`]. It
-is designed to be terse, and is inflexible as a consequence. [`Microstate::new`]
-always sets [`Open`](crate::boundary::Open) boundary conditions and initializes
-the seed and step to 0.
-```
-use hoomd_microstate::Microstate;
-# use hoomd_microstate::{Body, property::Point};
-# use hoomd_vector::Cartesian;
-
-let mut microstate = Microstate::new();
-# microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
-```
-
-When you need more control, use [`MicrostateBuilder`] to set the boundary conditions,
-use a different seed or starting step:
-
-```
-use hoomd_geometry::shape::Rectangle;
-use hoomd_microstate::{Microstate, MicrostateBuilder, Body, boundary::Closed};
-use hoomd_vector::Cartesian;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let square = Closed(Rectangle::with_equal_edges(10.0.try_into()?));
-
-let microstate = MicrostateBuilder::with_boundary(square)
-    .seed(0x43abf1)
-    .step(100_000)
-    .bodies([Body::point(Cartesian::from([0.0, 0.0]))])
-    .try_build()?;
-# Ok(())
-# }
-```
-*/
+/// Store and manage all the degrees of freedom of a single microstate in phase space.
+///
+/// [`Microstate`] implements the main logic of the crate. See the [crate-level
+/// documentation](crate) for a full overview and the method-specific documentation
+/// for additional details.
+///
+/// The generic type names are:
+/// `B`: The [`Body::properties`](crate::Body) type.
+/// `S`: The [`Site::properties`](crate::Site) type.
+/// `C`: The [`boundary`](crate::boundary) condition type.
+///
+/// ## Constructing Microstate
+///
+/// You will find many examples in this documentation using [`Microstate::new`]. It
+/// is designed to be terse, and is inflexible as a consequence. [`Microstate::new`]
+/// always sets [`Open`](crate::boundary::Open) boundary conditions and initializes
+/// the seed and step to 0.
+/// ```
+/// use hoomd_microstate::Microstate;
+/// # use hoomd_microstate::{Body, property::Point};
+/// # use hoomd_vector::Cartesian;
+///
+/// let mut microstate = Microstate::new();
+/// # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
+/// ```
+///
+/// When you need more control, use [`MicrostateBuilder`] to set the boundary conditions,
+/// use a different seed or starting step:
+///
+/// ```
+/// use hoomd_geometry::shape::Rectangle;
+/// use hoomd_microstate::{
+///     Body, Microstate, MicrostateBuilder, boundary::Closed,
+/// };
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let square = Closed(Rectangle::with_equal_edges(10.0.try_into()?));
+///
+/// let microstate = MicrostateBuilder::with_boundary(square)
+///     .seed(0x43abf1)
+///     .step(100_000)
+///     .bodies([Body::point(Cartesian::from([0.0, 0.0]))])
+///     .try_build()?;
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone)]
 pub struct Microstate<B, S = B, C = Open> {
     /// Total number of steps that this microstate has been advanced in a simulation model.
@@ -197,10 +195,9 @@ pub struct Microstate<B, S = B, C = Open> {
 }
 
 impl<B, S> Default for Microstate<B, S, Open> {
-    /** Construct an empty microstate with open boundary conditions.
-
-    See [`Microstate::new`].
-    */
+    /// Construct an empty microstate with open boundary conditions.
+    ///
+    /// See [`Microstate::new`].
     #[inline]
     fn default() -> Self {
         Self::new()
@@ -208,27 +205,26 @@ impl<B, S> Default for Microstate<B, S, Open> {
 }
 
 impl<B, S> Microstate<B, S, Open> {
-    /** Construct an empty microstate with open boundary conditions.
-     
-    The microstate starts at step 0, substep 0, random number seed 0,
-    and has no bodies.
-     
-    # Example
-    
-    ```
-    use hoomd_microstate::Microstate;
-    # use hoomd_microstate::{Body, property::Point};
-    # use hoomd_vector::Cartesian;
-     
-    let mut microstate = Microstate::new();
-    assert_eq!(microstate.step(), 0);
-    assert_eq!(microstate.substep(), 0);
-    assert_eq!(microstate.seed(), 0);
-    assert_eq!(microstate.bodies().len(), 0);
-    assert_eq!(microstate.sites().len(),0);
-    # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
-    ```
-    */
+    /// Construct an empty microstate with open boundary conditions.
+    ///
+    /// The microstate starts at step 0, substep 0, random number seed 0,
+    /// and has no bodies.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_microstate::Microstate;
+    /// # use hoomd_microstate::{Body, property::Point};
+    /// # use hoomd_vector::Cartesian;
+    ///
+    /// let mut microstate = Microstate::new();
+    /// assert_eq!(microstate.step(), 0);
+    /// assert_eq!(microstate.substep(), 0);
+    /// assert_eq!(microstate.seed(), 0);
+    /// assert_eq!(microstate.bodies().len(), 0);
+    /// assert_eq!(microstate.sites().len(), 0);
+    /// # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
+    /// ```
     #[inline]
     #[must_use]
     pub fn new() -> Self {
@@ -248,203 +244,197 @@ impl<B, S> Microstate<B, S, Open> {
 
 /// Access and manage the simulation step, substep, RNG seeds.
 impl<B, S, C> Microstate<B, S, C> {
-    /** Get the simulation step.
-
-    # Examples
-
-    Get the step:
-    ```
-    use hoomd_microstate::Microstate;
-    # use hoomd_microstate::{Body, property::Point};
-    # use hoomd_vector::Cartesian;
-
-    let mut microstate = Microstate::new();
-    # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
-    assert_eq!(microstate.step(), 0);
-    ```
-
-    Initialize a microstate with a given step:
-    ```
-    use hoomd_microstate::{Microstate, MicrostateBuilder};
-    # use hoomd_microstate::{Body, property::Point};
-    # use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let microstate = MicrostateBuilder::new()
-        .step(100_000)
-        # .bodies([Body::point(Cartesian::from([0.0, 0.0]))])
-        .try_build()?;
-    assert_eq!(microstate.step(), 100_000);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Get the simulation step.
+    ///
+    /// # Examples
+    ///
+    /// Get the step:
+    /// ```
+    /// use hoomd_microstate::Microstate;
+    /// # use hoomd_microstate::{Body, property::Point};
+    /// # use hoomd_vector::Cartesian;
+    ///
+    /// let mut microstate = Microstate::new();
+    /// # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
+    /// assert_eq!(microstate.step(), 0);
+    /// ```
+    ///
+    /// Initialize a microstate with a given step:
+    /// ```
+    /// use hoomd_microstate::{Microstate, MicrostateBuilder};
+    /// # use hoomd_microstate::{Body, property::Point};
+    /// # use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let microstate = MicrostateBuilder::new()
+    ///     .step(100_000)
+    /// # .bodies([Body::point(Cartesian::from([0.0, 0.0]))])
+    ///     .try_build()?;
+    /// assert_eq!(microstate.step(), 100_000);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     #[must_use]
     pub fn step(&self) -> u64 {
         self.step
     }
 
-    /** Increment the simulation step.
-
-    Also set the substep to 0.
-
-    # Examples
-
-    Increment the simulation step:
-    ```
-    use hoomd_microstate::Microstate;
-    # use hoomd_microstate::{Body, property::Point};
-    # use hoomd_vector::Cartesian;
-
-    let mut microstate = Microstate::new();
-    # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
-    microstate.increment_step();
-
-    assert_eq!(microstate.step(), 1);
-    ```
-
-    Confirm that `substep` resets to 0:
-    ```
-    use hoomd_microstate::Microstate;
-    # use hoomd_microstate::{Body, property::Point};
-    # use hoomd_vector::Cartesian;
-
-    let mut microstate = Microstate::new();
-    # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
-
-    microstate.increment_substep();
-    microstate.increment_substep();
-    microstate.increment_substep();
-    assert_eq!(microstate.substep(), 3);
-
-    microstate.increment_step();
-
-    assert_eq!(microstate.step(), 1);
-    assert_eq!(microstate.substep(), 0);
-    ```
-    */
+    /// Increment the simulation step.
+    ///
+    /// Also set the substep to 0.
+    ///
+    /// # Examples
+    ///
+    /// Increment the simulation step:
+    /// ```
+    /// use hoomd_microstate::Microstate;
+    /// # use hoomd_microstate::{Body, property::Point};
+    /// # use hoomd_vector::Cartesian;
+    ///
+    /// let mut microstate = Microstate::new();
+    /// # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
+    /// microstate.increment_step();
+    ///
+    /// assert_eq!(microstate.step(), 1);
+    /// ```
+    ///
+    /// Confirm that `substep` resets to 0:
+    /// ```
+    /// use hoomd_microstate::Microstate;
+    /// # use hoomd_microstate::{Body, property::Point};
+    /// # use hoomd_vector::Cartesian;
+    ///
+    /// let mut microstate = Microstate::new();
+    /// # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
+    ///
+    /// microstate.increment_substep();
+    /// microstate.increment_substep();
+    /// microstate.increment_substep();
+    /// assert_eq!(microstate.substep(), 3);
+    ///
+    /// microstate.increment_step();
+    ///
+    /// assert_eq!(microstate.step(), 1);
+    /// assert_eq!(microstate.substep(), 0);
+    /// ```
     #[inline]
     pub fn increment_step(&mut self) {
         self.step += 1;
         self.substep = 0;
     }
 
-    /** Get the simulation substep.
-
-    # Example
-    ```
-    use hoomd_microstate::Microstate;
-    # use hoomd_microstate::{Body, property::Point};
-    # use hoomd_vector::Cartesian;
-
-    let mut microstate = Microstate::new();
-    # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
-    microstate.increment_substep();
-
-    assert_eq!(microstate.substep(), 1);
-    ```
-    */
+    /// Get the simulation substep.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_microstate::Microstate;
+    /// # use hoomd_microstate::{Body, property::Point};
+    /// # use hoomd_vector::Cartesian;
+    ///
+    /// let mut microstate = Microstate::new();
+    /// # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
+    /// microstate.increment_substep();
+    ///
+    /// assert_eq!(microstate.substep(), 1);
+    /// ```
     #[inline]
     #[must_use]
     pub fn substep(&self) -> u32 {
         self.substep
     }
 
-    /** Increment the simulation substep.
-
-    # Example
-    ```
-    use hoomd_microstate::Microstate;
-    # use hoomd_microstate::{Body, property::Point};
-    # use hoomd_vector::Cartesian;
-
-    let mut microstate = Microstate::new();
-    # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
-    microstate.increment_substep();
-
-    assert_eq!(microstate.substep(), 1);
-    ```
-    */
+    /// Increment the simulation substep.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_microstate::Microstate;
+    /// # use hoomd_microstate::{Body, property::Point};
+    /// # use hoomd_vector::Cartesian;
+    ///
+    /// let mut microstate = Microstate::new();
+    /// # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
+    /// microstate.increment_substep();
+    ///
+    /// assert_eq!(microstate.substep(), 1);
+    /// ```
     #[inline]
     pub fn increment_substep(&mut self) {
         self.substep += 1;
     }
 
-    /** Get the simulation seed.
-
-    # Examples:
-
-    Get the simulation seed.
-    ```
-    use hoomd_microstate::Microstate;
-    # use hoomd_microstate::{Body, property::Point};
-    # use hoomd_vector::Cartesian;
-
-    let mut microstate = Microstate::new();
-    # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
-
-    assert_eq!(microstate.seed(), 0);
-    ```
-
-    Initialize a microstate with a given seed:
-    ```
-    use hoomd_microstate::{Microstate, MicrostateBuilder};
-    # use hoomd_microstate::{Body, property::Point};
-    # use hoomd_vector::Cartesian;
-
-    # type BodyProperties = Point<Cartesian<2>>;
-    # type SiteProperties = Point<Cartesian<2>>;
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let microstate = MicrostateBuilder::<BodyProperties, SiteProperties>::new()
-        .seed(0x1234abcd)
-        # .bodies([Body::point(Cartesian::from([0.0, 0.0]))])
-        .try_build()?;
-    assert_eq!(microstate.seed(), 0x1234abcd);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Get the simulation seed.
+    ///
+    /// # Examples:
+    ///
+    /// Get the simulation seed.
+    /// ```
+    /// use hoomd_microstate::Microstate;
+    /// # use hoomd_microstate::{Body, property::Point};
+    /// # use hoomd_vector::Cartesian;
+    ///
+    /// let mut microstate = Microstate::new();
+    /// # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
+    ///
+    /// assert_eq!(microstate.seed(), 0);
+    /// ```
+    ///
+    /// Initialize a microstate with a given seed:
+    /// ```
+    /// use hoomd_microstate::{Microstate, MicrostateBuilder};
+    /// # use hoomd_microstate::{Body, property::Point};
+    /// # use hoomd_vector::Cartesian;
+    ///
+    /// # type BodyProperties = Point<Cartesian<2>>;
+    /// # type SiteProperties = Point<Cartesian<2>>;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let microstate = MicrostateBuilder::<BodyProperties, SiteProperties>::new()
+    ///     .seed(0x1234abcd)
+    /// # .bodies([Body::point(Cartesian::from([0.0, 0.0]))])
+    ///     .try_build()?;
+    /// assert_eq!(microstate.seed(), 0x1234abcd);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     #[must_use]
     pub fn seed(&self) -> u32 {
         self.seed
     }
 
-    /** Create a partially constructed [`Counter`] from the current step, substep, and seed.
-
-    Use the produced [`Counter`] to make a independent random number generator at each
-    substep. Call additional methods on the [`Counter`] first to further differentiate
-    the stream.
-
-    # Example
-
-    Make a random number generator unique to this substep:
-    ```
-    use hoomd_microstate::Microstate;
-    # use hoomd_microstate::{Body, property::Point};
-    # use hoomd_vector::Cartesian;
-
-    let mut microstate = Microstate::new();
-    # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
-
-    let rng = microstate.counter().make_rng();
-    ```
-
-    Make a random number generator unique to a particular particle on this substep:
-
-    ```
-    use hoomd_microstate::Microstate;
-    # use hoomd_microstate::{Body, property::Point};
-    # use hoomd_vector::Cartesian;
-
-    let mut microstate = Microstate::new();
-    # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
-
-    let tag = 10;
-    let rng = microstate.counter().index(tag).make_rng();
-    ```
-    */
+    /// Create a partially constructed [`Counter`] from the current step, substep, and seed.
+    ///
+    /// Use the produced [`Counter`] to make a independent random number generator at each
+    /// substep. Call additional methods on the [`Counter`] first to further differentiate
+    /// the stream.
+    ///
+    /// # Example
+    ///
+    /// Make a random number generator unique to this substep:
+    /// ```
+    /// use hoomd_microstate::Microstate;
+    /// # use hoomd_microstate::{Body, property::Point};
+    /// # use hoomd_vector::Cartesian;
+    ///
+    /// let mut microstate = Microstate::new();
+    /// # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
+    ///
+    /// let rng = microstate.counter().make_rng();
+    /// ```
+    ///
+    /// Make a random number generator unique to a particular particle on this substep:
+    ///
+    /// ```
+    /// use hoomd_microstate::Microstate;
+    /// # use hoomd_microstate::{Body, property::Point};
+    /// # use hoomd_vector::Cartesian;
+    ///
+    /// let mut microstate = Microstate::new();
+    /// # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
+    ///
+    /// let tag = 10;
+    /// let rng = microstate.counter().index(tag).make_rng();
+    /// ```
     #[inline]
     pub fn counter(&self) -> Counter {
         Counter::new(self.step, self.substep, self.seed)
@@ -453,84 +443,80 @@ impl<B, S, C> Microstate<B, S, C> {
 
 /// Access and manage the boundary condition.
 impl<B, S, C> Microstate<B, S, C> {
-    /** Get the boundary condition.
-
-    # Example
-
-    ```
-    use hoomd_geometry::shape::Rectangle;
-    use hoomd_microstate::{Microstate, MicrostateBuilder, boundary::Closed};
-    # use hoomd_microstate::{Body, property::Point};
-    # use hoomd_vector::Cartesian;
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-
-    let square = Closed(Rectangle::with_equal_edges(10.0.try_into()?));
-    let microstate = MicrostateBuilder::with_boundary(square)
-        # .bodies([Body::point(Cartesian::from([0.0, 0.0]))])
-        .try_build()?;
-
-    assert_eq!(microstate.boundary().0.edge_lengths[0].get(), 10.0);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Get the boundary condition.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_geometry::shape::Rectangle;
+    /// use hoomd_microstate::{Microstate, MicrostateBuilder, boundary::Closed};
+    /// # use hoomd_microstate::{Body, property::Point};
+    /// # use hoomd_vector::Cartesian;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///
+    /// let square = Closed(Rectangle::with_equal_edges(10.0.try_into()?));
+    /// let microstate = MicrostateBuilder::with_boundary(square)
+    /// # .bodies([Body::point(Cartesian::from([0.0, 0.0]))])
+    ///     .try_build()?;
+    ///
+    /// assert_eq!(microstate.boundary().0.edge_lengths[0].get(), 10.0);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     pub fn boundary(&self) -> &C {
         &self.boundary
     }
 
-    /** Get the boundary condition (mutable).
-
-    # Example
-
-    ```
-    use hoomd_geometry::shape::Rectangle;
-    use hoomd_microstate::{Microstate, MicrostateBuilder, boundary::Closed};
-    # use hoomd_microstate::{Body, property::Point};
-    # use hoomd_vector::Cartesian;
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-
-    let square = Closed(Rectangle::with_equal_edges(10.0.try_into()?));
-    let mut microstate = MicrostateBuilder::with_boundary(square)
-        # .bodies([Body::point(Cartesian::from([0.0, 0.0]))])
-        .try_build()?;
-
-    microstate.boundary_mut().0.edge_lengths[0] = 11.0.try_into()?;
-    assert_eq!(microstate.boundary().0.edge_lengths[0].get(), 11.0);
-    # Ok(())
-    # }
-    ```
-
-    TODO: Replace with setter. `boundary_mut` allows the caller to create an
-    invalid microstate by changing the boundary in such a way that sites may
-    be outside. Changing the boundary will also require regenerating ghost
-    sites. Just checking for a valid boundary on set will pose some difficulty
-    to the caller. To increase the boundary, the caller will need to set
-    the new boundary and then move the bodies. To decrease the boundary, the
-    caller will need to move the bodies and then set the boundary. Perhaps a
-    `set_boundary_and_update_bodies` method that does both simultaneously would
-    solve this? It could take a function that updates the bodies along with the
-    new boundary.
-    */
+    /// Get the boundary condition (mutable).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_geometry::shape::Rectangle;
+    /// use hoomd_microstate::{Microstate, MicrostateBuilder, boundary::Closed};
+    /// # use hoomd_microstate::{Body, property::Point};
+    /// # use hoomd_vector::Cartesian;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///
+    /// let square = Closed(Rectangle::with_equal_edges(10.0.try_into()?));
+    /// let mut microstate = MicrostateBuilder::with_boundary(square)
+    /// # .bodies([Body::point(Cartesian::from([0.0, 0.0]))])
+    ///     .try_build()?;
+    ///
+    /// microstate.boundary_mut().0.edge_lengths[0] = 11.0.try_into()?;
+    /// assert_eq!(microstate.boundary().0.edge_lengths[0].get(), 11.0);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// TODO: Replace with setter. `boundary_mut` allows the caller to create an
+    /// invalid microstate by changing the boundary in such a way that sites may
+    /// be outside. Changing the boundary will also require regenerating ghost
+    /// sites. Just checking for a valid boundary on set will pose some difficulty
+    /// to the caller. To increase the boundary, the caller will need to set
+    /// the new boundary and then move the bodies. To decrease the boundary, the
+    /// caller will need to move the bodies and then set the boundary. Perhaps a
+    /// `set_boundary_and_update_bodies` method that does both simultaneously would
+    /// solve this? It could take a function that updates the bodies along with the
+    /// new boundary.
     #[inline]
     pub fn boundary_mut(&mut self) -> &mut C {
         &mut self.boundary
     }
 }
 
-/** Manage bodies in the microstate.
-*/
+/// Manage bodies in the microstate.
 impl<V, B, S, C> Microstate<B, S, C>
 where
     B: Transform<S> + Position<Vector = V>,
     S: Position<Vector = V> + Default,
     C: Wrap<B> + Wrap<S> + GenerateGhosts<S>,
 {
-    /** Update the ghosts of a site.
-
-    Given a site in the boundary, update that site's ghosts to be consistent
-    with that site's properties. This may require adding or removing ghosts.
-    */
+    /// Update the ghosts of a site.
+    ///
+    /// Given a site in the boundary, update that site's ghosts to be consistent
+    /// with that site's properties. This may require adding or removing ghosts.
     fn update_site_ghosts(
         sites: &VecWithTags<Site<S>>,
         site_index: usize,
@@ -587,53 +573,54 @@ where
         }
     }
 
-    /** Add a new body to the microstate.
-
-    Each body is assigned a unique tag. The first body is given tag 0,
-    the second is given tag 1, and so on. When a body is removed (see
-    [`Microstate::remove_body()`]), its tag becomes unused. The next call to
-    `add_body` will assign the smallest unused tag.
-
-    `add_body` also adds the body's sites to the microstate's
-    [`sites`](Microstate::sites) (in system coordinates) and assigns unique
-    tags to the sites similarly. It wraps the body's position (and the
-    positions of its sites in system coordinates) into the boundary (see
-    [`boundary`]).
-
-    [`boundary`]: crate::boundary
-
-    # Cost
-
-    The cost of adding a body is proportional to the number of sites in the
-    body.
-
-    # Returns
-
-    [`Ok(tag)`](Result::Ok) with the tag of the added body on success.
-
-    # Errors
-
-    [`Error::AddBody`] when the body cannot be added to the microstate because
-    the body position or any site position cannot be wrapped into the boundary
-
-    # Example
-
-    ```
-    use hoomd_microstate::{Microstate, Body};
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut microstate = Microstate::new();
-    let first_tag = microstate.add_body(Body::point(Cartesian::from([1.0, 0.0])))?;
-    let second_tag = microstate.add_body(Body::point(Cartesian::from([-1.0, 2.0])))?;
-
-    assert_eq!(microstate.bodies().len(), 2);
-    assert_eq!(first_tag, 0);
-    assert_eq!(second_tag, 1);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Add a new body to the microstate.
+    ///
+    /// Each body is assigned a unique tag. The first body is given tag 0,
+    /// the second is given tag 1, and so on. When a body is removed (see
+    /// [`Microstate::remove_body()`]), its tag becomes unused. The next call to
+    /// `add_body` will assign the smallest unused tag.
+    ///
+    /// `add_body` also adds the body's sites to the microstate's
+    /// [`sites`](Microstate::sites) (in system coordinates) and assigns unique
+    /// tags to the sites similarly. It wraps the body's position (and the
+    /// positions of its sites in system coordinates) into the boundary (see
+    /// [`boundary`]).
+    ///
+    /// [`boundary`]: crate::boundary
+    ///
+    /// # Cost
+    ///
+    /// The cost of adding a body is proportional to the number of sites in the
+    /// body.
+    ///
+    /// # Returns
+    ///
+    /// [`Ok(tag)`](Result::Ok) with the tag of the added body on success.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::AddBody`] when the body cannot be added to the microstate because
+    /// the body position or any site position cannot be wrapped into the boundary
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_microstate::{Body, Microstate};
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut microstate = Microstate::new();
+    /// let first_tag =
+    ///     microstate.add_body(Body::point(Cartesian::from([1.0, 0.0])))?;
+    /// let second_tag =
+    ///     microstate.add_body(Body::point(Cartesian::from([-1.0, 2.0])))?;
+    ///
+    /// assert_eq!(microstate.bodies().len(), 2);
+    /// assert_eq!(first_tag, 0);
+    /// assert_eq!(second_tag, 1);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     #[expect(
         clippy::missing_panics_doc,
@@ -696,33 +683,34 @@ where
         Ok(body_tag)
     }
 
-    /** Add multiple bodies to the microstate.
-
-    See [`Microstate::add_body()`] for details.
-
-    # Errors
-
-    [`Error::AddBody`] when any of the bodies cannot be added to the microstate.
-    `extend_bodies` adds each body one by one. When an error occurs, it
-    short-circuits and does not attempt to add any further bodies. The bodies
-    added before the error will remain in the microstate.
-
-    # Example
-
-    ```
-    use hoomd_microstate::{Microstate, Body};
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut microstate = Microstate::new();
-    microstate.extend_bodies([Body::point(Cartesian::from([1.0, 0.0])),
-                                  Body::point(Cartesian::from([-1.0, 2.0]))])?;
-
-    assert_eq!(microstate.bodies().len(), 2);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Add multiple bodies to the microstate.
+    ///
+    /// See [`Microstate::add_body()`] for details.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::AddBody`] when any of the bodies cannot be added to the microstate.
+    /// `extend_bodies` adds each body one by one. When an error occurs, it
+    /// short-circuits and does not attempt to add any further bodies. The bodies
+    /// added before the error will remain in the microstate.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_microstate::{Body, Microstate};
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut microstate = Microstate::new();
+    /// microstate.extend_bodies([
+    ///     Body::point(Cartesian::from([1.0, 0.0])),
+    ///     Body::point(Cartesian::from([-1.0, 2.0])),
+    /// ])?;
+    ///
+    /// assert_eq!(microstate.bodies().len(), 2);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     pub fn extend_bodies<T>(&mut self, bodies: T) -> Result<(), Error>
     where
@@ -735,44 +723,45 @@ where
         Ok(())
     }
 
-    /** Remove a body at the given *index* from the microstate.
-
-    Also remove all the body's sites. The body's tag (and the tags of its
-    sites) are then free to be reused by [`Microstate::add_body`].
-
-    Removing a body will change the index order of the
-    [`bodies`](Microstate::bodies) and [`sites`](Microstate::sites) arrays.
-    [`Microstate`] does not guarantee any specific ordering in these arrays
-    after calling `remove_body`.
-
-    # Cost
-
-    The cost of removing a body is proportional to the number of sites in the
-    body.
-
-    # Panics
-
-    Panics when `index` is out of bounds.
-
-    # Example
-
-    ```
-    use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut microstate = MicrostateBuilder::new()
-        .bodies([Body::point(Cartesian::from([1.0, 0.0])),
-                 Body::point(Cartesian::from([-1.0, 2.0]))])
-        .try_build()?;
-
-    microstate.remove_body(0);
-
-    assert_eq!(microstate.bodies().len(), 1);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Remove a body at the given *index* from the microstate.
+    ///
+    /// Also remove all the body's sites. The body's tag (and the tags of its
+    /// sites) are then free to be reused by [`Microstate::add_body`].
+    ///
+    /// Removing a body will change the index order of the
+    /// [`bodies`](Microstate::bodies) and [`sites`](Microstate::sites) arrays.
+    /// [`Microstate`] does not guarantee any specific ordering in these arrays
+    /// after calling `remove_body`.
+    ///
+    /// # Cost
+    ///
+    /// The cost of removing a body is proportional to the number of sites in the
+    /// body.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `index` is out of bounds.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_microstate::{Body, Microstate, MicrostateBuilder};
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut microstate = MicrostateBuilder::new()
+    ///     .bodies([
+    ///         Body::point(Cartesian::from([1.0, 0.0])),
+    ///         Body::point(Cartesian::from([-1.0, 2.0])),
+    ///     ])
+    ///     .try_build()?;
+    ///
+    /// microstate.remove_body(0);
+    ///
+    /// assert_eq!(microstate.bodies().len(), 1);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     pub fn remove_body(&mut self, body_index: usize) {
         let body_tag = self.bodies.items[body_index].tag;
@@ -800,36 +789,43 @@ where
         self.bodies.remove(body_index);
     }
 
-    /** Sets the properties of the given body.
-
-    `update_body_properties` also updates the properties of the sites (in the
-    system frame) associated with the body accordingly.
-
-    # Errors
-
-    [`Error::UpdateBody`] the body properties cannot be updated because the body
-    position or any site position cannot be wrapped into the boundary. When an
-    error occurs, `update_body_properties` makes no change to the [`Microstate`].
-
-    # Example
-
-    ```
-    use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
-    use hoomd_microstate::property::Point;
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut microstate = MicrostateBuilder::new()
-        .bodies([Body::point(Cartesian::from([1.0, 0.0]))])
-        .try_build()?;
-
-    microstate.update_body_properties(0, Point::new(Cartesian::from([-2.0, 3.0])))?;
-    assert_eq!(microstate.bodies()[0].item.properties.position, [-2.0, 3.0].into());
-    assert_eq!(microstate.sites()[0].properties.position, [-2.0, 3.0].into());
-    # Ok(())
-    # }
-    ```
-    */
+    /// Sets the properties of the given body.
+    ///
+    /// `update_body_properties` also updates the properties of the sites (in the
+    /// system frame) associated with the body accordingly.
+    ///
+    /// # Errors
+    ///
+    /// [`Error::UpdateBody`] the body properties cannot be updated because the body
+    /// position or any site position cannot be wrapped into the boundary. When an
+    /// error occurs, `update_body_properties` makes no change to the [`Microstate`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_microstate::{
+    ///     Body, Microstate, MicrostateBuilder, property::Point,
+    /// };
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut microstate = MicrostateBuilder::new()
+    ///     .bodies([Body::point(Cartesian::from([1.0, 0.0]))])
+    ///     .try_build()?;
+    ///
+    /// microstate
+    ///     .update_body_properties(0, Point::new(Cartesian::from([-2.0, 3.0])))?;
+    /// assert_eq!(
+    ///     microstate.bodies()[0].item.properties.position,
+    ///     [-2.0, 3.0].into()
+    /// );
+    /// assert_eq!(
+    ///     microstate.sites()[0].properties.position,
+    ///     [-2.0, 3.0].into()
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     #[expect(
         clippy::missing_panics_doc,
@@ -877,29 +873,29 @@ where
         Ok(())
     }
 
-    /** Remove all bodies from the microstate.
-
-    The step, substep, seed, and boundary are left unchanged.
-
-    # Example
-
-    ```
-    use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
-    use hoomd_microstate::property::Point;
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut microstate = MicrostateBuilder::new()
-        .bodies([Body::point(Cartesian::from([1.0, 0.0]))])
-        .try_build()?;
-
-    microstate.clear();
-    assert_eq!(microstate.bodies().len(), 0);
-    assert_eq!(microstate.sites().len(), 0);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Remove all bodies from the microstate.
+    ///
+    /// The step, substep, seed, and boundary are left unchanged.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_microstate::{
+    ///     Body, Microstate, MicrostateBuilder, property::Point,
+    /// };
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut microstate = MicrostateBuilder::new()
+    ///     .bodies([Body::point(Cartesian::from([1.0, 0.0]))])
+    ///     .try_build()?;
+    ///
+    /// microstate.clear();
+    /// assert_eq!(microstate.bodies().len(), 0);
+    /// assert_eq!(microstate.sites().len(), 0);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     pub fn clear(&mut self) {
         self.bodies.clear();
@@ -910,226 +906,235 @@ where
     }
 }
 
-/** Access contents of the microstate.
-*/
+/// Access contents of the microstate.
 impl<B, S, C> Microstate<B, S, C> {
-    /** Access the microstate's tagged bodies in index order.
-
-    [`Microstate`] stores bodies in a flat memory region. The [`Tagged`] type
-    holds the unique identifier for each body in [`Tagged::tag`] and the
-    [`Body`] itself in [`Tagged::item`].
-
-    [`bodies`](Microstate::bodies) provides direct immutable access
-    to this slice. To mutate a body (and by extension, its sites), see
-    [`Microstate::update_body_properties()`].
-
-    # Examples
-
-    Identify the tag of a body at a given index:
-
-    ```
-    use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let microstate = MicrostateBuilder::new()
-        .bodies([Body::point(Cartesian::from([1.0, 0.0])),
-                 Body::point(Cartesian::from([-1.0, 2.0]))])
-        .try_build()?;
-
-    // The initial index order is equivalent to the tag order.
-    assert_eq!(microstate.bodies()[0].tag, 0);
-    assert_eq!(microstate.bodies()[1].tag, 1);
-    # Ok(())
-    # }
-    ```
-
-    Compute system-wide properties that are order-independent:
-    ```
-    use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
-    use hoomd_vector::{Vector, Cartesian};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let microstate = MicrostateBuilder::new()
-        .bodies([Body::point(Cartesian::from([1.0, 0.0])),
-                 Body::point(Cartesian::from([-1.0, 2.0]))])
-        .try_build()?;
-
-    let average_position = microstate.bodies()
-        .iter()
-        .map(|tagged_body| tagged_body.item.properties.position)
-        .sum::<Cartesian<2>>() / (microstate.bodies().len() as f64);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Access the microstate's tagged bodies in index order.
+    ///
+    /// [`Microstate`] stores bodies in a flat memory region. The [`Tagged`] type
+    /// holds the unique identifier for each body in [`Tagged::tag`] and the
+    /// [`Body`] itself in [`Tagged::item`].
+    ///
+    /// [`bodies`](Microstate::bodies) provides direct immutable access
+    /// to this slice. To mutate a body (and by extension, its sites), see
+    /// [`Microstate::update_body_properties()`].
+    ///
+    /// # Examples
+    ///
+    /// Identify the tag of a body at a given index:
+    ///
+    /// ```
+    /// use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let microstate = MicrostateBuilder::new()
+    /// .bodies([Body::point(Cartesian::from([1.0, 0.0])),
+    /// Body::point(Cartesian::from([-1.0, 2.0]))])
+    /// .try_build()?;
+    ///
+    /// The initial index order is equivalent to the tag order.
+    /// assert_eq!(microstate.bodies()[0].tag, 0);
+    /// assert_eq!(microstate.bodies()[1].tag, 1);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Compute system-wide properties that are order-independent:
+    /// ```
+    /// use hoomd_microstate::{Body, Microstate, MicrostateBuilder};
+    /// use hoomd_vector::{Cartesian, Vector};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let microstate = MicrostateBuilder::new()
+    ///     .bodies([
+    ///         Body::point(Cartesian::from([1.0, 0.0])),
+    ///         Body::point(Cartesian::from([-1.0, 2.0])),
+    ///     ])
+    ///     .try_build()?;
+    ///
+    /// let average_position = microstate
+    ///     .bodies()
+    ///     .iter()
+    ///     .map(|tagged_body| tagged_body.item.properties.position)
+    ///     .sum::<Cartesian<2>>()
+    ///     / (microstate.bodies().len() as f64);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     pub fn bodies(&self) -> &[Tagged<Body<B, S>>] {
         &self.bodies.items
     }
 
-    /** Identify the index of a body given a tag.
-
-    Use [`body_indices`](Microstate::body_indices) to locate a specific body in
-    [`Microstate::bodies`].
-
-    `body_indices()[tag]` is:
-    * [`None`] when there is no body with the given tag in the microstate.
-    * [`Some(index)`](Option::Some) when the body with the given tag is in the
-      microstate. `index` is the index of the body in [`Microstate::bodies`].
-
-    # Example
-
-    ```
-    use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
-    use hoomd_vector::Cartesian;
-    use anyhow::anyhow;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut microstate = MicrostateBuilder::new()
-        .bodies([Body::point(Cartesian::from([1.0, 2.0])),
-                 Body::point(Cartesian::from([3.0, 4.0])),
-                 Body::point(Cartesian::from([5.0, 6.0])),
-                 Body::point(Cartesian::from([7.0, 8.0]))])
-        .try_build()?;
-
-    let index = microstate.body_indices()[0]
-        .ok_or(anyhow!("body 0 is not present"))?;
-    microstate.remove_body(index);
-
-    assert_eq!(microstate.body_indices()[0], None);
-    assert!(matches!(microstate.body_indices()[3], Some(_)));
-
-    let index = microstate.body_indices()[2]
-        .ok_or(anyhow!("body 2 is not present"))?;
-    assert_eq!(microstate.bodies()[index].item.properties.position,
-        [5.0, 6.0].into());
-    # Ok(())
-    # }
-    ```
-    */
+    /// Identify the index of a body given a tag.
+    ///
+    /// Use [`body_indices`](Microstate::body_indices) to locate a specific body in
+    /// [`Microstate::bodies`].
+    ///
+    /// `body_indices()[tag]` is:
+    /// [`None`] when there is no body with the given tag in the microstate.
+    /// [`Some(index)`](Option::Some) when the body with the given tag is in the
+    /// microstate. `index` is the index of the body in [`Microstate::bodies`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use anyhow::anyhow;
+    /// use hoomd_microstate::{Body, Microstate, MicrostateBuilder};
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut microstate = MicrostateBuilder::new()
+    ///     .bodies([
+    ///         Body::point(Cartesian::from([1.0, 2.0])),
+    ///         Body::point(Cartesian::from([3.0, 4.0])),
+    ///         Body::point(Cartesian::from([5.0, 6.0])),
+    ///         Body::point(Cartesian::from([7.0, 8.0])),
+    ///     ])
+    ///     .try_build()?;
+    ///
+    /// let index =
+    ///     microstate.body_indices()[0].ok_or(anyhow!("body 0 is not present"))?;
+    /// microstate.remove_body(index);
+    ///
+    /// assert_eq!(microstate.body_indices()[0], None);
+    /// assert!(matches!(microstate.body_indices()[3], Some(_)));
+    ///
+    /// let index =
+    ///     microstate.body_indices()[2].ok_or(anyhow!("body 2 is not present"))?;
+    /// assert_eq!(
+    ///     microstate.bodies()[index].item.properties.position,
+    ///     [5.0, 6.0].into()
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     pub fn body_indices(&self) -> &[Option<usize>] {
         &self.bodies.indices
     }
 
-    /** Access the microstate's sites (in the system frame) in index order.
-
-    [`Microstate`] stores sites twice. Each body in
-    [`bodies`](Microstate::bodies) stores its sites in the body frame of
-    reference. [`Microstate`] also stores a flat vector of sites that have been
-    transformed (see [`Transform`]) to the system reference frame. The [`Site`]
-    type holds the unique identifier for each site in [`Site::site_tag`],
-    the associated body tag in [`Site::body_tag`] and the site's properties in
-    [`Site::properties`].
-
-    [`sites`](Microstate::sites) provides direct immutable access to the
-    slice of all sites. To mutate a body (and by extension, its sites), see
-    [`Microstate::update_body_properties()`].
-
-    # Examples
-
-    Identify the site and body tags of a site at a given index:
-
-    ```
-    use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let microstate = MicrostateBuilder::new()
-        .bodies([Body::point(Cartesian::from([1.0, 0.0])),
-                 Body::point(Cartesian::from([-1.0, 2.0]))])
-        .try_build()?;
-
-    // The initial index order is equivalent to the tag order.
-    assert_eq!(microstate.sites()[0].site_tag, 0);
-    assert_eq!(microstate.sites()[0].body_tag, 0);
-
-    assert_eq!(microstate.sites()[1].body_tag, 1);
-    assert_eq!(microstate.sites()[1].body_tag, 1);
-    # Ok(())
-    # }
-    ```
-
-    Compute system-wide properties that are order-independent:
-    ```
-    use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
-    use hoomd_vector::{Vector, Cartesian};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let microstate = MicrostateBuilder::new()
-        .bodies([Body::point(Cartesian::from([1.0, 0.0])),
-                 Body::point(Cartesian::from([-1.0, 2.0]))])
-        .try_build()?;
-
-    let average_position = microstate.sites()
-        .iter()
-        .map(|site| site.properties.position)
-        .sum::<Cartesian<2>>() / (microstate.sites().len() as f64);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Access the microstate's sites (in the system frame) in index order.
+    ///
+    /// [`Microstate`] stores sites twice. Each body in
+    /// [`bodies`](Microstate::bodies) stores its sites in the body frame of
+    /// reference. [`Microstate`] also stores a flat vector of sites that have been
+    /// transformed (see [`Transform`]) to the system reference frame. The [`Site`]
+    /// type holds the unique identifier for each site in [`Site::site_tag`],
+    /// the associated body tag in [`Site::body_tag`] and the site's properties in
+    /// [`Site::properties`].
+    ///
+    /// [`sites`](Microstate::sites) provides direct immutable access to the
+    /// slice of all sites. To mutate a body (and by extension, its sites), see
+    /// [`Microstate::update_body_properties()`].
+    ///
+    /// # Examples
+    ///
+    /// Identify the site and body tags of a site at a given index:
+    ///
+    /// ```
+    /// use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let microstate = MicrostateBuilder::new()
+    /// .bodies([Body::point(Cartesian::from([1.0, 0.0])),
+    /// Body::point(Cartesian::from([-1.0, 2.0]))])
+    /// .try_build()?;
+    ///
+    /// The initial index order is equivalent to the tag order.
+    /// assert_eq!(microstate.sites()[0].site_tag, 0);
+    /// assert_eq!(microstate.sites()[0].body_tag, 0);
+    ///
+    /// assert_eq!(microstate.sites()[1].body_tag, 1);
+    /// assert_eq!(microstate.sites()[1].body_tag, 1);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Compute system-wide properties that are order-independent:
+    /// ```
+    /// use hoomd_microstate::{Body, Microstate, MicrostateBuilder};
+    /// use hoomd_vector::{Cartesian, Vector};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let microstate = MicrostateBuilder::new()
+    ///     .bodies([
+    ///         Body::point(Cartesian::from([1.0, 0.0])),
+    ///         Body::point(Cartesian::from([-1.0, 2.0])),
+    ///     ])
+    ///     .try_build()?;
+    ///
+    /// let average_position = microstate
+    ///     .sites()
+    ///     .iter()
+    ///     .map(|site| site.properties.position)
+    ///     .sum::<Cartesian<2>>()
+    ///     / (microstate.sites().len() as f64);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     pub fn sites(&self) -> &[Site<S>] {
         &self.sites.items
     }
 
-    /** Access the ghost sites in the system frame.
-
-    Each ghost site shares a `site_tag` and `body_tag` with a primary site
-    (in [`sites`]). Ghost sites are only placed when using periodic boundary
-    conditions and are outside the edges of the boundary.
-
-    [`sites`]: Self::sites
-    */
+    /// Access the ghost sites in the system frame.
+    ///
+    /// Each ghost site shares a `site_tag` and `body_tag` with a primary site
+    /// (in [`sites`]). Ghost sites are only placed when using periodic boundary
+    /// conditions and are outside the edges of the boundary.
+    ///
+    /// [`sites`]: Self::sites
     #[inline]
     pub fn ghosts(&self) -> &[Site<S>] {
         &self.ghosts.items
     }
 
-    /** Identify the index of a site given a tag.
-
-    Use [`site_indices`](Microstate::site_indices) to locate a specific site in
-    [`Microstate::sites`].
-
-    See [`body_indices`](Microstate::body_indices) for details.
-    */
+    /// Identify the index of a site given a tag.
+    ///
+    /// Use [`site_indices`](Microstate::site_indices) to locate a specific site in
+    /// [`Microstate::sites`].
+    ///
+    /// See [`body_indices`](Microstate::body_indices) for details.
     #[inline]
     pub fn site_indices(&self) -> &[Option<usize>] {
         &self.sites.indices
     }
 
-    /** Iterate over all the sites (in the system reference frame) associated with a body.
-
-    Use [`iter_body_sites`](Microstate::iter_body_sites) to perform computations
-    in the system reference frame on all sites that are associated with a given
-    body *index*. The borrowed sites are immutable. Call
-    [`Microstate::update_body_properties()`] to mutate a body.
-
-    `iter_body_sites` always iterates over *primary sites*. In periodic boundary
-    conditions, these sites may be split across one or more parts of the
-    boundary.
-
-    # Example
-
-    ```
-    use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
-    use hoomd_vector::{Vector, Cartesian};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let microstate = MicrostateBuilder::new()
-        .bodies([Body::point(Cartesian::from([1.0, 0.0])),
-                 Body::point(Cartesian::from([-1.0, 2.0]))])
-        .try_build()?;
-
-    let average_position = microstate.iter_body_sites(0)
-        .map(|site| site.properties.position)
-        .sum::<Cartesian<2>>() / (microstate.bodies()[0].item.sites.len() as f64);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Iterate over all the sites (in the system reference frame) associated with a body.
+    ///
+    /// Use [`iter_body_sites`](Microstate::iter_body_sites) to perform computations
+    /// in the system reference frame on all sites that are associated with a given
+    /// body *index*. The borrowed sites are immutable. Call
+    /// [`Microstate::update_body_properties()`] to mutate a body.
+    ///
+    /// `iter_body_sites` always iterates over *primary sites*. In periodic boundary
+    /// conditions, these sites may be split across one or more parts of the
+    /// boundary.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_microstate::{Body, Microstate, MicrostateBuilder};
+    /// use hoomd_vector::{Cartesian, Vector};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let microstate = MicrostateBuilder::new()
+    ///     .bodies([
+    ///         Body::point(Cartesian::from([1.0, 0.0])),
+    ///         Body::point(Cartesian::from([-1.0, 2.0])),
+    ///     ])
+    ///     .try_build()?;
+    ///
+    /// let average_position = microstate
+    ///     .iter_body_sites(0)
+    ///     .map(|site| site.properties.position)
+    ///     .sum::<Cartesian<2>>()
+    ///     / (microstate.bodies()[0].item.sites.len() as f64);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     #[expect(
         clippy::missing_panics_doc,
@@ -1148,23 +1153,22 @@ where
     S: Position<Vector = V>,
     V: Vector,
 {
-    /** Find sites near a point in space.
-
-    Iterate over all sites and ghost sites within a distance `r` of the given
-    `point`. All sites produced by this iterator will be in the system reference
-    frame and within the given distance metric. No wrapping is required for
-    ghost sites, which will be slightly outside the boundary condition. When a
-    ghost site is provided by the iterator, its `site_tag` and `body_tag` will
-    match that of the actual site.
-
-    The caller *may* provide a value for `r` that is larger than the maximum
-    interaction range. In the current implementation, this is not an error.
-    However, in such cases `iter_sites_near` will only iterate over the placed
-    ghosts which are within the boundary's `maximum_interaction_range`.
-
-    In other words, `iter_sites_near` is meant for use with pairwise functions
-    that follow the minimum image convention.
-    */
+    /// Find sites near a point in space.
+    ///
+    /// Iterate over all sites and ghost sites within a distance `r` of the given
+    /// `point`. All sites produced by this iterator will be in the system reference
+    /// frame and within the given distance metric. No wrapping is required for
+    /// ghost sites, which will be slightly outside the boundary condition. When a
+    /// ghost site is provided by the iterator, its `site_tag` and `body_tag` will
+    /// match that of the actual site.
+    ///
+    /// The caller *may* provide a value for `r` that is larger than the maximum
+    /// interaction range. In the current implementation, this is not an error.
+    /// However, in such cases `iter_sites_near` will only iterate over the placed
+    /// ghosts which are within the boundary's `maximum_interaction_range`.
+    ///
+    /// In other words, `iter_sites_near` is meant for use with pairwise functions
+    /// that follow the minimum image convention.
     #[inline]
     pub fn iter_sites_near(&self, point: &V, r: f64) -> impl Iterator<Item = &Site<S>> {
         self.sites
@@ -1175,33 +1179,34 @@ where
     }
 }
 
-/** Choose parameters when constructing a [`Microstate`].
-
-Use a [`MicrostateBuilder`] to choose the values of optional parameters when
-constructing a [`Microstate`]. Some parameters, such as `seed` and `step`,
-cannot be directly modified after building the [`Microstate`].
-
-# Example
-
-```
-use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
-use hoomd_vector::Cartesian;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut microstate = MicrostateBuilder::new()
-    .step(100_000)
-    .seed(0x1234abcd)
-    .bodies([Body::point(Cartesian::from([1.0, 0.0])),
-             Body::point(Cartesian::from([-1.0, 2.0]))])
-    .try_build()?;
-
-assert_eq!(microstate.step(), 100_000);
-assert_eq!(microstate.seed(), 0x1234abcd);
-assert_eq!(microstate.bodies().len(), 2);
-# Ok(())
-# }
-```
-*/
+/// Choose parameters when constructing a [`Microstate`].
+///
+/// Use a [`MicrostateBuilder`] to choose the values of optional parameters when
+/// constructing a [`Microstate`]. Some parameters, such as `seed` and `step`,
+/// cannot be directly modified after building the [`Microstate`].
+///
+/// # Example
+///
+/// ```
+/// use hoomd_microstate::{Body, Microstate, MicrostateBuilder};
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = MicrostateBuilder::new()
+///     .step(100_000)
+///     .seed(0x1234abcd)
+///     .bodies([
+///         Body::point(Cartesian::from([1.0, 0.0])),
+///         Body::point(Cartesian::from([-1.0, 2.0])),
+///     ])
+///     .try_build()?;
+///
+/// assert_eq!(microstate.step(), 100_000);
+/// assert_eq!(microstate.seed(), 0x1234abcd);
+/// assert_eq!(microstate.bodies().len(), 2);
+/// # Ok(())
+/// # }
+/// ```
 pub struct MicrostateBuilder<B, S = B, C = Open> {
     /// The initial value for step in the resulting [`Microstate`].
     step: u64,
@@ -1214,29 +1219,29 @@ pub struct MicrostateBuilder<B, S = B, C = Open> {
 }
 
 impl<B, S> MicrostateBuilder<B, S, Open> {
-    /** Construct an empty [`MicrostateBuilder`] with open boundary conditions.
-
-    The resulting microstate starts at step 0 and has a random seed of 0.
-
-    # Example
-
-    ```
-    use hoomd_microstate::{Microstate, MicrostateBuilder, property::Point};
-    use hoomd_vector::Cartesian;
-
-    # type BodyProperties = Point<Cartesian<2>>;
-    # type SiteProperties = Point<Cartesian<2>>;
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let microstate = MicrostateBuilder::<BodyProperties, SiteProperties>::new().try_build()?;
-
-    assert_eq!(microstate.step(), 0);
-    assert_eq!(microstate.seed(), 0);
-    assert_eq!(microstate.bodies().len(), 0);
-    assert_eq!(*microstate.boundary(), hoomd_microstate::boundary::Open);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Construct an empty [`MicrostateBuilder`] with open boundary conditions.
+    ///
+    /// The resulting microstate starts at step 0 and has a random seed of 0.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_microstate::{Microstate, MicrostateBuilder, property::Point};
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # type BodyProperties = Point<Cartesian<2>>;
+    /// # type SiteProperties = Point<Cartesian<2>>;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let microstate = MicrostateBuilder::<BodyProperties, SiteProperties>::new()
+    ///     .try_build()?;
+    ///
+    /// assert_eq!(microstate.step(), 0);
+    /// assert_eq!(microstate.seed(), 0);
+    /// assert_eq!(microstate.bodies().len(), 0);
+    /// assert_eq!(*microstate.boundary(), hoomd_microstate::boundary::Open);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     #[must_use]
     pub fn new() -> Self {
@@ -1252,34 +1257,37 @@ impl<B, S> Default for MicrostateBuilder<B, S, Open> {
 }
 
 impl<B, S, C> MicrostateBuilder<B, S, C> {
-    /** Construct an empty [`MicrostateBuilder`] with the given boundary conditions.
-
-    The resulting microstate starts at step 0 and has a random seed of 0.
-
-    # Example
-
-    ```
-    use hoomd_geometry::shape::Rectangle;
-    use hoomd_microstate::{Microstate, MicrostateBuilder, boundary::Closed};
-    use hoomd_vector::Cartesian;
-
-    # use hoomd_microstate::property::Point;
-    # type BodyProperties = Point<Cartesian<2>>;
-    # type SiteProperties = Point<Cartesian<2>>;
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let square = Closed(Rectangle::with_equal_edges(10.0.try_into()?));
-
-    let microstate = MicrostateBuilder::<BodyProperties, SiteProperties, Closed<Rectangle>>::with_boundary(square)
-        .try_build()?;
-
-    assert_eq!(microstate.step(), 0);
-    assert_eq!(microstate.seed(), 0);
-    assert_eq!(microstate.bodies().len(), 0);
-    assert_eq!(microstate.boundary().0.edge_lengths[0].get(), 10.0);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Construct an empty [`MicrostateBuilder`] with the given boundary conditions.
+    ///
+    /// The resulting microstate starts at step 0 and has a random seed of 0.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_geometry::shape::Rectangle;
+    /// use hoomd_microstate::{Microstate, MicrostateBuilder, boundary::Closed};
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # use hoomd_microstate::property::Point;
+    /// # type BodyProperties = Point<Cartesian<2>>;
+    /// # type SiteProperties = Point<Cartesian<2>>;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let square = Closed(Rectangle::with_equal_edges(10.0.try_into()?));
+    ///
+    /// let microstate = MicrostateBuilder::<
+    ///     BodyProperties,
+    ///     SiteProperties,
+    ///     Closed<Rectangle>,
+    /// >::with_boundary(square)
+    /// .try_build()?;
+    ///
+    /// assert_eq!(microstate.step(), 0);
+    /// assert_eq!(microstate.seed(), 0);
+    /// assert_eq!(microstate.bodies().len(), 0);
+    /// assert_eq!(microstate.boundary().0.edge_lengths[0].get(), 10.0);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     pub fn with_boundary(boundary: C) -> Self {
         Self {
@@ -1290,29 +1298,29 @@ impl<B, S, C> MicrostateBuilder<B, S, C> {
         }
     }
 
-    /** Choose the initial step in the resulting [`Microstate`].
-
-    The default `step` is 0.
-
-    # Example
-
-    ```
-    use hoomd_microstate::{Microstate, MicrostateBuilder, property::Point};
-    use hoomd_microstate::boundary::Open;
-    use hoomd_vector::Cartesian;
-
-    # type BodyProperties = Point<Cartesian<2>>;
-    # type SiteProperties = Point<Cartesian<2>>;
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let microstate = MicrostateBuilder::<BodyProperties, SiteProperties>::new()
-        .step(100_000)
-        .try_build()?;
-
-    assert_eq!(microstate.step(), 100_000);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Choose the initial step in the resulting [`Microstate`].
+    ///
+    /// The default `step` is 0.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_microstate::{
+    ///     Microstate, MicrostateBuilder, boundary::Open, property::Point,
+    /// };
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # type BodyProperties = Point<Cartesian<2>>;
+    /// # type SiteProperties = Point<Cartesian<2>>;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let microstate = MicrostateBuilder::<BodyProperties, SiteProperties>::new()
+    ///     .step(100_000)
+    ///     .try_build()?;
+    ///
+    /// assert_eq!(microstate.step(), 100_000);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     #[must_use]
     pub fn step(mut self, step: u64) -> Self {
@@ -1320,29 +1328,29 @@ impl<B, S, C> MicrostateBuilder<B, S, C> {
         self
     }
 
-    /** Choose the random number seed in the resulting [`Microstate`].
-
-    The default `seed` is 0.
-
-    # Example
-
-    ```
-    use hoomd_microstate::{Microstate, MicrostateBuilder, property::Point};
-    use hoomd_microstate::boundary::Open;
-    use hoomd_vector::Cartesian;
-
-    # type BodyProperties = Point<Cartesian<2>>;
-    # type SiteProperties = Point<Cartesian<2>>;
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let microstate = MicrostateBuilder::<BodyProperties, SiteProperties>::new()
-        .seed(0x1234abcd)
-        .try_build()?;
-
-    assert_eq!(microstate.seed(), 0x1234abcd);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Choose the random number seed in the resulting [`Microstate`].
+    ///
+    /// The default `seed` is 0.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_microstate::{
+    ///     Microstate, MicrostateBuilder, boundary::Open, property::Point,
+    /// };
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # type BodyProperties = Point<Cartesian<2>>;
+    /// # type SiteProperties = Point<Cartesian<2>>;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let microstate = MicrostateBuilder::<BodyProperties, SiteProperties>::new()
+    ///     .seed(0x1234abcd)
+    ///     .try_build()?;
+    ///
+    /// assert_eq!(microstate.seed(), 0x1234abcd);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     #[must_use]
     pub fn seed(mut self, seed: u32) -> Self {
@@ -1350,27 +1358,28 @@ impl<B, S, C> MicrostateBuilder<B, S, C> {
         self
     }
 
-    /** Add bodies to the resulting [`Microstate`].
-
-    All bodies will be appended when this method is called multiple times.
-
-    # Example
-
-    ```
-    use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut microstate = MicrostateBuilder::new()
-        .bodies([Body::point(Cartesian::from([1.0, 0.0])),
-                 Body::point(Cartesian::from([-1.0, 2.0]))])
-        .try_build()?;
-
-    assert_eq!(microstate.bodies().len(), 2);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Add bodies to the resulting [`Microstate`].
+    ///
+    /// All bodies will be appended when this method is called multiple times.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_microstate::{Body, Microstate, MicrostateBuilder};
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut microstate = MicrostateBuilder::new()
+    ///     .bodies([
+    ///         Body::point(Cartesian::from([1.0, 0.0])),
+    ///         Body::point(Cartesian::from([-1.0, 2.0])),
+    ///     ])
+    ///     .try_build()?;
+    ///
+    /// assert_eq!(microstate.bodies().len(), 2);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     #[must_use]
     pub fn bodies<T>(mut self, bodies: T) -> Self
@@ -1381,33 +1390,34 @@ impl<B, S, C> MicrostateBuilder<B, S, C> {
         self
     }
 
-    /** Construct a [`Microstate`] with the chosen options.
-
-    # Errors
-
-    See [`Microstate::extend_bodies()`].
-
-    # Example
-
-    ```
-    use hoomd_microstate::{Microstate, MicrostateBuilder, Body};
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut microstate = MicrostateBuilder::new()
-        .step(100_000)
-        .seed(0x1234abcd)
-        .bodies([Body::point(Cartesian::from([1.0, 0.0])),
-                 Body::point(Cartesian::from([-1.0, 2.0]))])
-        .try_build()?;
-
-    assert_eq!(microstate.step(), 100_000);
-    assert_eq!(microstate.seed(), 0x1234abcd);
-    assert_eq!(microstate.bodies().len(), 2);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Construct a [`Microstate`] with the chosen options.
+    ///
+    /// # Errors
+    ///
+    /// See [`Microstate::extend_bodies()`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_microstate::{Body, Microstate, MicrostateBuilder};
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut microstate = MicrostateBuilder::new()
+    ///     .step(100_000)
+    ///     .seed(0x1234abcd)
+    ///     .bodies([
+    ///         Body::point(Cartesian::from([1.0, 0.0])),
+    ///         Body::point(Cartesian::from([-1.0, 2.0])),
+    ///     ])
+    ///     .try_build()?;
+    ///
+    /// assert_eq!(microstate.step(), 100_000);
+    /// assert_eq!(microstate.seed(), 0x1234abcd);
+    /// assert_eq!(microstate.bodies().len(), 2);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     pub fn try_build<V>(self) -> Result<Microstate<B, S, C>, Error>
     where

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -209,26 +209,26 @@ impl<B, S> Default for Microstate<B, S, Open> {
 
 impl<B, S> Microstate<B, S, Open> {
     /** Construct an empty microstate with open boundary conditions.
-     *
-     * The microstate starts at step 0, substep 0, random number seed 0,
-     * and has no bodies.
-     *
-     * # Example
-     *
-     * ```
-     * use hoomd_microstate::Microstate;
-     * # use hoomd_microstate::{Body, property::Point};
-     * # use hoomd_vector::Cartesian;
-     *
-     * let mut microstate = Microstate::new();
-     * assert_eq!(microstate.step(), 0);
-     * assert_eq!(microstate.substep(), 0);
-     * assert_eq!(microstate.seed(), 0);
-     * assert_eq!(microstate.bodies().len(), 0);
-     * assert_eq!(microstate.sites().len(),0);
-     * # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
-     * ```
-     **/
+     
+     The microstate starts at step 0, substep 0, random number seed 0,
+     and has no bodies.
+     
+     # Example
+    
+     ```
+     use hoomd_microstate::Microstate;
+     # use hoomd_microstate::{Body, property::Point};
+     # use hoomd_vector::Cartesian;
+     
+     let mut microstate = Microstate::new();
+     assert_eq!(microstate.step(), 0);
+     assert_eq!(microstate.substep(), 0);
+     assert_eq!(microstate.seed(), 0);
+     assert_eq!(microstate.bodies().len(), 0);
+     assert_eq!(microstate.sites().len(),0);
+     # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
+     ```
+     */
     #[inline]
     #[must_use]
     pub fn new() -> Self {

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -210,25 +210,25 @@ impl<B, S> Default for Microstate<B, S, Open> {
 impl<B, S> Microstate<B, S, Open> {
     /** Construct an empty microstate with open boundary conditions.
      
-     The microstate starts at step 0, substep 0, random number seed 0,
-     and has no bodies.
+    The microstate starts at step 0, substep 0, random number seed 0,
+    and has no bodies.
      
-     # Example
+    # Example
     
-     ```
-     use hoomd_microstate::Microstate;
-     # use hoomd_microstate::{Body, property::Point};
-     # use hoomd_vector::Cartesian;
+    ```
+    use hoomd_microstate::Microstate;
+    # use hoomd_microstate::{Body, property::Point};
+    # use hoomd_vector::Cartesian;
      
-     let mut microstate = Microstate::new();
-     assert_eq!(microstate.step(), 0);
-     assert_eq!(microstate.substep(), 0);
-     assert_eq!(microstate.seed(), 0);
-     assert_eq!(microstate.bodies().len(), 0);
-     assert_eq!(microstate.sites().len(),0);
-     # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
-     ```
-     */
+    let mut microstate = Microstate::new();
+    assert_eq!(microstate.step(), 0);
+    assert_eq!(microstate.substep(), 0);
+    assert_eq!(microstate.seed(), 0);
+    assert_eq!(microstate.bodies().len(), 0);
+    assert_eq!(microstate.sites().len(),0);
+    # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
+    ```
+    */
     #[inline]
     #[must_use]
     pub fn new() -> Self {

--- a/hoomd-microstate/src/property.rs
+++ b/hoomd-microstate/src/property.rs
@@ -153,7 +153,6 @@ pub trait Position {
 /// The units of [`Orientation`] depend on the representation chosen for `R`.
 /// For example, [`hoomd_vector::Angle`] has units of radians while
 /// [`hoomd_vector::Versor`] is unitless.
-///
 pub trait Orientation {
     /// Type that can express the orientation of a body or site.
     type Rotation;

--- a/hoomd-microstate/src/property.rs
+++ b/hoomd-microstate/src/property.rs
@@ -1,108 +1,114 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Traits that describe body and/or site properties a a selection types that implement them.
-
-See the [crate-level documentation](crate) for an overview of how body and site
-properties interact with [`Microstate`](crate::Microstate) and model methods.
-
-# Provided types
-
-The structs provided in `property` may be used as [`Body`](crate::Body) and/or
-[`Site`](crate::Site) properties.
-
-[`Point`] represents a position in space:
-```
-use hoomd_microstate::property::Point;
-use hoomd_vector::Cartesian;
-
-let point = Point::new(Cartesian::from([1.0, -3.0]));
-```
-
-[`OrientedPoint`] contains both the position and orientation of an extended body:
-```
-use hoomd_microstate::property::OrientedPoint;
-use hoomd_vector::{Angle, Cartesian};
-
-let point = OrientedPoint { position: Cartesian::from([1.0, -3.0]),
-    orientation: Angle::from(1.2),
-};
-```
-
-# Custom property types
-
-When none of the provided types meets your needs, you can define a custom type.
-You must implement [`Position`] for your type and may implement other
-property traits as needed by your model.
-
-For example, this `Custom` type implements [`Position`], [`Orientation`],
-and has a `custom` field. The full site properties type is available when
-hoomd-rs computes interactions on sites, so you can use the custom fields
-in your own custom interaction potentials.
-
-```
-use hoomd_vector::{Cartesian, Versor};
-use hoomd_microstate::property::{Orientation, Position};
-
-struct Custom {
-    position: Cartesian<3>,
-    orientation: Versor,
-    custom: f64,
-    }
-
-impl Orientation for Custom {
-    type Rotation = Versor;
-
-    fn orientation(&self) -> &Versor {
-        &self.orientation
-    }
-
-    fn orientation_mut(&mut self) -> &mut Versor {
-        &mut self.orientation
-    }
-}
-
-impl Position for Custom {
-    type Vector = Cartesian<3>;
-
-    fn position(&self) -> &Cartesian<3> {
-        &self.position
-    }
-
-    fn position_mut(&mut self) -> &mut Cartesian<3> {
-        &mut self.position
-    }
-}
-```
-
-## Transformations
-
-
-Implement `Transform` to take sites from the body frame to the system frame.
-Typically, this involves transforming position and orientation while leaving
-all other fields unchanged:
-
-```
-use hoomd_vector::{Cartesian, Rotate, Rotation, Versor};
-use hoomd_microstate::{Transform, property::{Orientation, OrientedPoint, Position}};
-
-struct Custom {
-    position: Cartesian<3>,
-    orientation: Versor,
-    custom: f64,
-    }
-
-impl Transform<Custom> for OrientedPoint<Cartesian<3>, Versor> {
-    fn transform(&self, site_properties: &Custom) -> Custom {
-        Custom {
-            position: self.position + self.orientation.rotate(&site_properties.position),
-            orientation: self.orientation.combine(&site_properties.orientation),
-            .. *site_properties
-        }
-    }
-}
-```
-*/
+//! Traits that describe body and/or site properties a a selection types that implement them.
+//!
+//! See the [crate-level documentation](crate) for an overview of how body and site
+//! properties interact with [`Microstate`](crate::Microstate) and model methods.
+//!
+//! # Provided types
+//!
+//! The structs provided in `property` may be used as [`Body`](crate::Body) and/or
+//! [`Site`](crate::Site) properties.
+//!
+//! [`Point`] represents a position in space:
+//! ```
+//! use hoomd_microstate::property::Point;
+//! use hoomd_vector::Cartesian;
+//!
+//! let point = Point::new(Cartesian::from([1.0, -3.0]));
+//! ```
+//!
+//! [`OrientedPoint`] contains both the position and orientation of an extended body:
+//! ```
+//! use hoomd_microstate::property::OrientedPoint;
+//! use hoomd_vector::{Angle, Cartesian};
+//!
+//! let point = OrientedPoint {
+//!     position: Cartesian::from([1.0, -3.0]),
+//!     orientation: Angle::from(1.2),
+//! };
+//! ```
+//!
+//! # Custom property types
+//!
+//! When none of the provided types meets your needs, you can define a custom type.
+//! You must implement [`Position`] for your type and may implement other
+//! property traits as needed by your model.
+//!
+//! For example, this `Custom` type implements [`Position`], [`Orientation`],
+//! and has a `custom` field. The full site properties type is available when
+//! hoomd-rs computes interactions on sites, so you can use the custom fields
+//! in your own custom interaction potentials.
+//!
+//! ```
+//! use hoomd_microstate::property::{Orientation, Position};
+//! use hoomd_vector::{Cartesian, Versor};
+//!
+//! struct Custom {
+//!     position: Cartesian<3>,
+//!     orientation: Versor,
+//!     custom: f64,
+//! }
+//!
+//! impl Orientation for Custom {
+//!     type Rotation = Versor;
+//!
+//!     fn orientation(&self) -> &Versor {
+//!         &self.orientation
+//!     }
+//!
+//!     fn orientation_mut(&mut self) -> &mut Versor {
+//!         &mut self.orientation
+//!     }
+//! }
+//!
+//! impl Position for Custom {
+//!     type Vector = Cartesian<3>;
+//!
+//!     fn position(&self) -> &Cartesian<3> {
+//!         &self.position
+//!     }
+//!
+//!     fn position_mut(&mut self) -> &mut Cartesian<3> {
+//!         &mut self.position
+//!     }
+//! }
+//! ```
+//!
+//! ## Transformations
+//!
+//!
+//! Implement `Transform` to take sites from the body frame to the system frame.
+//! Typically, this involves transforming position and orientation while leaving
+//! all other fields unchanged:
+//!
+//! ```
+//! use hoomd_microstate::{
+//!     Transform,
+//!     property::{Orientation, OrientedPoint, Position},
+//! };
+//! use hoomd_vector::{Cartesian, Rotate, Rotation, Versor};
+//!
+//! struct Custom {
+//!     position: Cartesian<3>,
+//!     orientation: Versor,
+//!     custom: f64,
+//! }
+//!
+//! impl Transform<Custom> for OrientedPoint<Cartesian<3>, Versor> {
+//!     fn transform(&self, site_properties: &Custom) -> Custom {
+//!         Custom {
+//!             position: self.position
+//!                 + self.orientation.rotate(&site_properties.position),
+//!             orientation: self
+//!                 .orientation
+//!                 .combine(&site_properties.orientation),
+//!             ..*site_properties
+//!         }
+//!     }
+//! }
+//! ```
 
 mod point;
 pub use point::Point;
@@ -110,20 +116,19 @@ pub use point::Point;
 mod oriented_point;
 pub use oriented_point::OrientedPoint;
 
-/** Locate sites and bodies.
-
-When applied to site properties, [`Position`] describes the location of the site
-relative to the origin of the body. In other words, it is the position of the
-site in the body reference frame.
-
-When applied to body properties [`Position`] describes the location of the body
-relative to the origin of the system coordinate system. In other words, it is
-the position of the body's origin in the system reference frame.
-
-# Units
-
-Position vectors have units of *\[length\]*.
-*/
+/// Locate sites and bodies.
+///
+/// When applied to site properties, [`Position`] describes the location of the site
+/// relative to the origin of the body. In other words, it is the position of the
+/// site in the body reference frame.
+///
+/// When applied to body properties [`Position`] describes the location of the body
+/// relative to the origin of the system coordinate system. In other words, it is
+/// the position of the body's origin in the system reference frame.
+///
+/// # Units
+///
+/// Position vectors have units of *\[length\]*.
 pub trait Position {
     /// Every position is located in this vector space.
     type Vector;
@@ -135,21 +140,20 @@ pub trait Position {
     fn position_mut(&mut self) -> &mut Self::Vector;
 }
 
-/** Rotate sites and bodies.
-
-When applied to site properties, [`Orientation`] describes the rotation from the
-site's local coordinates to the body frame.
-
-When applied to body properties, [`Orientation`] describes the rotation from the
-body frame to the system.
-
-# Units
-
-The units of [`Orientation`] depend on the representation chosen for `R`.
-For example, [`hoomd_vector::Angle`] has units of radians while
-[`hoomd_vector::Versor`] is unitless.
-
-*/
+/// Rotate sites and bodies.
+///
+/// When applied to site properties, [`Orientation`] describes the rotation from the
+/// site's local coordinates to the body frame.
+///
+/// When applied to body properties, [`Orientation`] describes the rotation from the
+/// body frame to the system.
+///
+/// # Units
+///
+/// The units of [`Orientation`] depend on the representation chosen for `R`.
+/// For example, [`hoomd_vector::Angle`] has units of radians while
+/// [`hoomd_vector::Versor`] is unitless.
+///
 pub trait Orientation {
     /// Type that can express the orientation of a body or site.
     type Rotation;

--- a/hoomd-microstate/src/property/oriented_point.rs
+++ b/hoomd-microstate/src/property/oriented_point.rs
@@ -1,27 +1,27 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement Point */
+//! Implement Point
 
 use super::{Orientation, Point, Position};
 use crate::Transform;
 use hoomd_vector::{Rotate, Rotation, Vector};
 
-/** The position and orientation of an extended body.
-
-Use [`OrientedPoint`] as a [`Body`](crate::Body) or [`Site`](crate::Site) property type.
-
-# Example
-
-```
-use hoomd_microstate::property::OrientedPoint;
-use hoomd_vector::{Angle, Cartesian};
-
-let point = OrientedPoint { position: Cartesian::from([1.0, -3.0]),
-    orientation: Angle::from(1.2),
-};
-```
-*/
+/// The position and orientation of an extended body.
+///
+/// Use [`OrientedPoint`] as a [`Body`](crate::Body) or [`Site`](crate::Site) property type.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_microstate::property::OrientedPoint;
+/// use hoomd_vector::{Angle, Cartesian};
+///
+/// let point = OrientedPoint {
+///     position: Cartesian::from([1.0, -3.0]),
+///     orientation: Angle::from(1.2),
+/// };
+/// ```
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct OrientedPoint<V, R> {
     /// The location of the extended body in space.
@@ -30,35 +30,36 @@ pub struct OrientedPoint<V, R> {
     pub orientation: R,
 }
 
-/** Treat [`Point`] sites as constituents of oriented rigid bodies.
- */
+/// Treat [`Point`] sites as constituents of oriented rigid bodies.
 impl<V, R> Transform<Point<V>> for OrientedPoint<V, R>
 where
     V: Vector,
     R: Rotate<V>,
 {
-    /** Move [`Point`] properties from the local body frame to the system frame.
-
-    ```math
-    \vec{r} = \vec{r}_\mathrm{body} + R_\mathrm{body}(\vec{r}_\mathrm{site})
-    ```
-
-    ```
-    use hoomd_vector::{Angle, Cartesian};
-    use hoomd_microstate::{property::{OrientedPoint, Point}, Transform};
-    use std::f64::consts::PI;
-    use approx::assert_relative_eq;
-
-    let body_properties = OrientedPoint {
-        position: Cartesian::from([1.0, -2.0]),
-        orientation: Angle::from(PI / 2.0),
-    };
-    let site_properties = Point::new(Cartesian::from([-1.0, 0.0]));
-
-    let system_site = body_properties.transform(&site_properties);
-    assert_relative_eq!(system_site.position, [1.0, -3.0].into());
-    ```
-    */
+    /// Move [`Point`] properties from the local body frame to the system frame.
+    ///
+    /// ```math
+    /// \vec{r} = \vec{r}_\mathrm{body} + R_\mathrm{body}(\vec{r}_\mathrm{site})
+    /// ```
+    ///
+    /// ```
+    /// use approx::assert_relative_eq;
+    /// use hoomd_microstate::{
+    ///     Transform,
+    ///     property::{OrientedPoint, Point},
+    /// };
+    /// use hoomd_vector::{Angle, Cartesian};
+    /// use std::f64::consts::PI;
+    ///
+    /// let body_properties = OrientedPoint {
+    ///     position: Cartesian::from([1.0, -2.0]),
+    ///     orientation: Angle::from(PI / 2.0),
+    /// };
+    /// let site_properties = Point::new(Cartesian::from([-1.0, 0.0]));
+    ///
+    /// let system_site = body_properties.transform(&site_properties);
+    /// assert_relative_eq!(system_site.position, [1.0, -3.0].into());
+    /// ```
     #[inline]
     fn transform(&self, site_properties: &Point<V>) -> Point<V> {
         Point {
@@ -67,43 +68,40 @@ where
     }
 }
 
-/** Treat [`OrientedPoint`] sites as constituents of oriented rigid bodies.
- */
+/// Treat [`OrientedPoint`] sites as constituents of oriented rigid bodies.
 impl<V, R> Transform<OrientedPoint<V, R>> for OrientedPoint<V, R>
 where
     V: Vector,
     R: Rotate<V> + Rotation,
 {
-    /** Move [`Point`] properties from the local body frame to the system frame.
-
-    ```math
-    \vec{r} = \vec{r}_\mathrm{body} + R_\mathrm{body}(\vec{r}_\mathrm{site})
-    ```
-    ```math
-    R = R_\mathrm{body}(R_\mathrm{site})
-    ```
-
-    ```
-    use hoomd_vector::{Angle, Cartesian};
-    use hoomd_microstate::{Transform, property::OrientedPoint};
-    use std::f64::consts::PI;
-    use approx::assert_relative_eq;
-
-    let body_properties = OrientedPoint {
-        position: Cartesian::from([1.0, -2.0]),
-        orientation: Angle::from(PI / 2.0),
-    };
-    let site_properties = OrientedPoint {
-        position: Cartesian::from([-1.0, 0.0]),
-        orientation: Angle::from(PI / 4.0),
-    };
-
-
-    let system_site = body_properties.transform(&site_properties);
-    assert_relative_eq!(system_site.position, [1.0, -3.0].into());
-    assert_relative_eq!(system_site.orientation.theta, 3.0 * PI / 4.0);
-    ```
-    */
+    /// Move [`Point`] properties from the local body frame to the system frame.
+    ///
+    /// ```math
+    /// \vec{r} = \vec{r}_\mathrm{body} + R_\mathrm{body}(\vec{r}_\mathrm{site})
+    /// ```
+    /// ```math
+    /// R = R_\mathrm{body}(R_\mathrm{site})
+    /// ```
+    ///
+    /// ```
+    /// use approx::assert_relative_eq;
+    /// use hoomd_microstate::{Transform, property::OrientedPoint};
+    /// use hoomd_vector::{Angle, Cartesian};
+    /// use std::f64::consts::PI;
+    ///
+    /// let body_properties = OrientedPoint {
+    ///     position: Cartesian::from([1.0, -2.0]),
+    ///     orientation: Angle::from(PI / 2.0),
+    /// };
+    /// let site_properties = OrientedPoint {
+    ///     position: Cartesian::from([-1.0, 0.0]),
+    ///     orientation: Angle::from(PI / 4.0),
+    /// };
+    ///
+    /// let system_site = body_properties.transform(&site_properties);
+    /// assert_relative_eq!(system_site.position, [1.0, -3.0].into());
+    /// assert_relative_eq!(system_site.orientation.theta, 3.0 * PI / 4.0);
+    /// ```
     #[inline]
     fn transform(&self, site_properties: &OrientedPoint<V, R>) -> OrientedPoint<V, R> {
         OrientedPoint {

--- a/hoomd-microstate/src/property/point.rs
+++ b/hoomd-microstate/src/property/point.rs
@@ -1,25 +1,24 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement Point */
+//! Implement Point
 
 use super::Position;
 use crate::Transform;
 use hoomd_vector::Vector;
 
-/** A position in space and nothing more.
-
-Use [`Point`] as a [`Body`](crate::Body) or [`Site`](crate::Site) property type.
-
-# Example
-
-```
-use hoomd_vector::Cartesian;
-use hoomd_microstate::property::Point;
-
-let point = Point::new(Cartesian::from([1.0, -2.0, 3.0]));
-```
-*/
+/// A position in space and nothing more.
+///
+/// Use [`Point`] as a [`Body`](crate::Body) or [`Site`](crate::Site) property type.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_microstate::property::Point;
+/// use hoomd_vector::Cartesian;
+///
+/// let point = Point::new(Cartesian::from([1.0, -2.0, 3.0]));
+/// ```
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct Point<V> {
     /// The location of the point in space.
@@ -27,17 +26,16 @@ pub struct Point<V> {
 }
 
 impl<V> Point<V> {
-    /** Construct a new point at the given position.
-
-    # Example
-
-    ```
-    use hoomd_vector::Cartesian;
-    use hoomd_microstate::property::Point;
-
-    let point = Point::new(Cartesian::from([1.0, -2.0, 3.0]));
-    ```
-    */
+    /// Construct a new point at the given position.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_microstate::property::Point;
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// let point = Point::new(Cartesian::from([1.0, -2.0, 3.0]));
+    /// ```
     #[inline]
     #[must_use]
     pub fn new(position: V) -> Self {
@@ -45,29 +43,27 @@ impl<V> Point<V> {
     }
 }
 
-/** Move [`Point`] properties from the local body frame to the system frame.
- */
+/// Move [`Point`] properties from the local body frame to the system frame.
 impl<V> Transform<Point<V>> for Point<V>
 where
     V: Vector,
 {
-    /** Points transform by vector addition.
-
-    ```math
-    \vec{r} = \vec{r}_\mathrm{body} + \vec{r}_\mathrm{site}
-    ```
-
-    ```
-    use hoomd_vector::Cartesian;
-    use hoomd_microstate::{property::Point, Transform};
-
-    let body_properties = Point::new(Cartesian::from([1.0, -2.0, 3.0]));
-    let site_properties = Point::new(Cartesian::from([-3.0, 2.0, 1.0]));
-
-    let system_site = body_properties.transform(&site_properties);
-    assert_eq!(system_site.position, [-2.0, 0.0, 4.0].into());
-    ```
-    */
+    /// Points transform by vector addition.
+    ///
+    /// ```math
+    /// \vec{r} = \vec{r}_\mathrm{body} + \vec{r}_\mathrm{site}
+    /// ```
+    ///
+    /// ```
+    /// use hoomd_microstate::{Transform, property::Point};
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// let body_properties = Point::new(Cartesian::from([1.0, -2.0, 3.0]));
+    /// let site_properties = Point::new(Cartesian::from([-3.0, 2.0, 1.0]));
+    ///
+    /// let system_site = body_properties.transform(&site_properties);
+    /// assert_eq!(system_site.position, [-2.0, 0.0, 4.0].into());
+    /// ```
     #[inline]
     fn transform(&self, site_properties: &Point<V>) -> Point<V> {
         Point {

--- a/hoomd-simulation/src/lib.rs
+++ b/hoomd-simulation/src/lib.rs
@@ -8,32 +8,29 @@
     html_logo_url = "https://hoomd-blue.readthedocs.io/en/latest/_static/hoomdblue-logo-favicon.svg"
 )]
 
-/*! Interact with simulations at a high level.
+//! Interact with simulations at a high level.
+//!
+//! `hoomd-simulation` defines the [`Simulation`] trait. Implement it for a type
+//! that holds the simulation parameters, types that implement the simulation
+//! model, and the microstate (or microstates) that it operates on.
+//!
+//! See the tutorials in the documentation for numerous examples.
 
-`hoomd-simulation` defines the [`Simulation`] trait. Implement it for a type
-that holds the simulation parameters, types that implement the simulation
-model, and the microstate (or microstates) that it operates on.
-
-See the tutorials in the documentation for numerous examples.
-*/
-
-/** Store parameters, the model and the microstate(s) it acts on.
-
-A [`Simulation`] type stores the microstate, all model actors, and any
-macrostate parameters in fields. A given [`Simulation`] can be advanced
-forward one step at a time via the `advance` method.
-*/
+/// Store parameters, the model and the microstate(s) it acts on.
+///
+/// A [`Simulation`] type stores the microstate, all model actors, and any
+/// macrostate parameters in fields. A given [`Simulation`] can be advanced
+/// forward one step at a time via the `advance` method.
 pub trait Simulation {
-    /** Advance the simulation forward one step.
-
-    # Errors
-
-    When an error occurs, return an `Err` with any type that implements
-    [`Error`]. The caller will catch the error and
-    display it when exiting.
-
-    [`Error`]: std::error::Error
-    */
+    /// Advance the simulation forward one step.
+    ///
+    /// # Errors
+    ///
+    /// When an error occurs, return an `Err` with any type that implements
+    /// [`Error`]. The caller will catch the error and
+    /// display it when exiting.
+    ///
+    /// [`Error`]: std::error::Error
     fn advance(&mut self) -> anyhow::Result<()>;
 
     /// Get the simulation step.

--- a/hoomd-utility/benches/chacha.rs
+++ b/hoomd-utility/benches/chacha.rs
@@ -6,7 +6,7 @@
     reason = "benches don't need public documentation"
 )]
 
-/*! Benchmark `ChaCha` implementations */
+//! Benchmark `ChaCha` implementations
 
 use divan::{self, Bencher, black_box, counter::ItemsCount};
 use rand::{Rng, SeedableRng};

--- a/hoomd-utility/src/lib.rs
+++ b/hoomd-utility/src/lib.rs
@@ -8,10 +8,9 @@
     html_logo_url = "https://hoomd-blue.readthedocs.io/en/latest/_static/hoomdblue-logo-favicon.svg"
 )]
 
-/*! Utilities
-
-Common utility code used by many other hoomd-rs crates.
-*/
+//! Utilities
+//!
+//! Common utility code used by many other hoomd-rs crates.
 
 pub mod random;
 pub mod valid;

--- a/hoomd-utility/src/random.rs
+++ b/hoomd-utility/src/random.rs
@@ -1,66 +1,63 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Helpers that enable consistent use of random numbers througought hoomd-rs.
- */
+//! Helpers that enable consistent use of random numbers througought hoomd-rs.
 
 use chacha20::ChaCha8Rng;
 use rand::{Rng, SeedableRng};
 
-/** Conveniently construct counter based random number generators.
-
-    Counter based random number generators produce a stream of random numbers
-    that is a reproducible function of a counter value. They are efficient to
-    use, even when only one or a few random numbers are needed. [`Counter`]
-    allows callers to conveniently construct RNGS that are independent, as well
-    as ones that produce identical values.
-
-    There are 3 required elements of each counter.
-    * `step` is the current simulation step and ensures that random number
-      streams are not correlated from one simulation step to the next.
-    * `substep` similarly ensures that different parts of the algorithm that
-      advance the simulation are not correlated within a single step.
-    * `seed` is a value that allows users to execute replicate simulations that
-      are identical except for the random numbers applied.
-
-    There are two optional indices. Generally, many simulation algorithms will
-    set these to particle indices so that RNG streams are independent from one
-    particle (or pair of particles) to the next. To generate the same random
-    numbers (e.g. for use in a DPD thermostat) in independent threads, set the
-    first index to `min(i,j)` and the second to `max(i,j)`.
-
-    There are also three general purpose counters. Simulation algorithms can
-    use these as needed when many independent streams are needed per particle,
-    per substep.
-
-    # Performance
-
-    The current implementation uses `ChaCha8`. `ChaCha` generates random numbers
-    in 64 word batches. Benchmarks show that `Counter.new(...).make_rng()`
-    and sampling values that fall in the first batch runs at approximately
-    10 million operations per second (run `cargo bench` to see the measured
-    performance on your architecture). This is slow enough that serial
-    algorithms should make ONE random generator and sample from it repeatedly
-    (instead of e.g. making one random generator per particle). Parallel
-    algorithms by necessity must make many different random generators from
-    different counters. Should `ChaCha` prove to be a bottleneck in practice,
-    this implementation may be switched to a more efficient RNG.
-
-    # Example
-
-    ```
-    use hoomd_utility::random::Counter;
-    use rand::Rng;
-
-    # let step = 100_000;
-    # let substep = 10;
-    # let seed = 100;
-    let mut rng = Counter::new(step, substep, seed)
-        .make_rng();
-
-    let r: f64 = rng.random();
-    ```
-*/
+/// Conveniently construct counter based random number generators.
+///
+/// Counter based random number generators produce a stream of random numbers
+/// that is a reproducible function of a counter value. They are efficient to
+/// use, even when only one or a few random numbers are needed. [`Counter`]
+/// allows callers to conveniently construct RNGS that are independent, as well
+/// as ones that produce identical values.
+///
+/// There are 3 required elements of each counter.
+/// `step` is the current simulation step and ensures that random number
+/// streams are not correlated from one simulation step to the next.
+/// `substep` similarly ensures that different parts of the algorithm that
+/// advance the simulation are not correlated within a single step.
+/// `seed` is a value that allows users to execute replicate simulations that
+/// are identical except for the random numbers applied.
+///
+/// There are two optional indices. Generally, many simulation algorithms will
+/// set these to particle indices so that RNG streams are independent from one
+/// particle (or pair of particles) to the next. To generate the same random
+/// numbers (e.g. for use in a DPD thermostat) in independent threads, set the
+/// first index to `min(i,j)` and the second to `max(i,j)`.
+///
+/// There are also three general purpose counters. Simulation algorithms can
+/// use these as needed when many independent streams are needed per particle,
+/// per substep.
+///
+/// # Performance
+///
+/// The current implementation uses `ChaCha8`. `ChaCha` generates random numbers
+/// in 64 word batches. Benchmarks show that `Counter.new(...).make_rng()`
+/// and sampling values that fall in the first batch runs at approximately
+/// 10 million operations per second (run `cargo bench` to see the measured
+/// performance on your architecture). This is slow enough that serial
+/// algorithms should make ONE random generator and sample from it repeatedly
+/// (instead of e.g. making one random generator per particle). Parallel
+/// algorithms by necessity must make many different random generators from
+/// different counters. Should `ChaCha` prove to be a bottleneck in practice,
+/// this implementation may be switched to a more efficient RNG.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_utility::random::Counter;
+/// use rand::Rng;
+///
+/// # let step = 100_000;
+/// # let substep = 10;
+/// # let seed = 100;
+/// let mut rng = Counter::new(step, substep, seed).make_rng();
+///
+/// let r: f64 = rng.random();
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[expect(
     clippy::struct_field_names,
@@ -86,21 +83,20 @@ pub struct Counter {
 }
 
 impl Counter {
-    /** Construct a new counter.
-
-    On constructions, all indices and counters default to 0.
-
-    # Example
-
-    ```
-    use hoomd_utility::random::Counter;
-
-    # let step = 100_000;
-    # let substep = 10;
-    # let seed = 100;
-    let counter = Counter::new(step, substep, seed);
-    ```
-    */
+    /// Construct a new counter.
+    ///
+    /// On constructions, all indices and counters default to 0.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_utility::random::Counter;
+    ///
+    /// # let step = 100_000;
+    /// # let substep = 10;
+    /// # let seed = 100;
+    /// let counter = Counter::new(step, substep, seed);
+    /// ```
     #[must_use]
     #[inline]
     pub fn new(step: u64, substep: u32, seed: u32) -> Self {
@@ -116,25 +112,23 @@ impl Counter {
         }
     }
 
-    /** Set indices.
-
-    There are only 2 indices. Calling `indices` (or [`index`](Self::index)) more
-    than once will overwrite existing values.
-
-    # Example
-
-    ```
-    use hoomd_utility::random::Counter;
-
-    # let step = 100_000;
-    # let substep = 10;
-    # let seed = 100;
-    # let i = 12;
-    # let j = 152;
-    let counter = Counter::new(step, substep, seed)
-        .indices(i.max(j), i.min(j));
-    ```
-    */
+    /// Set indices.
+    ///
+    /// There are only 2 indices. Calling `indices` (or [`index`](Self::index)) more
+    /// than once will overwrite existing values.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_utility::random::Counter;
+    ///
+    /// # let step = 100_000;
+    /// # let substep = 10;
+    /// # let seed = 100;
+    /// # let i = 12;
+    /// # let j = 152;
+    /// let counter = Counter::new(step, substep, seed).indices(i.max(j), i.min(j));
+    /// ```
     #[must_use]
     #[inline]
     pub fn indices(&mut self, a: u64, b: u64) -> &mut Self {
@@ -143,23 +137,21 @@ impl Counter {
         self
     }
 
-    /** Set one index.
-
-    Equivalent to `indices(a, 0)`.
-
-    # Example
-
-    ```
-    use hoomd_utility::random::Counter;
-
-    # let step = 100_000;
-    # let substep = 10;
-    # let seed = 100;
-    # let i = 12;
-    let counter = Counter::new(step, substep, seed)
-        .index(i);
-    ```
-    */
+    /// Set one index.
+    ///
+    /// Equivalent to `indices(a, 0)`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_utility::random::Counter;
+    ///
+    /// # let step = 100_000;
+    /// # let substep = 10;
+    /// # let seed = 100;
+    /// # let i = 12;
+    /// let counter = Counter::new(step, substep, seed).index(i);
+    /// ```
     #[must_use]
     #[inline]
     pub fn index(&mut self, a: u64) -> &mut Self {
@@ -167,26 +159,24 @@ impl Counter {
         self
     }
 
-    /** Set counters.
-
-    There are only 3 counters. Calling `counters` (or
-    [`counter`](Self::counter)) more than once will overwrite existing values.
-
-    # Example
-
-    ```
-    use hoomd_utility::random::Counter;
-
-    # let step = 100_000;
-    # let substep = 10;
-    # let seed = 100;
-    # let a = 12;
-    # let b = 54;
-    # let c = 62;
-    let counter = Counter::new(step, substep, seed)
-        .counters(a, b, c);
-    ```
-    */
+    /// Set counters.
+    ///
+    /// There are only 3 counters. Calling `counters` (or
+    /// [`counter`](Self::counter)) more than once will overwrite existing values.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_utility::random::Counter;
+    ///
+    /// # let step = 100_000;
+    /// # let substep = 10;
+    /// # let seed = 100;
+    /// # let a = 12;
+    /// # let b = 54;
+    /// # let c = 62;
+    /// let counter = Counter::new(step, substep, seed).counters(a, b, c);
+    /// ```
     #[must_use]
     #[inline]
     pub fn counters(&mut self, a: u32, b: u32, c: u32) -> &mut Self {
@@ -196,22 +186,20 @@ impl Counter {
         self
     }
 
-    /** Set one counter.
-
-    Equivalent to `counters(a, 0, 0)`.
-
-    # Example
-
-    ```
-    use hoomd_utility::random::Counter;
-
-    # let step = 100_000;
-    # let substep = 10;
-    # let seed = 100;
-    let counter = Counter::new(step, substep, seed)
-        .counter(1);
-    ```
-    */
+    /// Set one counter.
+    ///
+    /// Equivalent to `counters(a, 0, 0)`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_utility::random::Counter;
+    ///
+    /// # let step = 100_000;
+    /// # let substep = 10;
+    /// # let seed = 100;
+    /// let counter = Counter::new(step, substep, seed).counter(1);
+    /// ```
     #[must_use]
     #[inline]
     pub fn counter(&mut self, a: u32) -> &mut Self {
@@ -219,24 +207,22 @@ impl Counter {
         self
     }
 
-    /** Seed a [`Rng`] with the counter.
-
-    # Example
-
-    ```
-    use hoomd_utility::random::Counter;
-    use rand::Rng;
-
-    # let step = 100_000;
-    # let substep = 10;
-    # let seed = 100;
-    let mut rng = Counter::new(step, substep, seed)
-        .make_rng();
-
-    let r: f64 = rng.random();
-    ```
-
-    */
+    /// Seed a [`Rng`] with the counter.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_utility::random::Counter;
+    /// use rand::Rng;
+    ///
+    /// # let step = 100_000;
+    /// # let substep = 10;
+    /// # let seed = 100;
+    /// let mut rng = Counter::new(step, substep, seed).make_rng();
+    ///
+    /// let r: f64 = rng.random();
+    /// ```
+    ///
     #[must_use]
     #[inline]
     pub fn make_rng(&self) -> impl Rng + use<> {

--- a/hoomd-utility/src/random.rs
+++ b/hoomd-utility/src/random.rs
@@ -15,12 +15,12 @@ use rand::{Rng, SeedableRng};
 /// as ones that produce identical values.
 ///
 /// There are 3 required elements of each counter.
-/// `step` is the current simulation step and ensures that random number
-/// streams are not correlated from one simulation step to the next.
-/// `substep` similarly ensures that different parts of the algorithm that
-/// advance the simulation are not correlated within a single step.
-/// `seed` is a value that allows users to execute replicate simulations that
-/// are identical except for the random numbers applied.
+/// * `step` is the current simulation step and ensures that random number
+///   streams are not correlated from one simulation step to the next.
+/// * `substep` similarly ensures that different parts of the algorithm that
+///   advance the simulation are not correlated within a single step.
+/// * `seed` is a value that allows users to execute replicate simulations that
+///   are identical except for the random numbers applied.
 ///
 /// There are two optional indices. Generally, many simulation algorithms will
 /// set these to particle indices so that RNG streams are independent from one

--- a/hoomd-utility/src/random.rs
+++ b/hoomd-utility/src/random.rs
@@ -222,7 +222,6 @@ impl Counter {
     ///
     /// let r: f64 = rng.random();
     /// ```
-    ///
     #[must_use]
     #[inline]
     pub fn make_rng(&self) -> impl Rng + use<> {

--- a/hoomd-utility/src/valid.rs
+++ b/hoomd-utility/src/valid.rs
@@ -1,42 +1,39 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Ensure that values are in well-defined ranges.
- */
+//! Ensure that values are in well-defined ranges.
 
 use crate::Error;
 
-/** A f64 value that is not +/- inf, nan, or a value <= 0.
-
-# Example
-
-```
-use hoomd_utility::valid::PositiveReal;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let positive = PositiveReal::try_from(1.0)?;
-# Ok(())
-# }
-```
-*/
+/// A f64 value that is not +/- inf, nan, or a value <= 0.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_utility::valid::PositiveReal;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let positive = PositiveReal::try_from(1.0)?;
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PositiveReal(f64);
 
 impl PositiveReal {
-    /** Access the value.
-
-    # Example
-
-    ```
-    use hoomd_utility::valid::PositiveReal;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let positive = PositiveReal::try_from(1.0)?;
-
-    assert_eq!(positive.get(), 1.0);
-    # Ok(())
-    # }
-    */
+    /// Access the value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_utility::valid::PositiveReal;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let positive = PositiveReal::try_from(1.0)?;
+    ///
+    /// assert_eq!(positive.get(), 1.0);
+    /// # Ok(())
+    /// # }
     #[must_use]
     #[inline]
     pub fn get(&self) -> f64 {
@@ -47,33 +44,32 @@ impl PositiveReal {
 impl TryFrom<f64> for PositiveReal {
     type Error = Error;
 
-    /** Convert [`f64`] to [`PositiveReal`].
-
-    # Example
-
-    Valid conversion:
-    ```
-    use hoomd_utility::valid::PositiveReal;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let positive = PositiveReal::try_from(1.0)?;
-    # Ok(())
-    # }
-    ```
-
-    Invalid conversion
-    ```
-    use hoomd_utility::valid::PositiveReal;
-
-    let result = PositiveReal::try_from(-1.0);
-    assert!(matches!(result, Err(hoomd_utility::Error::NotPositive(_))));
-    ```
-
-    # Errors
-
-    * `[Error::NotFinite]` when `v` is not finite.
-    * `[Error::NotPositive]` when `v` is not a positive value
-    */
+    /// Convert [`f64`] to [`PositiveReal`].
+    ///
+    /// # Example
+    ///
+    /// Valid conversion:
+    /// ```
+    /// use hoomd_utility::valid::PositiveReal;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let positive = PositiveReal::try_from(1.0)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Invalid conversion
+    /// ```
+    /// use hoomd_utility::valid::PositiveReal;
+    ///
+    /// let result = PositiveReal::try_from(-1.0);
+    /// assert!(matches!(result, Err(hoomd_utility::Error::NotPositive(_))));
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// `[Error::NotFinite]` when `v` is not finite.
+    /// `[Error::NotPositive]` when `v` is not a positive value
     #[inline]
     fn try_from(v: f64) -> Result<PositiveReal, Error> {
         if !v.is_finite() {

--- a/hoomd-vector/benches/angle.rs
+++ b/hoomd-vector/benches/angle.rs
@@ -6,7 +6,7 @@
     reason = "benches don't need public documentation"
 )]
 
-/*! Benchmark Angle */
+//! Benchmark Angle
 
 use divan::{self, Bencher, black_box, counter::ItemsCount};
 use rand::{Rng, SeedableRng, rngs::StdRng};

--- a/hoomd-vector/benches/cartesian.rs
+++ b/hoomd-vector/benches/cartesian.rs
@@ -10,7 +10,7 @@
     reason = "benches can use expect without individual reasons"
 )]
 
-/*! Benchmark Cartesian */
+//! Benchmark Cartesian
 
 use divan::{self, Bencher, black_box, counter::ItemsCount};
 use rand::{Rng, SeedableRng, distr::Uniform, rngs::StdRng};

--- a/hoomd-vector/benches/quaternion.rs
+++ b/hoomd-vector/benches/quaternion.rs
@@ -6,7 +6,7 @@
     reason = "benches don't need public documentation"
 )]
 
-/*! Benchmark Quaternion */
+//! Benchmark Quaternion
 
 use divan::{self, Bencher, black_box, counter::ItemsCount};
 use rand::{Rng, SeedableRng, rngs::StdRng};

--- a/hoomd-vector/src/angle.rs
+++ b/hoomd-vector/src/angle.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement [`Angle`]
- */
+//! Implement [`Angle`]
 
 use rand::{
     Rng,
@@ -12,67 +11,66 @@ use std::{f64::consts::PI, fmt};
 
 use crate::{Cartesian, Rotate, Rotation, RotationMatrix};
 
-/** Rotation in the plane.
-
-The rotation is represented by an angle `theta` in radians. Positive values rotate
-counter-clockwise.
-
-## Constructing [`Angle`]
-
-The default Angle rotates by 0 radians:
-
-```
-use hoomd_vector::Angle;
-
-let a = Angle::default();
-assert_eq!(a.theta, 0.0)
-```
-
-Create an [`Angle`] with a given value:
-```
-use hoomd_vector::Angle;
-use std::f64::consts::PI;
-
-let a = Angle::from(PI / 2.0);
-assert_eq!(a.theta, PI / 2.0);
-```
-
-Create a random [`Angle`] from the uniform distribution over all rotations:
-```
-use hoomd_vector::Angle;
-use rand::{rngs::StdRng, Rng, SeedableRng};
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut rng = StdRng::seed_from_u64(1);
-let a: Angle = rng.random();
-# Ok(())
-# }
-```
-
-## Operations using [`Angle`]
-
-Rotate a [`Cartesian<2>`] vector by an [`Angle`]:
-```
-use hoomd_vector::{Angle, Rotate, Rotation, Cartesian};
-use std::f64::consts::PI;
-
-let v = Cartesian::from([-1.0, 0.0]);
-let a = Angle::from(PI / 2.0);
-let rotated = a.rotate(&v);
-// rotated is approximately [0.0, -1.0]
-```
-
-Combine two rotations together:
-```
-use hoomd_vector::{Angle, Rotation};
-use std::f64::consts::PI;
-
-let a = Angle::from(PI / 2.0);
-let b = Angle::from(-PI / 4.0);
-let c = a.combine(&b);
-assert_eq!(c.theta, PI / 4.0);
-```
-*/
+/// Rotation in the plane.
+///
+/// The rotation is represented by an angle `theta` in radians. Positive values rotate
+/// counter-clockwise.
+///
+/// ## Constructing [`Angle`]
+///
+/// The default Angle rotates by 0 radians:
+///
+/// ```
+/// use hoomd_vector::Angle;
+///
+/// let a = Angle::default();
+/// assert_eq!(a.theta, 0.0)
+/// ```
+///
+/// Create an [`Angle`] with a given value:
+/// ```
+/// use hoomd_vector::Angle;
+/// use std::f64::consts::PI;
+///
+/// let a = Angle::from(PI / 2.0);
+/// assert_eq!(a.theta, PI / 2.0);
+/// ```
+///
+/// Create a random [`Angle`] from the uniform distribution over all rotations:
+/// ```
+/// use hoomd_vector::Angle;
+/// use rand::{Rng, SeedableRng, rngs::StdRng};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut rng = StdRng::seed_from_u64(1);
+/// let a: Angle = rng.random();
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ## Operations using [`Angle`]
+///
+/// Rotate a [`Cartesian<2>`] vector by an [`Angle`]:
+/// ```
+/// use hoomd_vector::{Angle, Rotate, Rotation, Cartesian};
+/// use std::f64::consts::PI;
+///
+/// let v = Cartesian::from([-1.0, 0.0]);
+/// let a = Angle::from(PI / 2.0);
+/// let rotated = a.rotate(&v);
+/// rotated is approximately [0.0, -1.0]
+/// ```
+///
+/// Combine two rotations together:
+/// ```
+/// use hoomd_vector::{Angle, Rotation};
+/// use std::f64::consts::PI;
+///
+/// let a = Angle::from(PI / 2.0);
+/// let b = Angle::from(-PI / 4.0);
+/// let c = a.combine(&b);
+/// assert_eq!(c.theta, PI / 4.0);
+/// ```
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct Angle {
     /// Rotation angle (radians).
@@ -80,23 +78,22 @@ pub struct Angle {
 }
 
 impl Angle {
-    /** Reduce the rotation.
-
-    [`Angle`] rotations are well-defined for any value of `theta`. However, combining small
-    rotations with large ones will introduce floating point round-off error. Reducing an [`Angle`]
-    creates an equivalent rotation with `theta` in the range from 0 to 2 pi.
-
-    # Example
-
-    ```
-    use hoomd_vector::Angle;
-    use std::f64::consts::PI;
-
-    let a = Angle::from(20.0 * PI);
-    let b = a.to_reduced();
-    assert_eq!(b.theta, 0.0)
-    ```
-    */
+    /// Reduce the rotation.
+    ///
+    /// [`Angle`] rotations are well-defined for any value of `theta`. However, combining small
+    /// rotations with large ones will introduce floating point round-off error. Reducing an [`Angle`]
+    /// creates an equivalent rotation with `theta` in the range from 0 to 2 pi.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_vector::Angle;
+    /// use std::f64::consts::PI;
+    ///
+    /// let a = Angle::from(20.0 * PI);
+    /// let b = a.to_reduced();
+    /// assert_eq!(b.theta, 0.0)
+    /// ```
     #[inline]
     #[must_use]
     pub fn to_reduced(self) -> Self {
@@ -107,24 +104,23 @@ impl Angle {
 }
 
 impl From<Angle> for RotationMatrix<2> {
-    /** Construct a rotation matrix equivalent to this angle's rotation.
-
-    When rotating many vectors by the same [`Angle`], improve performance
-    by converting to a matrix first and applying that matrix to the vectors.
-
-    # Example
-    ```
-    use hoomd_vector::{Angle, Rotate, RotationMatrix, Cartesian};
-    use std::f64::consts::PI;
-
-    let v = Cartesian::from([-1.0, 0.0]);
-    let a = Angle::from(PI / 2.0);
-
-    let matrix = RotationMatrix::from(a);
-    let rotated = matrix.rotate(&v);
-    // rotated is approximately [0.0, -1.0]
-    ```
-    */
+    /// Construct a rotation matrix equivalent to this angle's rotation.
+    ///
+    /// When rotating many vectors by the same [`Angle`], improve performance
+    /// by converting to a matrix first and applying that matrix to the vectors.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Angle, Rotate, RotationMatrix, Cartesian};
+    /// use std::f64::consts::PI;
+    ///
+    /// let v = Cartesian::from([-1.0, 0.0]);
+    /// let a = Angle::from(PI / 2.0);
+    ///
+    /// let matrix = RotationMatrix::from(a);
+    /// let rotated = matrix.rotate(&v);
+    /// rotated is approximately [0.0, -1.0]
+    /// ```
     #[inline]
     fn from(angle: Angle) -> RotationMatrix<2> {
         let sin_theta = angle.theta.sin();
@@ -139,16 +135,15 @@ impl From<Angle> for RotationMatrix<2> {
 }
 
 impl From<f64> for Angle {
-    /** Create a rotation by `theta` radians.
-
-    # Example
-    ```
-    use hoomd_vector::Angle;
-
-    let a = Angle::from(1.5);
-    assert_eq!(a.theta, 1.5);
-    ```
-    */
+    /// Create a rotation by `theta` radians.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::Angle;
+    ///
+    /// let a = Angle::from(1.5);
+    /// assert_eq!(a.theta, 1.5);
+    /// ```
     #[inline]
     fn from(theta: f64) -> Self {
         Self { theta }
@@ -159,19 +154,18 @@ impl Rotate<Cartesian<2>> for Angle {
     type Matrix = RotationMatrix<2>;
 
     #[inline]
-    /** Rotate a [`Cartesian<2>`] in the plane by an [`Angle`]
-
-    # Example
-    ```
-    use hoomd_vector::{Angle, Rotate, Rotation, Cartesian};
-    use std::f64::consts::PI;
-
-    let v = Cartesian::from([-1.0, 0.0]);
-    let a = Angle::from(PI / 2.0);
-    let rotated = a.rotate(&v);
-    // rotated is approximately [0.0, -1.0]
-    ```
-    */
+    /// Rotate a [`Cartesian<2>`] in the plane by an [`Angle`]
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Angle, Rotate, Rotation, Cartesian};
+    /// use std::f64::consts::PI;
+    ///
+    /// let v = Cartesian::from([-1.0, 0.0]);
+    /// let a = Angle::from(PI / 2.0);
+    /// let rotated = a.rotate(&v);
+    /// rotated is approximately [0.0, -1.0]
+    /// ```
     fn rotate(&self, vector: &Cartesian<2>) -> Cartesian<2> {
         let sin_theta = self.theta.sin();
         let cos_theta = self.theta.cos();
@@ -184,51 +178,48 @@ impl Rotate<Cartesian<2>> for Angle {
 
 impl Rotation for Angle {
     #[inline]
-    /** Create an [`Angle`] that rotates by 0 radians.
-
-    # Example
-    ```
-    use hoomd_vector::{Angle, Rotation};
-
-    let a = Angle::default();
-    assert_eq!(a.theta, 0.0);
-    ```
-    */
+    /// Create an [`Angle`] that rotates by 0 radians.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Angle, Rotation};
+    ///
+    /// let a = Angle::default();
+    /// assert_eq!(a.theta, 0.0);
+    /// ```
     fn identity() -> Self {
         Self::default()
     }
 
     #[inline]
-    /** Create an [`Angle`] that rotates by the same amount in the opposite direction.
-
-    # Example
-    ```
-    use hoomd_vector::{Angle, Rotation};
-    use std::f64::consts::PI;
-
-    let a = Angle::from(PI / 3.0);
-    let b = a.inverted();
-    assert_eq!(b.theta, -PI / 3.0);
-    ```
-    */
+    /// Create an [`Angle`] that rotates by the same amount in the opposite direction.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Angle, Rotation};
+    /// use std::f64::consts::PI;
+    ///
+    /// let a = Angle::from(PI / 3.0);
+    /// let b = a.inverted();
+    /// assert_eq!(b.theta, -PI / 3.0);
+    /// ```
     fn inverted(self) -> Self {
         Self::from(-self.theta)
     }
 
     #[inline]
-    /** Create an [`Angle`] that rotates by the sum of the two angles.
-
-    # Example
-    ```
-    use hoomd_vector::{Angle, Rotation};
-    use std::f64::consts::PI;
-
-    let a = Angle::from(PI / 2.0);
-    let b = Angle::from(-PI / 4.0);
-    let c = a.combine(&b);
-    assert_eq!(c.theta, PI / 4.0);
-    ```
-    */
+    /// Create an [`Angle`] that rotates by the sum of the two angles.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Angle, Rotation};
+    /// use std::f64::consts::PI;
+    ///
+    /// let a = Angle::from(PI / 2.0);
+    /// let b = Angle::from(-PI / 4.0);
+    /// let c = a.combine(&b);
+    /// assert_eq!(c.theta, PI / 4.0);
+    /// ```
     fn combine(&self, other: &Self) -> Self {
         Self::from(self.theta + other.theta)
     }
@@ -243,21 +234,20 @@ impl fmt::Display for Angle {
 }
 
 impl Distribution<Angle> for StandardUniform {
-    /** Sample a random angle from the uniform distribution over all rotations.
-
-    # Example
-
-    ```
-    use hoomd_vector::Angle;
-    use rand::{rngs::StdRng, Rng, SeedableRng};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = StdRng::seed_from_u64(1);
-    let v: Angle = rng.random();
-    # Ok(())
-    # }
-    ```
-    */
+    /// Sample a random angle from the uniform distribution over all rotations.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_vector::Angle;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut rng = StdRng::seed_from_u64(1);
+    /// let v: Angle = rng.random();
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Angle {
         #[expect(

--- a/hoomd-vector/src/angle.rs
+++ b/hoomd-vector/src/angle.rs
@@ -52,9 +52,9 @@ use crate::{Cartesian, Rotate, Rotation, RotationMatrix};
 ///
 /// Rotate a [`Cartesian<2>`] vector by an [`Angle`]:
 /// ```
-/// use hoomd_vector::{Angle, Rotate, Rotation, Cartesian};
-/// use std::f64::consts::PI;
 /// use ::approx::assert_relative_eq;
+/// use hoomd_vector::{Angle, Cartesian, Rotate, Rotation};
+/// use std::f64::consts::PI;
 ///
 /// let v = Cartesian::from([-1.0, 0.0]);
 /// let a = Angle::from(PI / 2.0);
@@ -112,9 +112,9 @@ impl From<Angle> for RotationMatrix<2> {
     ///
     /// # Example
     /// ```
-    /// use hoomd_vector::{Angle, Rotate, RotationMatrix, Cartesian};
-    /// use std::f64::consts::PI;
     /// use ::approx::assert_relative_eq;
+    /// use hoomd_vector::{Angle, Cartesian, Rotate, RotationMatrix};
+    /// use std::f64::consts::PI;
     ///
     /// let v = Cartesian::from([-1.0, 0.0]);
     /// let a = Angle::from(PI / 2.0);
@@ -160,9 +160,9 @@ impl Rotate<Cartesian<2>> for Angle {
     ///
     /// # Example
     /// ```
-    /// use hoomd_vector::{Angle, Rotate, Rotation, Cartesian};
-    /// use std::f64::consts::PI;
     /// use ::approx::assert_relative_eq;
+    /// use hoomd_vector::{Angle, Cartesian, Rotate, Rotation};
+    /// use std::f64::consts::PI;
     ///
     /// let v = Cartesian::from([-1.0, 0.0]);
     /// let a = Angle::from(PI / 2.0);

--- a/hoomd-vector/src/angle.rs
+++ b/hoomd-vector/src/angle.rs
@@ -54,11 +54,12 @@ use crate::{Cartesian, Rotate, Rotation, RotationMatrix};
 /// ```
 /// use hoomd_vector::{Angle, Rotate, Rotation, Cartesian};
 /// use std::f64::consts::PI;
+/// use ::approx::assert_relative_eq;
 ///
 /// let v = Cartesian::from([-1.0, 0.0]);
 /// let a = Angle::from(PI / 2.0);
 /// let rotated = a.rotate(&v);
-/// rotated is approximately [0.0, -1.0]
+/// assert_relative_eq!(rotated, [0.0, -1.0].into())
 /// ```
 ///
 /// Combine two rotations together:
@@ -113,13 +114,14 @@ impl From<Angle> for RotationMatrix<2> {
     /// ```
     /// use hoomd_vector::{Angle, Rotate, RotationMatrix, Cartesian};
     /// use std::f64::consts::PI;
+    /// use ::approx::assert_relative_eq;
     ///
     /// let v = Cartesian::from([-1.0, 0.0]);
     /// let a = Angle::from(PI / 2.0);
     ///
     /// let matrix = RotationMatrix::from(a);
     /// let rotated = matrix.rotate(&v);
-    /// rotated is approximately [0.0, -1.0]
+    /// assert_relative_eq!(rotated, [0.0, -1.0].into());
     /// ```
     #[inline]
     fn from(angle: Angle) -> RotationMatrix<2> {
@@ -160,11 +162,12 @@ impl Rotate<Cartesian<2>> for Angle {
     /// ```
     /// use hoomd_vector::{Angle, Rotate, Rotation, Cartesian};
     /// use std::f64::consts::PI;
+    /// use ::approx::assert_relative_eq;
     ///
     /// let v = Cartesian::from([-1.0, 0.0]);
     /// let a = Angle::from(PI / 2.0);
     /// let rotated = a.rotate(&v);
-    /// rotated is approximately [0.0, -1.0]
+    /// assert_relative_eq!(rotated, [0.0, -1.0].into());
     /// ```
     fn rotate(&self, vector: &Cartesian<2>) -> Cartesian<2> {
         let sin_theta = self.theta.sin();

--- a/hoomd-vector/src/approx.rs
+++ b/hoomd-vector/src/approx.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement approximate comparisons for vector and rotation types
- */
+//! Implement approximate comparisons for vector and rotation types
 
 use crate::{Cartesian, Quaternion, Versor};
 

--- a/hoomd-vector/src/cartesian.rs
+++ b/hoomd-vector/src/cartesian.rs
@@ -641,9 +641,9 @@ impl<const N: usize> Rotate<Cartesian<N>> for RotationMatrix<N> {
     ///
     /// # Examples
     /// ```
-    /// use hoomd_vector::{Angle, Rotate, RotationMatrix, Cartesian};
-    /// use std::f64::consts::PI;
     /// use ::approx::assert_relative_eq;
+    /// use hoomd_vector::{Angle, Cartesian, Rotate, RotationMatrix};
+    /// use std::f64::consts::PI;
     ///
     /// let v = Cartesian::from([-1.0, 0.0]);
     /// let a = Angle::from(PI / 2.0);
@@ -654,9 +654,9 @@ impl<const N: usize> Rotate<Cartesian<N>> for RotationMatrix<N> {
     /// ```
     ///
     /// ```
-    /// use hoomd_vector::{Versor, Rotate, RotationMatrix, Cartesian};
-    /// use std::f64::consts::PI;
     /// use ::approx::assert_relative_eq;
+    /// use hoomd_vector::{Cartesian, Rotate, RotationMatrix, Versor};
+    /// use std::f64::consts::PI;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let a = Cartesian::from([-1.0, 0.0, 0.0]);

--- a/hoomd-vector/src/cartesian.rs
+++ b/hoomd-vector/src/cartesian.rs
@@ -531,8 +531,8 @@ impl<const N: usize> Sum for Cartesian<N> {
 /// Construct a [`RotationMatrix`] to efficiently rotate many vectors by the same rotation.
 ///
 /// See:
-/// [`RotationMatrix::from<Angle>`]
-/// [`RotationMatrix::from<Versor>`]
+/// * [`RotationMatrix::from<Angle>`]
+/// * [`RotationMatrix::from<Versor>`]
 ///
 /// [`RotationMatrix`] _intentionally_ does not implement [`Rotation`](crate::Rotation).
 /// [`Angle`](crate::Angle) and [`Versor`](crate::Versor) are representations of
@@ -643,18 +643,20 @@ impl<const N: usize> Rotate<Cartesian<N>> for RotationMatrix<N> {
     /// ```
     /// use hoomd_vector::{Angle, Rotate, RotationMatrix, Cartesian};
     /// use std::f64::consts::PI;
+    /// use ::approx::assert_relative_eq;
     ///
     /// let v = Cartesian::from([-1.0, 0.0]);
     /// let a = Angle::from(PI / 2.0);
     ///
     /// let matrix = RotationMatrix::from(a);
     /// let rotated = matrix.rotate(&v);
-    /// rotated is approximately [0.0, -1.0]
+    /// assert_relative_eq!(rotated, [0.0, -1.0].into());
     /// ```
     ///
     /// ```
     /// use hoomd_vector::{Versor, Rotate, RotationMatrix, Cartesian};
     /// use std::f64::consts::PI;
+    /// use ::approx::assert_relative_eq;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let a = Cartesian::from([-1.0, 0.0, 0.0]);
@@ -662,7 +664,7 @@ impl<const N: usize> Rotate<Cartesian<N>> for RotationMatrix<N> {
     ///
     /// let matrix = RotationMatrix::from(v);
     /// let b = matrix.rotate(&a);
-    /// b is approximately [0.0, -1.0, 0.0]
+    /// assert_relative_eq!(b, [0.0, -1.0, 0.0].into());
     /// # Ok(())
     /// # }
     /// ```

--- a/hoomd-vector/src/cartesian.rs
+++ b/hoomd-vector/src/cartesian.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement canonical vector types.
- */
+//! Implement canonical vector types.
 use std::{
     array, fmt,
     iter::{Sum, zip},
@@ -16,76 +15,76 @@ use rand::{
 
 use crate::{Cross, Error, InnerProduct, Rotate, Unit, Vector};
 
-/** A [`Vector`] represented by `N` `f64` coordinates.
-
-[`Cartesian`] is the canonical implementation of [`InnerProduct`].
-
-## Constructing vectors
-
-The default is the 0 vector:
-```
-use hoomd_vector::Cartesian;
-
-let v = Cartesian::<3>::default();
-assert_eq!(v, [0.0; 3].into())
-```
-
-Create a vector with an array of coordinates:
-```
-use hoomd_vector::Cartesian;
-
-let v = Cartesian::from([1.0, 2.0, 3.0, 4.0, 5.0]);
-```
-
-2D and 3D vectors can also be initialized from tuples:
-```
-use hoomd_vector::Cartesian;
-
-let a = Cartesian::from((1.0, 2.0, 3.0));
-let b = Cartesian::from((4.0, 5.0));
-```
-
-Construct a random vector in the [-1, 1] hypercube:
-
-```
-use hoomd_vector::Cartesian;
-use rand::{rngs::StdRng, Rng, SeedableRng};
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut rng = StdRng::seed_from_u64(1);
-let v: Cartesian::<3> = rng.random();
-# Ok(())
-# }
-```
-
-## Operating on vectors
-
-Use vector math operations when you can:
-```
-use hoomd_vector::{Cartesian, InnerProduct};
-
-let a = Cartesian::from([1.0, 2.0]);
-let b = Cartesian::from([4.0, 8.0]);
-let c = (a + b).dot(&a);
-```
-
-Access the coordinates directly when needed:
-```
-use hoomd_vector::Cartesian;
-
-let a = Cartesian::from((1.0, 2.0));
-let b = Cartesian::from((a[1], 0.0));
-```
-
-Compute the sum of an iterator over vectors:
-```
-use hoomd_vector::Cartesian;
-
-let total: Cartesian<2> = [Cartesian::from((1.0, 2.0)), Cartesian::from((3.0, 4.0))]
-    .into_iter()
-    .sum();
-```
-*/
+/// A [`Vector`] represented by `N` `f64` coordinates.
+///
+/// [`Cartesian`] is the canonical implementation of [`InnerProduct`].
+///
+/// ## Constructing vectors
+///
+/// The default is the 0 vector:
+/// ```
+/// use hoomd_vector::Cartesian;
+///
+/// let v = Cartesian::<3>::default();
+/// assert_eq!(v, [0.0; 3].into())
+/// ```
+///
+/// Create a vector with an array of coordinates:
+/// ```
+/// use hoomd_vector::Cartesian;
+///
+/// let v = Cartesian::from([1.0, 2.0, 3.0, 4.0, 5.0]);
+/// ```
+///
+/// 2D and 3D vectors can also be initialized from tuples:
+/// ```
+/// use hoomd_vector::Cartesian;
+///
+/// let a = Cartesian::from((1.0, 2.0, 3.0));
+/// let b = Cartesian::from((4.0, 5.0));
+/// ```
+///
+/// Construct a random vector in the [-1, 1] hypercube:
+///
+/// ```
+/// use hoomd_vector::Cartesian;
+/// use rand::{Rng, SeedableRng, rngs::StdRng};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut rng = StdRng::seed_from_u64(1);
+/// let v: Cartesian<3> = rng.random();
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ## Operating on vectors
+///
+/// Use vector math operations when you can:
+/// ```
+/// use hoomd_vector::{Cartesian, InnerProduct};
+///
+/// let a = Cartesian::from([1.0, 2.0]);
+/// let b = Cartesian::from([4.0, 8.0]);
+/// let c = (a + b).dot(&a);
+/// ```
+///
+/// Access the coordinates directly when needed:
+/// ```
+/// use hoomd_vector::Cartesian;
+///
+/// let a = Cartesian::from((1.0, 2.0));
+/// let b = Cartesian::from((a[1], 0.0));
+/// ```
+///
+/// Compute the sum of an iterator over vectors:
+/// ```
+/// use hoomd_vector::Cartesian;
+///
+/// let total: Cartesian<2> =
+///     [Cartesian::from((1.0, 2.0)), Cartesian::from((3.0, 4.0))]
+///         .into_iter()
+///         .sum();
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Cartesian<const N: usize> {
     /// The vector's coordinates.
@@ -93,16 +92,15 @@ pub struct Cartesian<const N: usize> {
 }
 
 impl<const N: usize> Default for Cartesian<N> {
-    /** Create a 0 vector.
-
-    # Example
-    ```
-    use hoomd_vector::Cartesian;
-
-    let v = Cartesian::<3>::default();
-    assert_eq!(v, [0.0; 3].into())
-    ```
-    */
+    /// Create a 0 vector.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// let v = Cartesian::<3>::default();
+    /// assert_eq!(v, [0.0; 3].into())
+    /// ```
     #[inline]
     fn default() -> Self {
         Cartesian::from([0.0; N])
@@ -110,15 +108,14 @@ impl<const N: usize> Default for Cartesian<N> {
 }
 
 impl<const N: usize> From<[f64; N]> for Cartesian<N> {
-    /** Create a Cartesian vector with the given coordinates.
-
-    # Example
-    ```
-    use hoomd_vector::Cartesian;
-
-    let v = Cartesian::from([4.0, 3.0]);
-    ```
-    */
+    /// Create a Cartesian vector with the given coordinates.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// let v = Cartesian::from([4.0, 3.0]);
+    /// ```
     #[inline]
     fn from(coordinates: [f64; N]) -> Self {
         Self { coordinates }
@@ -129,20 +126,19 @@ impl<const N: usize> IntoIterator for Cartesian<N> {
     type Item = f64;
     type IntoIter = <[f64; N] as IntoIterator>::IntoIter;
 
-    /** Iterate over the components of the vector.
-
-    # Example
-    ```
-    use hoomd_vector::Cartesian;
-
-    let a = Cartesian::from([1.0, 2.0]);
-    let mut iter = a.into_iter();
-
-    assert_eq!(iter.next(), Some(1.0));
-    assert_eq!(iter.next(), Some(2.0));
-    assert_eq!(iter.next(), None);
-    ```
-    */
+    /// Iterate over the components of the vector.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// let a = Cartesian::from([1.0, 2.0]);
+    /// let mut iter = a.into_iter();
+    ///
+    /// assert_eq!(iter.next(), Some(1.0));
+    /// assert_eq!(iter.next(), Some(2.0));
+    /// assert_eq!(iter.next(), None);
+    /// ```
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.coordinates.into_iter()
@@ -170,25 +166,24 @@ impl From<(f64, f64, f64)> for Cartesian<3> {
 impl<const N: usize> TryFrom<Vec<f64>> for Cartesian<N> {
     type Error = Error;
 
-    /** Create a Cartesian vector with coordinates given by a [`Vec<f64>`]
-
-    # Example
-    ```
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let v = Cartesian::<3>::try_from(vec![3.0, 4.0, 5.0])?;
-    assert_eq!(v, [3.0, 4.0, 5.0].into());
-    # Ok(())
-    # }
-    ```
-    <div class="warning">
-
-    This method deallocates the Vec after copying it.
-    Use `Cartesian::From<[f64; N]>` in performance critical code.
-
-    </div>
-    */
+    /// Create a Cartesian vector with coordinates given by a [`Vec<f64>`]
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let v = Cartesian::<3>::try_from(vec![3.0, 4.0, 5.0])?;
+    /// assert_eq!(v, [3.0, 4.0, 5.0].into());
+    /// # Ok(())
+    /// # }
+    /// ```
+    /// <div class="warning">
+    ///
+    /// This method deallocates the Vec after copying it.
+    /// Use `Cartesian::From<[f64; N]>` in performance critical code.
+    ///
+    /// </div>
     #[inline]
     fn try_from(value: Vec<f64>) -> Result<Self, Self::Error> {
         let coordinates = value.try_into().map_err(|_| Error::InvalidVectorLength)?;
@@ -199,19 +194,18 @@ impl<const N: usize> TryFrom<Vec<f64>> for Cartesian<N> {
 impl<const N: usize> TryFrom<std::ops::Range<usize>> for Cartesian<N> {
     type Error = Error;
 
-    /** Create a Cartesian vector with coordinates given by a range.
-
-    # Example
-    ```
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let v = Cartesian::<3>::try_from(3..6)?;
-    assert_eq!(v, [3.0, 4.0, 5.0].into());
-    # Ok(())
-    # }
-    ```
-    */
+    /// Create a Cartesian vector with coordinates given by a range.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let v = Cartesian::<3>::try_from(3..6)?;
+    /// assert_eq!(v, [3.0, 4.0, 5.0].into());
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn try_from(value: std::ops::Range<usize>) -> Result<Self, Self::Error> {
         if value.len() != N {
@@ -226,19 +220,18 @@ impl<const N: usize> TryFrom<std::ops::Range<usize>> for Cartesian<N> {
 impl<const N: usize> TryFrom<[f64; N]> for Unit<Cartesian<N>> {
     type Error = Error;
 
-    /** Create a unit Cartesian vector by normalizing the given coordinates.
-
-    # Example
-    ```
-    use hoomd_vector::{Unit, Cartesian};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let n = Unit::<Cartesian<3>>::try_from([2.0, 0.0, 0.0])?;
-    assert_eq!(*n.get(), [1.0, 0.0, 0.0].into());
-    # Ok(())
-    # }
-    ```
-    */
+    /// Create a unit Cartesian vector by normalizing the given coordinates.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Cartesian, Unit};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let n = Unit::<Cartesian<3>>::try_from([2.0, 0.0, 0.0])?;
+    /// assert_eq!(*n.get(), [1.0, 0.0, 0.0].into());
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn try_from(value: [f64; N]) -> Result<Self, Self::Error> {
         Cartesian::from(value).to_unit().map(|t| t.0)
@@ -252,21 +245,20 @@ impl<const N: usize> InnerProduct for Cartesian<N> {
             .fold(0.0, |product, (&x, &y)| x.mul_add(y, product))
     }
 
-    /** Create a unit vector in the space.
-
-    The default unit vector in Cartesian space is `[0.0, 0.0, ...., 1.0]`.
-
-    # Example
-    ```
-    use hoomd_vector::{Cartesian, InnerProduct};
-
-    let u = Cartesian::<2>::default_unit();
-    assert_eq!(*u.get(), [0.0, 1.0].into());
-
-    let u = Cartesian::<3>::default_unit();
-    assert_eq!(*u.get(), [0.0, 0.0, 1.0].into());
-    ```
-    */
+    /// Create a unit vector in the space.
+    ///
+    /// The default unit vector in Cartesian space is `[0.0, 0.0, ...., 1.0]`.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Cartesian, InnerProduct};
+    ///
+    /// let u = Cartesian::<2>::default_unit();
+    /// assert_eq!(*u.get(), [0.0, 1.0].into());
+    ///
+    /// let u = Cartesian::<3>::default_unit();
+    /// assert_eq!(*u.get(), [0.0, 0.0, 1.0].into());
+    /// ```
     #[inline]
     fn default_unit() -> Unit<Self> {
         assert!(N >= 1);
@@ -277,23 +269,22 @@ impl<const N: usize> InnerProduct for Cartesian<N> {
 }
 
 impl<const N: usize> Vector for Cartesian<N> {
-    /** Computes the squared distance between two points in Euclidean space.
-    ```math
-    d^2(\vec{x},\vec{y}) = \sum_{i=1}^{N} (x_i - y_i)^2
-    ```
-
-    # Example
-    ```
-    use hoomd_vector::{Cartesian, Vector};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let x = Cartesian::from([0.0, 1.0, 1.0]);
-    let y = Cartesian::from([1.0, 0.0, 0.0]);
-    assert_eq!(3.0, x.distance_squared(&y));
-    # Ok(())
-    # }
-    ```
-    */
+    /// Computes the squared distance between two points in Euclidean space.
+    /// ```math
+    /// d^2(\vec{x},\vec{y}) = \sum_{i=1}^{N} (x_i - y_i)^2
+    /// ```
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Cartesian, Vector};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let x = Cartesian::from([0.0, 1.0, 1.0]);
+    /// let y = Cartesian::from([1.0, 0.0, 0.0]);
+    /// assert_eq!(3.0, x.distance_squared(&y));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn distance_squared(&self, other: &Self) -> f64 {
         zip(self.coordinates.iter(), other.coordinates.iter())
@@ -425,23 +416,22 @@ impl Cross for Cartesian<3> {
 }
 
 impl<const N: usize> Distribution<Cartesian<N>> for StandardUniform {
-    /** Sample a Cartesian vector from the uniform [-1, 1] hypercube.
-
-    Each coordinate in the vector is in the closed range [-1, 1].
-
-    # Example
-
-    ```
-    use hoomd_vector::Cartesian;
-    use rand::{rngs::StdRng, Rng, SeedableRng};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = StdRng::seed_from_u64(1);
-    let v: Cartesian::<3> = rng.random();
-    # Ok(())
-    # }
-    ```
-    */
+    /// Sample a Cartesian vector from the uniform [-1, 1] hypercube.
+    ///
+    /// Each coordinate in the vector is in the closed range [-1, 1].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_vector::Cartesian;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut rng = StdRng::seed_from_u64(1);
+    /// let v: Cartesian<3> = rng.random();
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Cartesian<N> {
         #[expect(
@@ -461,19 +451,18 @@ where
     T: Into<usize> + std::slice::SliceIndex<[f64], Output = f64>,
 {
     type Output = f64;
-    /** Get the value of the vector at coordinate i.
-
-    # Example
-    ```
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let v = Cartesian::<3>::try_from(3..6)?;
-    assert_eq!((v[0], v[1], v[2]), (3.0, 4.0, 5.0));
-    # Ok(())
-    # }
-    ```
-    */
+    /// Get the value of the vector at coordinate i.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let v = Cartesian::<3>::try_from(3..6)?;
+    /// assert_eq!((v[0], v[1], v[2]), (3.0, 4.0, 5.0));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn index(&self, index: T) -> &Self::Output {
         &self.coordinates[index]
@@ -481,22 +470,21 @@ where
 }
 
 impl Cartesian<2> {
-    /** Construct a 2-vector perpendicular to self.
-
-    Given a vector $`(v_x, v_y)`$ `perpendicular` returns the vector
-    rotated by $`\pi/2`$:
-    ```math
-    (-v_y, v_x)
-    ```
-
-    # Example
-    ```
-    use hoomd_vector::Cartesian;
-
-    let v = Cartesian::from([1.0, -4.5]);
-    assert_eq!(v.perpendicular(), [4.5, 1.0].into());
-    ```
-    */
+    /// Construct a 2-vector perpendicular to self.
+    ///
+    /// Given a vector $`(v_x, v_y)`$ `perpendicular` returns the vector
+    /// rotated by $`\pi/2`$:
+    /// ```math
+    /// (-v_y, v_x)
+    /// ```
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// let v = Cartesian::from([1.0, -4.5]);
+    /// assert_eq!(v.perpendicular(), [4.5, 1.0].into());
+    /// ```
     #[inline]
     #[must_use]
     pub fn perpendicular(self) -> Self {
@@ -508,21 +496,20 @@ impl<const N: usize, T> IndexMut<T> for Cartesian<N>
 where
     T: Into<usize> + std::slice::SliceIndex<[f64], Output = f64>,
 {
-    /** Get a mutable reference to the value of the vector at coordinate i.
-
-    # Example
-    ```
-    use hoomd_vector::Cartesian;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut v = Cartesian::<3>::try_from(3..6)?;
-    assert_eq!((v[0], v[1], v[2]), (3.0, 4.0, 5.0));
-    v[0] += 1.0;
-    assert_eq!(v[0], 4.0);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Get a mutable reference to the value of the vector at coordinate i.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut v = Cartesian::<3>::try_from(3..6)?;
+    /// assert_eq!((v[0], v[1], v[2]), (3.0, 4.0, 5.0));
+    /// v[0] += 1.0;
+    /// assert_eq!(v[0], 4.0);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn index_mut(&mut self, index: T) -> &mut Self::Output {
         &mut self.coordinates[index]
@@ -539,19 +526,18 @@ impl<const N: usize> Sum for Cartesian<N> {
     }
 }
 
-/** Rotate vectors efficiently.
-
-Construct a [`RotationMatrix`] to efficiently rotate many vectors by the same rotation.
-
-See:
-* [`RotationMatrix::from<Angle>`]
-* [`RotationMatrix::from<Versor>`]
-
-[`RotationMatrix`] _intentionally_ does not implement [`Rotation`](crate::Rotation).
-[`Angle`](crate::Angle) and [`Versor`](crate::Versor) are representations of
-rotations that are often the most effective and numerically stable to
-manipulate.
-*/
+/// Rotate vectors efficiently.
+///
+/// Construct a [`RotationMatrix`] to efficiently rotate many vectors by the same rotation.
+///
+/// See:
+/// [`RotationMatrix::from<Angle>`]
+/// [`RotationMatrix::from<Versor>`]
+///
+/// [`RotationMatrix`] _intentionally_ does not implement [`Rotation`](crate::Rotation).
+/// [`Angle`](crate::Angle) and [`Versor`](crate::Versor) are representations of
+/// rotations that are often the most effective and numerically stable to
+/// manipulate.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct RotationMatrix<const N: usize> {
     /// Rows of the rotation matrix.
@@ -559,45 +545,43 @@ pub struct RotationMatrix<const N: usize> {
 }
 
 impl<const N: usize> RotationMatrix<N> {
-    /** Get the rows of the rotation matrix.
-
-    # Example
-    ```
-    use hoomd_vector::{Angle, InnerProduct, RotationMatrix, Vector};
-    use std::f64::consts::PI;
-
-    let a = Angle::from(PI / 2.0);
-
-    let matrix = RotationMatrix::from(a);
-    assert!(matrix.rows()[0].dot(&[0.0, -1.0].into()) > 0.99);
-    assert!(matrix.rows()[1].dot(&[1.0, 0.0].into()) > 0.99);
-    ```
-    */
+    /// Get the rows of the rotation matrix.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Angle, InnerProduct, RotationMatrix, Vector};
+    /// use std::f64::consts::PI;
+    ///
+    /// let a = Angle::from(PI / 2.0);
+    ///
+    /// let matrix = RotationMatrix::from(a);
+    /// assert!(matrix.rows()[0].dot(&[0.0, -1.0].into()) > 0.99);
+    /// assert!(matrix.rows()[1].dot(&[1.0, 0.0].into()) > 0.99);
+    /// ```
     #[inline]
     #[must_use]
     pub fn rows(&self) -> [Cartesian<N>; N] {
         self.rows
     }
 
-    /** Create a matrix that performs the inverse rotation.
-
-    Matrix inversion is cheaper than [`Angle`](crate::Angle) ->
-    [`RotationMatrix`] and [`Versor`](crate::Versor) -> [`RotationMatrix`]
-    conversions. When you need both rotations, convert once and then invert.
-
-    # Example
-    ```
-    use hoomd_vector::{Angle, InnerProduct, RotationMatrix, Vector};
-    use std::f64::consts::PI;
-
-    let a = Angle::from(PI / 2.0);
-
-    let matrix = RotationMatrix::from(a);
-    let inverted_matrix = matrix.inverted();
-    assert!(inverted_matrix.rows()[0].dot(&[0.0, 1.0].into()) > 0.99);
-    assert!(inverted_matrix.rows()[1].dot(&[-1.0, 0.0].into()) > 0.99);
-    ```
-    */
+    /// Create a matrix that performs the inverse rotation.
+    ///
+    /// Matrix inversion is cheaper than [`Angle`](crate::Angle) ->
+    /// [`RotationMatrix`] and [`Versor`](crate::Versor) -> [`RotationMatrix`]
+    /// conversions. When you need both rotations, convert once and then invert.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Angle, InnerProduct, RotationMatrix, Vector};
+    /// use std::f64::consts::PI;
+    ///
+    /// let a = Angle::from(PI / 2.0);
+    ///
+    /// let matrix = RotationMatrix::from(a);
+    /// let inverted_matrix = matrix.inverted();
+    /// assert!(inverted_matrix.rows()[0].dot(&[0.0, 1.0].into()) > 0.99);
+    /// assert!(inverted_matrix.rows()[1].dot(&[-1.0, 0.0].into()) > 0.99);
+    /// ```
     #[inline]
     #[must_use]
     pub fn inverted(self) -> Self {
@@ -608,25 +592,24 @@ impl<const N: usize> RotationMatrix<N> {
 }
 
 impl<const N: usize> Default for RotationMatrix<N> {
-    /** Create an identity matrix.
-
-    ```math
-    \begin{bmatrix} 1 & 0 \\ 0 & 1 \end{bmatrix}
-    ```
-    ,
-    ```math
-    \begin{bmatrix} 1 & 0 & 0 \\ 0 & 1 & 0 \\ 0 & 0 & 1 \end{bmatrix}
-    ```
-    , and so on.
-
-    # Example
-
-    ```
-    use hoomd_vector::RotationMatrix;
-
-    let identity = RotationMatrix::<3>::default();
-    ```
-    */
+    /// Create an identity matrix.
+    ///
+    /// ```math
+    /// \begin{bmatrix} 1 & 0 \\ 0 & 1 \end{bmatrix}
+    /// ```
+    /// ,
+    /// ```math
+    /// \begin{bmatrix} 1 & 0 & 0 \\ 0 & 1 & 0 \\ 0 & 0 & 1 \end{bmatrix}
+    /// ```
+    /// , and so on.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_vector::RotationMatrix;
+    ///
+    /// let identity = RotationMatrix::<3>::default();
+    /// ```
     #[inline]
     fn default() -> RotationMatrix<N> {
         RotationMatrix {
@@ -654,36 +637,35 @@ impl<const N: usize> Rotate<Cartesian<N>> for RotationMatrix<N> {
     type Matrix = RotationMatrix<N>;
 
     #[inline]
-    /** Rotate a [`Cartesian<N>`] by a [`RotationMatrix`]
-
-    # Examples
-    ```
-    use hoomd_vector::{Angle, Rotate, RotationMatrix, Cartesian};
-    use std::f64::consts::PI;
-
-    let v = Cartesian::from([-1.0, 0.0]);
-    let a = Angle::from(PI / 2.0);
-
-    let matrix = RotationMatrix::from(a);
-    let rotated = matrix.rotate(&v);
-    // rotated is approximately [0.0, -1.0]
-    ```
-
-    ```
-    use hoomd_vector::{Versor, Rotate, RotationMatrix, Cartesian};
-    use std::f64::consts::PI;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let a = Cartesian::from([-1.0, 0.0, 0.0]);
-    let v = Versor::from_axis_angle([0.0, 0.0, 1.0].try_into()?, PI / 2.0);
-
-    let matrix = RotationMatrix::from(v);
-    let b = matrix.rotate(&a);
-    // b is approximately [0.0, -1.0, 0.0]
-    # Ok(())
-    # }
-    ```
-    */
+    /// Rotate a [`Cartesian<N>`] by a [`RotationMatrix`]
+    ///
+    /// # Examples
+    /// ```
+    /// use hoomd_vector::{Angle, Rotate, RotationMatrix, Cartesian};
+    /// use std::f64::consts::PI;
+    ///
+    /// let v = Cartesian::from([-1.0, 0.0]);
+    /// let a = Angle::from(PI / 2.0);
+    ///
+    /// let matrix = RotationMatrix::from(a);
+    /// let rotated = matrix.rotate(&v);
+    /// rotated is approximately [0.0, -1.0]
+    /// ```
+    ///
+    /// ```
+    /// use hoomd_vector::{Versor, Rotate, RotationMatrix, Cartesian};
+    /// use std::f64::consts::PI;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let a = Cartesian::from([-1.0, 0.0, 0.0]);
+    /// let v = Versor::from_axis_angle([0.0, 0.0, 1.0].try_into()?, PI / 2.0);
+    ///
+    /// let matrix = RotationMatrix::from(v);
+    /// let b = matrix.rotate(&a);
+    /// b is approximately [0.0, -1.0, 0.0]
+    /// # Ok(())
+    /// # }
+    /// ```
     fn rotate(&self, vector: &Cartesian<N>) -> Cartesian<N> {
         let mut coordinates = [0.0; N];
 

--- a/hoomd-vector/src/distribution.rs
+++ b/hoomd-vector/src/distribution.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Random distributions of vectors.
- */
+//! Random distributions of vectors.
 
 use super::{Cartesian, InnerProduct};
 use hoomd_utility::valid::PositiveReal;
@@ -13,24 +12,25 @@ use rand::{
 };
 use std::array;
 
-/** A uniform distribution of all points inside or on a sphere with radius `r`.
-
-# Example
-
-```
-use hoomd_vector::{Cartesian, distribution::Ball};
-use rand::{distr::Distribution, Rng, rngs::StdRng, SeedableRng};
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut rng = StdRng::seed_from_u64(1);
-
-let r = 5.0;
-let ball = Ball { radius: r.try_into()? };
-let v: Cartesian<3> = ball.sample(&mut rng);
-# Ok(())
-# }
-```
-*/
+/// A uniform distribution of all points inside or on a sphere with radius `r`.
+///
+/// # Example
+///
+/// ```
+/// use hoomd_vector::{Cartesian, distribution::Ball};
+/// use rand::{Rng, SeedableRng, distr::Distribution, rngs::StdRng};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut rng = StdRng::seed_from_u64(1);
+///
+/// let r = 5.0;
+/// let ball = Ball {
+///     radius: r.try_into()?,
+/// };
+/// let v: Cartesian<3> = ball.sample(&mut rng);
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Ball {
     /// The radius of the ball *(\[length\])*.

--- a/hoomd-vector/src/lib.rs
+++ b/hoomd-vector/src/lib.rs
@@ -123,9 +123,9 @@
 //!
 //! [`Angle`] implements rotations on [`Cartesian<2>`] vectors.
 //! ```
-//! use hoomd_vector::{Angle, Rotate, Rotation, Cartesian};
-//! use std::f64::consts::PI;
 //! use ::approx::assert_relative_eq;
+//! use hoomd_vector::{Angle, Cartesian, Rotate, Rotation};
+//! use std::f64::consts::PI;
 //!
 //! let v = Cartesian::from([-1.0, 0.0]);
 //! let a = Angle::from(PI / 2.0);
@@ -135,9 +135,9 @@
 //!
 //! [`Versor`] implements rotations on [`Cartesian<3>`] vectors.
 //! ```
-//! use hoomd_vector::{Versor, Rotate, Rotation, Cartesian};
-//! use std::f64::consts::PI;
 //! use ::approx::assert_relative_eq;
+//! use hoomd_vector::{Cartesian, Rotate, Rotation, Versor};
+//! use std::f64::consts::PI;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let a = Cartesian::from([-1.0, 0.0, 0.0]);
@@ -391,7 +391,6 @@ pub trait Vector:
 ///
 /// The [`InnerProduct`] subtrait defines additional methods that can be performed on any vector
 /// in an inner product space, specifically vector norms and inner products.
-///
 pub trait InnerProduct: Vector {
     /// Compute the vector dot product between two vectors.
     ///
@@ -615,8 +614,8 @@ pub trait Rotate<V: Vector> {
     ///
     /// # Example
     /// ```
-    /// use hoomd_vector::{Angle, Rotate, Rotation, Cartesian};
     /// use ::approx::assert_relative_eq;
+    /// use hoomd_vector::{Angle, Cartesian, Rotate, Rotation};
     ///
     /// let v = Cartesian::from([-1.0, 0.0]);
     /// let a = Angle::from(std::f64::consts::PI / 2.0);

--- a/hoomd-vector/src/lib.rs
+++ b/hoomd-vector/src/lib.rs
@@ -8,179 +8,178 @@
     html_logo_url = "https://hoomd-blue.readthedocs.io/en/latest/_static/hoomdblue-logo-favicon.svg"
 )]
 
-/*! Vector and quaternion math.
-
-`hoomd_vector` implements vector math types and operations used in scientific
-computations, specifically those used in the HOOMD molecular simulation software
-suite. Its API is firmly rooted in mathematical principles. Users in
-other fields may find `hoomd_vector` useful outside the context of `HOOMD`.
-
-## Vectors
-
-The [`Vector`] trait describes any type that is a member of a metric vector
-space. Write code with a [`Vector`] trait bound when you can express the
-computation with vector arithmetic and a distance metric. Your generic code can
-then be invoked on vector types with any dimension or representation (e.g.
-spherical coordinates).
-
-```
-use hoomd_vector::Vector;
-
-fn some_function<V: Vector>(a: &V, b: &V, c: &V) -> f64 {
-    (*a + *b).distance(&c)
-}
-```
-
-The [`InnerProduct`] subtrait of [`Vector`] describes any type that is a member of
-an inner product space. [`InnerProduct`] implements vector norms and dot products.
-
-```
-use hoomd_vector::InnerProduct;
-
-fn some_other_function<V: InnerProduct>(a: &V, b: &V) -> f64 {
-    a.dot(b) / (a.norm_squared())
-}
-```
-
-Require additional trait bounds to perform more specific operations, such as [`Cross`]:
-```
-use hoomd_vector::{Cross, InnerProduct};
-
-fn triple<V: InnerProduct + Cross>(a: &V, b: &V, c: &V) -> f64 {
-    a.dot(&b.cross(c))
-}
-```
-
-Use the provided [`Cartesian`] type to concretely represent N-dimensional
-vectors, or when your algorithm requires Cartesian coordinates:
-
-```
-use hoomd_vector::{Cartesian, InnerProduct};
-
-let a = Cartesian::from([1.0, 2.0]);
-let b = Cartesian::from([-2.0, 1.0]);
-
-let product = a.dot(&b);
-assert_eq!(product, 0.0);
-
-let x = a[0];
-let y = a[1];
-```
-
-## Quaternions
-
-Quaternions are generalized complex numbers and a convenient way to describe the motion
-of rotating bodies. The [`Quaternion`] type describes a single quaternion and implements
-the associated algebra.
-
-```
-use hoomd_vector::Quaternion;
-
-let a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
-let b = Quaternion::from([-2.0, 6.0, 4.0, 1.0]);
-
-let norm = a.norm();
-assert_eq!(norm, 57.0_f64.sqrt());
-
-let sum = a + b;
-assert_eq!(sum, [-1.0, 4.0, 10.0, -3.0].into());
-
-let product = a * b;
-assert_eq!(product, [-10.0, 32.0, -30.0, -35.0].into());
-```
-
-A **unit quaternion** (called a [`Versor`] in mathematics) can represent a 3D rotation.
-
-```
-use hoomd_vector::{Quaternion, Versor};
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let q = Quaternion::from([3.0, 0.0, 0.0, 4.0]);
-let v = q.to_versor()?;
-assert_eq!(*v.get(), [3.0 / 5.0, 0.0, 0.0, 4.0 / 5.0].into());
-# Ok(())
-# }
-```
-
-## Rotations
-
-A [`Rotation`] describes a transformation from one orthonormal basis to
-another. A type that implements [`Rotation`] has an
-[`identity`](Rotation::identity). Instances of that type have an
-[`inverse`](Rotation::inverted) and can be [`combined`](Rotation::combine)
-with other rotations.
-
-Through the [`Rotate<V>`] trait, a [`Rotation`] can rotate a vector.
-
-As with [`Vector`], you can implement methods that operate on generic types:
-```
-use hoomd_vector::{Rotate, Vector};
-
-fn rotate_and_translate<R: Rotate<V>, V: Vector>(r: &R, a: &V, b: &V) -> V {
-    r.rotate(a) + *b
-}
-```
-
-[`Angle`] implements rotations on [`Cartesian<2>`] vectors.
-```
-use hoomd_vector::{Angle, Rotate, Rotation, Cartesian};
-use std::f64::consts::PI;
-
-let v = Cartesian::from([-1.0, 0.0]);
-let a = Angle::from(PI / 2.0);
-let rotated = a.rotate(&v);
-// rotated is approximately [0.0, -1.0]
-```
-
-[`Versor`] implements rotations on [`Cartesian<3>`] vectors.
-```
-use hoomd_vector::{Versor, Rotate, Rotation, Cartesian};
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let a = Cartesian::from([-1.0, 0.0, 0.0]);
-let v = Versor::from_axis_angle([0.0, 0.0, 1.0].try_into()?, PI / 2.0);
-let b = v.rotate(&a);
-// b is approximately [0.0, -1.0, 0.0]
-# Ok(())
-# }
-```
-
-Convert to a [`RotationMatrix`] when you need to rotate many vectors by the same
-rotation. [`RotationMatrix::rotate`] is typically several times faster than
-[`Versor::rotate`].
-
-# Random distributions
-
-`hoomd_vector` interoperates with [`rand`] to generate random vectors and rotations.
-
-The [`StandardUniform`](rand::distr::StandardUniform) distribution
-samples rotations uniformly from the set of all rotations and vectors from the
-`[-1,1]` hypercube.
-
-
-```
-use hoomd_vector::{Angle, Cartesian, Versor};
-use rand::{rngs::StdRng, Rng, SeedableRng};
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut rng = StdRng::seed_from_u64(1);
-let angle: Angle = rng.random();
-let vector: Cartesian::<3> = rng.random();
-let versor: Versor = rng.random();
-# Ok(())
-# }
-```
-
-# Feature flags
-
-These unstable features are intended for internal use. `hoomd-vector` may make
-breaking changes to the code gated behind unstable features in any release.
-
-* `approx`: Enable `assert_relative_eq` and `assert_abs_diff_eq` from the
-  [`approx`](https://docs.rs/approx/latest/approx/) crate on [`Cartesian`],
-  [`Quaternion`] and [`Versor`].
-*/
+//! Vector and quaternion math.
+//!
+//! `hoomd_vector` implements vector math types and operations used in scientific
+//! computations, specifically those used in the HOOMD molecular simulation software
+//! suite. Its API is firmly rooted in mathematical principles. Users in
+//! other fields may find `hoomd_vector` useful outside the context of `HOOMD`.
+//!
+//! ## Vectors
+//!
+//! The [`Vector`] trait describes any type that is a member of a metric vector
+//! space. Write code with a [`Vector`] trait bound when you can express the
+//! computation with vector arithmetic and a distance metric. Your generic code can
+//! then be invoked on vector types with any dimension or representation (e.g.
+//! spherical coordinates).
+//!
+//! ```
+//! use hoomd_vector::Vector;
+//!
+//! fn some_function<V: Vector>(a: &V, b: &V, c: &V) -> f64 {
+//!     (*a + *b).distance(&c)
+//! }
+//! ```
+//!
+//! The [`InnerProduct`] subtrait of [`Vector`] describes any type that is a member of
+//! an inner product space. [`InnerProduct`] implements vector norms and dot products.
+//!
+//! ```
+//! use hoomd_vector::InnerProduct;
+//!
+//! fn some_other_function<V: InnerProduct>(a: &V, b: &V) -> f64 {
+//!     a.dot(b) / (a.norm_squared())
+//! }
+//! ```
+//!
+//! Require additional trait bounds to perform more specific operations, such as [`Cross`]:
+//! ```
+//! use hoomd_vector::{Cross, InnerProduct};
+//!
+//! fn triple<V: InnerProduct + Cross>(a: &V, b: &V, c: &V) -> f64 {
+//!     a.dot(&b.cross(c))
+//! }
+//! ```
+//!
+//! Use the provided [`Cartesian`] type to concretely represent N-dimensional
+//! vectors, or when your algorithm requires Cartesian coordinates:
+//!
+//! ```
+//! use hoomd_vector::{Cartesian, InnerProduct};
+//!
+//! let a = Cartesian::from([1.0, 2.0]);
+//! let b = Cartesian::from([-2.0, 1.0]);
+//!
+//! let product = a.dot(&b);
+//! assert_eq!(product, 0.0);
+//!
+//! let x = a[0];
+//! let y = a[1];
+//! ```
+//!
+//! ## Quaternions
+//!
+//! Quaternions are generalized complex numbers and a convenient way to describe the motion
+//! of rotating bodies. The [`Quaternion`] type describes a single quaternion and implements
+//! the associated algebra.
+//!
+//! ```
+//! use hoomd_vector::Quaternion;
+//!
+//! let a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
+//! let b = Quaternion::from([-2.0, 6.0, 4.0, 1.0]);
+//!
+//! let norm = a.norm();
+//! assert_eq!(norm, 57.0_f64.sqrt());
+//!
+//! let sum = a + b;
+//! assert_eq!(sum, [-1.0, 4.0, 10.0, -3.0].into());
+//!
+//! let product = a * b;
+//! assert_eq!(product, [-10.0, 32.0, -30.0, -35.0].into());
+//! ```
+//!
+//! A **unit quaternion** (called a [`Versor`] in mathematics) can represent a 3D rotation.
+//!
+//! ```
+//! use hoomd_vector::{Quaternion, Versor};
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let q = Quaternion::from([3.0, 0.0, 0.0, 4.0]);
+//! let v = q.to_versor()?;
+//! assert_eq!(*v.get(), [3.0 / 5.0, 0.0, 0.0, 4.0 / 5.0].into());
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Rotations
+//!
+//! A [`Rotation`] describes a transformation from one orthonormal basis to
+//! another. A type that implements [`Rotation`] has an
+//! [`identity`](Rotation::identity). Instances of that type have an
+//! [`inverse`](Rotation::inverted) and can be [`combined`](Rotation::combine)
+//! with other rotations.
+//!
+//! Through the [`Rotate<V>`] trait, a [`Rotation`] can rotate a vector.
+//!
+//! As with [`Vector`], you can implement methods that operate on generic types:
+//! ```
+//! use hoomd_vector::{Rotate, Vector};
+//!
+//! fn rotate_and_translate<R: Rotate<V>, V: Vector>(r: &R, a: &V, b: &V) -> V {
+//!     r.rotate(a) + *b
+//! }
+//! ```
+//!
+//! [`Angle`] implements rotations on [`Cartesian<2>`] vectors.
+//! ```
+//! use hoomd_vector::{Angle, Rotate, Rotation, Cartesian};
+//! use std::f64::consts::PI;
+//!
+//! let v = Cartesian::from([-1.0, 0.0]);
+//! let a = Angle::from(PI / 2.0);
+//! let rotated = a.rotate(&v);
+//! rotated is approximately [0.0, -1.0]
+//! ```
+//!
+//! [`Versor`] implements rotations on [`Cartesian<3>`] vectors.
+//! ```
+//! use hoomd_vector::{Versor, Rotate, Rotation, Cartesian};
+//! use std::f64::consts::PI;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let a = Cartesian::from([-1.0, 0.0, 0.0]);
+//! let v = Versor::from_axis_angle([0.0, 0.0, 1.0].try_into()?, PI / 2.0);
+//! let b = v.rotate(&a);
+//! b is approximately [0.0, -1.0, 0.0]
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Convert to a [`RotationMatrix`] when you need to rotate many vectors by the same
+//! rotation. [`RotationMatrix::rotate`] is typically several times faster than
+//! [`Versor::rotate`].
+//!
+//! # Random distributions
+//!
+//! `hoomd_vector` interoperates with [`rand`] to generate random vectors and rotations.
+//!
+//! The [`StandardUniform`](rand::distr::StandardUniform) distribution
+//! samples rotations uniformly from the set of all rotations and vectors from the
+//! `[-1,1]` hypercube.
+//!
+//!
+//! ```
+//! use hoomd_vector::{Angle, Cartesian, Versor};
+//! use rand::{Rng, SeedableRng, rngs::StdRng};
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let mut rng = StdRng::seed_from_u64(1);
+//! let angle: Angle = rng.random();
+//! let vector: Cartesian<3> = rng.random();
+//! let versor: Versor = rng.random();
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Feature flags
+//!
+//! These unstable features are intended for internal use. `hoomd-vector` may make
+//! breaking changes to the code gated behind unstable features in any release.
+//!
+//! `approx`: Enable `assert_relative_eq` and `assert_abs_diff_eq` from the
+//! [`approx`](https://docs.rs/approx/latest/approx/) crate on [`Cartesian`],
+//! [`Quaternion`] and [`Versor`].
 
 mod angle;
 mod cartesian;
@@ -214,137 +213,136 @@ pub enum Error {
     InvalidQuaternionMagnitude,
 }
 
-/** Operate on elements of a metric vector space.
-
-Specifically, [`Vector`] defines methods that can be performed on any vector in a metric vector
-space. Note that this is not an inner product space by default, and calculations requiring an
-inner product should use the [`InnerProduct`] subtrait.
-
-## Vector Operations
-
-The following examples demonstrate vector operations applied to the following
-vectors:
-
-```
-use hoomd_vector::Cartesian;
-
-# fn main() {
-let mut a = Cartesian::from([1.0, 2.0]);
-let mut b = Cartesian::from([4.0, 8.0]);
-# }
-```
-
-Vector addition:
-
-```
-# use hoomd_vector::Cartesian;
-# fn main() {
-# let mut a = Cartesian::from([1.0, 2.0]);
-# let mut b = Cartesian::from([4.0, 8.0]);
-let c = a + b;
-assert_eq!(c, [5.0, 10.0].into())
-# }
-```
-
-```
-# use hoomd_vector::Cartesian;
-# fn main() {
-# let mut a = Cartesian::from([1.0, 2.0]);
-# let mut b = Cartesian::from([4.0, 8.0]);
-a += b;
-assert_eq!(a, [5.0, 10.0].into())
-# }
-```
-
-Vector subtraction:
-
-```
-# use hoomd_vector::Cartesian;
-# fn main() {
-# let mut a = Cartesian::from([1.0, 2.0]);
-# let mut b = Cartesian::from([4.0, 8.0]);
-let c = b - a;
-assert_eq!(c, [3.0, 6.0].into())
-# }
-```
-
-```
-# use hoomd_vector::Cartesian;
-# fn main() {
-# let mut a = Cartesian::from([1.0, 2.0]);
-# let mut b = Cartesian::from([4.0, 8.0]);
-b -= a;
-assert_eq!(b, [3.0, 6.0].into())
-# }
-```
-
-Multiplication of a vector by a scalar:
-
-```
-# use hoomd_vector::Cartesian;
-# fn main() {
-# let mut a = Cartesian::from([1.0, 2.0]);
-# let mut b = Cartesian::from([4.0, 8.0]);
-let c = a * 2.0;
-assert_eq!(c, [2.0, 4.0].into())
-# }
-```
-
-```
-# use hoomd_vector::Cartesian;
-# fn main() {
-# let mut a = Cartesian::from([1.0, 2.0]);
-# let mut b = Cartesian::from([4.0, 8.0]);
-a *= 2.0;
-assert_eq!(a, [2.0, 4.0].into())
-# }
-```
-
-Division of a vector by a scalar:
-
-```
-# use hoomd_vector::Cartesian;
-# fn main() {
-# let mut a = Cartesian::from([1.0, 2.0]);
-# let mut b = Cartesian::from([4.0, 8.0]);
-let c = b / 2.0;
-assert_eq!(c, [2.0, 4.0].into())
-# }
-```
-
-```
-# use hoomd_vector::Cartesian;
-# fn main() {
-# let mut a = Cartesian::from([1.0, 2.0]);
-# let mut b = Cartesian::from([4.0, 8.0]);
-b /= 2.0;
-assert_eq!(b, [2.0, 4.0].into())
-# }
-```
-
-Negation:
-
-```
-# use hoomd_vector::Cartesian;
-# fn main() {
-# let mut a = Cartesian::from([1.0, 2.0]);
-# let mut b = Cartesian::from([4.0, 8.0]);
-let mut c = -a;
-assert_eq!(c, [-1.0, -2.0].into());
-# }
-```
-
-Equality:
-
-```
-# use hoomd_vector::Cartesian;
-# fn main() {
-# let mut a = Cartesian::from([1.0, 2.0]);
-# let mut b = Cartesian::from([4.0, 8.0]);
-assert!(a != b)
-# }
-```
-*/
+/// Operate on elements of a metric vector space.
+///
+/// Specifically, [`Vector`] defines methods that can be performed on any vector in a metric vector
+/// space. Note that this is not an inner product space by default, and calculations requiring an
+/// inner product should use the [`InnerProduct`] subtrait.
+///
+/// ## Vector Operations
+///
+/// The following examples demonstrate vector operations applied to the following
+/// vectors:
+///
+/// ```
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() {
+/// let mut a = Cartesian::from([1.0, 2.0]);
+/// let mut b = Cartesian::from([4.0, 8.0]);
+/// # }
+/// ```
+///
+/// Vector addition:
+///
+/// ```
+/// # use hoomd_vector::Cartesian;
+/// # fn main() {
+/// # let mut a = Cartesian::from([1.0, 2.0]);
+/// # let mut b = Cartesian::from([4.0, 8.0]);
+/// let c = a + b;
+/// assert_eq!(c, [5.0, 10.0].into())
+/// # }
+/// ```
+///
+/// ```
+/// # use hoomd_vector::Cartesian;
+/// # fn main() {
+/// # let mut a = Cartesian::from([1.0, 2.0]);
+/// # let mut b = Cartesian::from([4.0, 8.0]);
+/// a += b;
+/// assert_eq!(a, [5.0, 10.0].into())
+/// # }
+/// ```
+///
+/// Vector subtraction:
+///
+/// ```
+/// # use hoomd_vector::Cartesian;
+/// # fn main() {
+/// # let mut a = Cartesian::from([1.0, 2.0]);
+/// # let mut b = Cartesian::from([4.0, 8.0]);
+/// let c = b - a;
+/// assert_eq!(c, [3.0, 6.0].into())
+/// # }
+/// ```
+///
+/// ```
+/// # use hoomd_vector::Cartesian;
+/// # fn main() {
+/// # let mut a = Cartesian::from([1.0, 2.0]);
+/// # let mut b = Cartesian::from([4.0, 8.0]);
+/// b -= a;
+/// assert_eq!(b, [3.0, 6.0].into())
+/// # }
+/// ```
+///
+/// Multiplication of a vector by a scalar:
+///
+/// ```
+/// # use hoomd_vector::Cartesian;
+/// # fn main() {
+/// # let mut a = Cartesian::from([1.0, 2.0]);
+/// # let mut b = Cartesian::from([4.0, 8.0]);
+/// let c = a * 2.0;
+/// assert_eq!(c, [2.0, 4.0].into())
+/// # }
+/// ```
+///
+/// ```
+/// # use hoomd_vector::Cartesian;
+/// # fn main() {
+/// # let mut a = Cartesian::from([1.0, 2.0]);
+/// # let mut b = Cartesian::from([4.0, 8.0]);
+/// a *= 2.0;
+/// assert_eq!(a, [2.0, 4.0].into())
+/// # }
+/// ```
+///
+/// Division of a vector by a scalar:
+///
+/// ```
+/// # use hoomd_vector::Cartesian;
+/// # fn main() {
+/// # let mut a = Cartesian::from([1.0, 2.0]);
+/// # let mut b = Cartesian::from([4.0, 8.0]);
+/// let c = b / 2.0;
+/// assert_eq!(c, [2.0, 4.0].into())
+/// # }
+/// ```
+///
+/// ```
+/// # use hoomd_vector::Cartesian;
+/// # fn main() {
+/// # let mut a = Cartesian::from([1.0, 2.0]);
+/// # let mut b = Cartesian::from([4.0, 8.0]);
+/// b /= 2.0;
+/// assert_eq!(b, [2.0, 4.0].into())
+/// # }
+/// ```
+///
+/// Negation:
+///
+/// ```
+/// # use hoomd_vector::Cartesian;
+/// # fn main() {
+/// # let mut a = Cartesian::from([1.0, 2.0]);
+/// # let mut b = Cartesian::from([4.0, 8.0]);
+/// let mut c = -a;
+/// assert_eq!(c, [-1.0, -2.0].into());
+/// # }
+/// ```
+///
+/// Equality:
+///
+/// ```
+/// # use hoomd_vector::Cartesian;
+/// # fn main() {
+/// # let mut a = Cartesian::from([1.0, 2.0]);
+/// # let mut b = Cartesian::from([4.0, 8.0]);
+/// assert!(a != b)
+/// # }
+/// ```
 pub trait Vector:
     Add<Self, Output = Self>
     + AddAssign
@@ -358,143 +356,136 @@ pub trait Vector:
     + SubAssign
     + Neg<Output = Self>
 {
-    /** Compute the squared distance between two vectors belonging to a metric space.
-
-    # Example
-    ```
-    use hoomd_vector::{Cartesian, Vector};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let x = Cartesian::from([0.0, 1.0, 1.0]);
-    let y = Cartesian::from([1.0, 0.0, 0.0]);
-    assert_eq!(3.0, x.distance_squared(&y));
-    # Ok(())
-    # }
-    ```
-     */
+    /// Compute the squared distance between two vectors belonging to a metric space.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Cartesian, Vector};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let x = Cartesian::from([0.0, 1.0, 1.0]);
+    /// let y = Cartesian::from([1.0, 0.0, 0.0]);
+    /// assert_eq!(3.0, x.distance_squared(&y));
+    /// # Ok(())
+    /// # }
+    /// ```
     fn distance_squared(&self, other: &Self) -> f64;
 
-    /** Compute the distance between two vectors belonging to a metric space.
-    # Example
-    ```
-    use hoomd_vector::{Cartesian, Vector};
-
-    let x = Cartesian::from([0.0, 0.0]);
-    let y = Cartesian::from([3.0, 4.0]);
-    assert_eq!(5.0, x.distance(&y));
-    ```
-     */
+    /// Compute the distance between two vectors belonging to a metric space.
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Cartesian, Vector};
+    ///
+    /// let x = Cartesian::from([0.0, 0.0]);
+    /// let y = Cartesian::from([3.0, 4.0]);
+    /// assert_eq!(5.0, x.distance(&y));
+    /// ```
     #[inline]
     fn distance(&self, other: &Self) -> f64 {
         self.distance_squared(other).sqrt()
     }
 }
-/** Operate on elements of an inner product space.
-
-The [`InnerProduct`] subtrait defines additional methods that can be performed on any vector
-in an inner product space, specifically vector norms and inner products.
-
-*/
+/// Operate on elements of an inner product space.
+///
+/// The [`InnerProduct`] subtrait defines additional methods that can be performed on any vector
+/// in an inner product space, specifically vector norms and inner products.
+///
 pub trait InnerProduct: Vector {
-    /** Compute the vector dot product between two vectors.
-
-    ```math
-    c = \vec{a} \cdot \vec{b}
-    ```
-
-    # Example
-    ```
-    use hoomd_vector::{Cartesian, InnerProduct};
-
-    # fn main() {
-    let a = Cartesian::from([1.0, 2.0]);
-    let b = Cartesian::from([3.0, 4.0]);
-    let c = a.dot(&b);
-    assert_eq!(c, 11.0);
-    # }
-    ```
-    */
+    /// Compute the vector dot product between two vectors.
+    ///
+    /// ```math
+    /// c = \vec{a} \cdot \vec{b}
+    /// ```
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Cartesian, InnerProduct};
+    ///
+    /// # fn main() {
+    /// let a = Cartesian::from([1.0, 2.0]);
+    /// let b = Cartesian::from([3.0, 4.0]);
+    /// let c = a.dot(&b);
+    /// assert_eq!(c, 11.0);
+    /// # }
+    /// ```
     #[must_use]
     fn dot(&self, other: &Self) -> f64;
 
-    /** Compute the squared norm of the vector.
-
-    ```math
-    \left| \vec{v} \right|^2
-    ```
-
-    # Example
-    ```
-    use hoomd_vector::{Cartesian, InnerProduct};
-
-    # fn main() {
-    let v = Cartesian::from([2.0, 4.0]);
-    let norm_squared = v.norm_squared();
-    assert_eq!(norm_squared, 20.0);
-    # }
-    ```
-    */
+    /// Compute the squared norm of the vector.
+    ///
+    /// ```math
+    /// \left| \vec{v} \right|^2
+    /// ```
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Cartesian, InnerProduct};
+    ///
+    /// # fn main() {
+    /// let v = Cartesian::from([2.0, 4.0]);
+    /// let norm_squared = v.norm_squared();
+    /// assert_eq!(norm_squared, 20.0);
+    /// # }
+    /// ```
     #[must_use]
     #[inline]
     fn norm_squared(&self) -> f64 {
         self.dot(self)
     }
 
-    /** Compute the norm of the vector.
-
-    ```math
-    \left| \vec{v} \right|
-    ```
-
-    <div class="warning">
-
-    Computing the norm calls `sqrt`. Prefer
-    [`norm_squared`](InnerProduct::norm_squared) when possible.
-
-    </div>
-
-    # Example
-    ```
-    use hoomd_vector::{Cartesian, InnerProduct};
-
-    # fn main() {
-    let v = Cartesian::from([3.0, 4.0]);
-    let norm= v.norm();
-    assert_eq!(norm, 5.0);
-    # }
-    ```
-    */
+    /// Compute the norm of the vector.
+    ///
+    /// ```math
+    /// \left| \vec{v} \right|
+    /// ```
+    ///
+    /// <div class="warning">
+    ///
+    /// Computing the norm calls `sqrt`. Prefer
+    /// [`norm_squared`](InnerProduct::norm_squared) when possible.
+    ///
+    /// </div>
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Cartesian, InnerProduct};
+    ///
+    /// # fn main() {
+    /// let v = Cartesian::from([3.0, 4.0]);
+    /// let norm = v.norm();
+    /// assert_eq!(norm, 5.0);
+    /// # }
+    /// ```
     #[must_use]
     #[inline]
     fn norm(&self) -> f64 {
         self.norm_squared().sqrt()
     }
 
-    /** Create a vector of unit length pointing in the same direction as the given vector.
-
-    Returns a tuple containing unit vector along with the original vector's norm:
-    ```math
-    \frac{\vec{v}}{|\vec{v}|}
-    ```
-
-    # Example
-
-    ```
-    use hoomd_vector::{Cartesian, Unit, InnerProduct};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let a = Cartesian::from([3.0, 4.0]);
-    let (unit, norm) = a.to_unit()?;
-    assert_eq!(*unit.get(), [3.0 / 5.0, 4.0 / 5.0].into());
-    assert_eq!(norm, 5.0);
-    # Ok(())
-    # }
-    ```
-
-    # Errors
-
-    [`Error::InvalidVectorMagnitude`] when `self` is the 0 vector.
-    */
+    /// Create a vector of unit length pointing in the same direction as the given vector.
+    ///
+    /// Returns a tuple containing unit vector along with the original vector's norm:
+    /// ```math
+    /// \frac{\vec{v}}{|\vec{v}|}
+    /// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_vector::{Cartesian, InnerProduct, Unit};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let a = Cartesian::from([3.0, 4.0]);
+    /// let (unit, norm) = a.to_unit()?;
+    /// assert_eq!(*unit.get(), [3.0 / 5.0, 4.0 / 5.0].into());
+    /// assert_eq!(norm, 5.0);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// [`Error::InvalidVectorMagnitude`] when `self` is the 0 vector.
     #[inline]
     fn to_unit(self) -> Result<(Unit<Self>, f64), Error> {
         let norm = self.norm();
@@ -505,69 +496,66 @@ pub trait InnerProduct: Vector {
         }
     }
 
-    /** Create a vector of unit length pointing in the same direction as the given vector.
-
-    Returns a tuple containing unit vector along with the original vector's norm:
-    ```math
-    \frac{\vec{v}}{|\vec{v}|}
-    ```
-
-    # Example
-
-    ```
-    use hoomd_vector::{Cartesian, Unit, InnerProduct};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let a = Cartesian::from([3.0, 4.0]);
-    let (unit, norm) = a.to_unit_unchecked();
-    assert_eq!(*unit.get(), [3.0 / 5.0, 4.0 / 5.0].into());
-    assert_eq!(norm, 5.0);
-    # Ok(())
-    # }
-    ```
-
-    # Panics
-
-    Divide by 0 when `self` is the 0 vector.
-    */
+    /// Create a vector of unit length pointing in the same direction as the given vector.
+    ///
+    /// Returns a tuple containing unit vector along with the original vector's norm:
+    /// ```math
+    /// \frac{\vec{v}}{|\vec{v}|}
+    /// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_vector::{Cartesian, InnerProduct, Unit};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let a = Cartesian::from([3.0, 4.0]);
+    /// let (unit, norm) = a.to_unit_unchecked();
+    /// assert_eq!(*unit.get(), [3.0 / 5.0, 4.0 / 5.0].into());
+    /// assert_eq!(norm, 5.0);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Divide by 0 when `self` is the 0 vector.
     #[inline]
     fn to_unit_unchecked(self) -> (Unit<Self>, f64) {
         let norm = self.norm();
         (Unit(self / norm), norm)
     }
 
-    /** Project one vector onto another.
-    ```math
-    \left(\frac{\vec{a} \cdot \vec{b}}{|\vec{b}|^2}\right) \vec{b}
-    ```
-    where `self` is $`\vec{a}`$.
-    # Example
-    ```
-    use hoomd_vector::{Cartesian, InnerProduct, Vector};
-    let a = Cartesian::from([1.0, 2.0]);
-    let b = Cartesian::from([4.0, 0.0]);
-    let c = a.project(&b);
-    assert_eq!(c, [1.0, 0.0].into());
-    ```
-    */
+    /// Project one vector onto another.
+    /// ```math
+    /// \left(\frac{\vec{a} \cdot \vec{b}}{|\vec{b}|^2}\right) \vec{b}
+    /// ```
+    /// where `self` is $`\vec{a}`$.
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Cartesian, InnerProduct, Vector};
+    /// let a = Cartesian::from([1.0, 2.0]);
+    /// let b = Cartesian::from([4.0, 0.0]);
+    /// let c = a.project(&b);
+    /// assert_eq!(c, [1.0, 0.0].into());
+    /// ```
     #[inline]
     #[must_use]
     fn project(&self, b: &Self) -> Self {
         *b * self.dot(b) / b.norm_squared()
     }
 
-    /** Create a unit vector in the space.
-
-    Each vector space defines its own default unit vector.
-
-    # Example
-    ```
-    use hoomd_vector::{Cartesian, InnerProduct};
-
-    let u = Cartesian::<2>::default_unit();
-    assert_eq!(*u.get(), [0.0, 1.0].into());
-    ```
-    */
+    /// Create a unit vector in the space.
+    ///
+    /// Each vector space defines its own default unit vector.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Cartesian, InnerProduct};
+    ///
+    /// let u = Cartesian::<2>::default_unit();
+    /// assert_eq!(*u.get(), [0.0, 1.0].into());
+    /// ```
     fn default_unit() -> Unit<Self>;
 }
 
@@ -583,141 +571,133 @@ impl<V> Unit<V> {
     }
 }
 
-/** A vector space where the cross product is defined.
- */
+/// A vector space where the cross product is defined.
 pub trait Cross {
-    /** Perform the cross product.
-    Compute the cross product (right-handed) of two vectors:
-
-    ```math
-    \vec{c} = \vec{a} × \vec{b}
-    ```
-
-    # Example
-    ```
-    use hoomd_vector::{Cartesian, Cross, Vector};
-
-    # fn main() {
-    let a = Cartesian::from([1.0, 0.0, 0.0]);
-    let b = Cartesian::from([0.0, 1.0, 0.0]);
-    let c = a.cross(&b);
-    assert_eq!(c, [0.0, 0.0, 1.0].into());
-    # }
-    ```
-    */
+    /// Perform the cross product.
+    /// Compute the cross product (right-handed) of two vectors:
+    ///
+    /// ```math
+    /// \vec{c} = \vec{a} × \vec{b}
+    /// ```
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Cartesian, Cross, Vector};
+    ///
+    /// # fn main() {
+    /// let a = Cartesian::from([1.0, 0.0, 0.0]);
+    /// let b = Cartesian::from([0.0, 1.0, 0.0]);
+    /// let c = a.cross(&b);
+    /// assert_eq!(c, [0.0, 0.0, 1.0].into());
+    /// # }
+    /// ```
     #[must_use]
     fn cross(&self, other: &Self) -> Self;
 }
 
-/** Applies the rotation operation to vectors.
-
-The [`Rotate`] trait describes a type that can rotate a given vector. The rotated vector has the
-same magnitude, but possibly a different direction.
-
-Types that implement [`Rotate`] may or _may not_ implement [`Rotation`].
-*/
+/// Applies the rotation operation to vectors.
+///
+/// The [`Rotate`] trait describes a type that can rotate a given vector. The rotated vector has the
+/// same magnitude, but possibly a different direction.
+///
+/// Types that implement [`Rotate`] may or _may not_ implement [`Rotation`].
 pub trait Rotate<V: Vector> {
     /// Type of the related rotation matrix
     type Matrix: Rotate<V>;
 
-    /** Rotate a vector.
-
-    ```math
-    \vec{b} = R(\vec{a})
-    ```
-
-    # Example
-    ```
-    use hoomd_vector::{Angle, Rotate, Rotation, Cartesian};
-
-    let v = Cartesian::from([-1.0, 0.0]);
-    let a = Angle::from(std::f64::consts::PI / 2.0);
-    let rotated = a.rotate(&v);
-    // rotated is approximately [0.0, -1.0]
-    ```
-     */
+    /// Rotate a vector.
+    ///
+    /// ```math
+    /// \vec{b} = R(\vec{a})
+    /// ```
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Angle, Rotate, Rotation, Cartesian};
+    ///
+    /// let v = Cartesian::from([-1.0, 0.0]);
+    /// let a = Angle::from(std::f64::consts::PI / 2.0);
+    /// let rotated = a.rotate(&v);
+    /// rotated is approximately [0.0, -1.0]
+    /// ```
     #[must_use]
     fn rotate(&self, vector: &V) -> V;
 }
 
-/** Describes the transformation from one orthonormal basis to another.
-
-A [`Rotation`] represents a single rotation operation. Rotations change the direction of a vector
-while keeping its magnitude constant. To maintain generality, this documentation shows rotations
-mathematically as _functions_:
-```math
-\vec{b} = R(\vec{a})
-```
-
-All types that implement [`Rotation`] _should_ implement [`Rotate`] for at least one vector type.
-*/
+/// Describes the transformation from one orthonormal basis to another.
+///
+/// A [`Rotation`] represents a single rotation operation. Rotations change the direction of a vector
+/// while keeping its magnitude constant. To maintain generality, this documentation shows rotations
+/// mathematically as _functions_:
+/// ```math
+/// \vec{b} = R(\vec{a})
+/// ```
+///
+/// All types that implement [`Rotation`] _should_ implement [`Rotate`] for at least one vector type.
 pub trait Rotation: Copy {
-    /** The identity rotation.
-    ```math
-    \vec{a} = I(\vec{a})
-    ```
-    */
+    /// The identity rotation.
+    /// ```math
+    /// \vec{a} = I(\vec{a})
+    /// ```
     #[must_use]
     fn identity() -> Self;
 
-    /** Inverse the rotation.
-    ```math
-    \vec{a} = R^{-1}(R(\vec{a}))
-    ```
-
-    # Example
-    ```
-    # use hoomd_vector::{Rotation};
-    # fn inverse<R: Rotation>(r: R) {
-    let r_inverse = r.inverted();
-    # }
-    ```
-    */
+    /// Inverse the rotation.
+    /// ```math
+    /// \vec{a} = R^{-1}(R(\vec{a}))
+    /// ```
+    ///
+    /// # Example
+    /// ```
+    /// # use hoomd_vector::{Rotation};
+    /// # fn inverse<R: Rotation>(r: R) {
+    /// let r_inverse = r.inverted();
+    /// # }
+    /// ```
     #[must_use]
     fn inverted(self) -> Self;
 
-    /** Combine two rotations.
-
-    The resulting rotation `R_ab` will rotate by **first** `R_b` _followed by_ a
-    rotation of `R_a`.
-
-    ```math
-    R_{ab}(\vec{v})= R_a(R_b(\vec{v}))
-    ```
-
-    # Example
-    ```
-    # use hoomd_vector::{Rotation};
-    # fn inverse<R: Rotation>(R_a: &R, R_b: &R) {
-    let R_ab = R_a.combine(R_b);
-    # }
-    ```
-    */
+    /// Combine two rotations.
+    ///
+    /// The resulting rotation `R_ab` will rotate by **first** `R_b` _followed by_ a
+    /// rotation of `R_a`.
+    ///
+    /// ```math
+    /// R_{ab}(\vec{v})= R_a(R_b(\vec{v}))
+    /// ```
+    ///
+    /// # Example
+    /// ```
+    /// # use hoomd_vector::{Rotation};
+    /// # fn inverse<R: Rotation>(R_a: &R, R_b: &R) {
+    /// let R_ab = R_a.combine(R_b);
+    /// # }
+    /// ```
     #[must_use]
     fn combine(&self, other: &Self) -> Self;
 }
 
-/** Get the relative position and orientation given pairs of positions and orientations.
-
-# Example
-
-```
-use hoomd_vector::{self, Angle, Cartesian};
-use std::f64::consts::PI;
-use ::approx::assert_relative_eq;
-
-let r_a = Cartesian::from([1.0, -2.0]);
-let o_a = Angle::from(PI / 2.0);
-
-let r_b = Cartesian::from([2.0, -1.0]);
-let o_b = Angle::from(PI);
-
-let (v_ab, o_ab) = hoomd_vector::pair_system_to_local(&r_a, &o_a, &r_b, &o_b);
-assert_relative_eq!(v_ab[0], 1.0);
-assert_relative_eq!(v_ab[1], -1.0);
-assert_relative_eq!(o_ab.theta, PI / 2.0);
-```
-*/
+/// Get the relative position and orientation given pairs of positions and orientations.
+///
+/// # Example
+///
+/// ```
+/// use ::approx::assert_relative_eq;
+/// use hoomd_vector::{self, Angle, Cartesian};
+/// use std::f64::consts::PI;
+///
+/// let r_a = Cartesian::from([1.0, -2.0]);
+/// let o_a = Angle::from(PI / 2.0);
+///
+/// let r_b = Cartesian::from([2.0, -1.0]);
+/// let o_b = Angle::from(PI);
+///
+/// let (v_ab, o_ab) =
+///     hoomd_vector::pair_system_to_local(&r_a, &o_a, &r_b, &o_b);
+/// assert_relative_eq!(v_ab[0], 1.0);
+/// assert_relative_eq!(v_ab[1], -1.0);
+/// assert_relative_eq!(o_ab.theta, PI / 2.0);
+/// ```
 #[inline]
 #[expect(clippy::similar_names, reason = "standard math notation")]
 pub fn pair_system_to_local<V, R>(r_a: &V, o_a: &R, r_b: &V, o_b: &R) -> (V, R)

--- a/hoomd-vector/src/lib.rs
+++ b/hoomd-vector/src/lib.rs
@@ -125,23 +125,25 @@
 //! ```
 //! use hoomd_vector::{Angle, Rotate, Rotation, Cartesian};
 //! use std::f64::consts::PI;
+//! use ::approx::assert_relative_eq;
 //!
 //! let v = Cartesian::from([-1.0, 0.0]);
 //! let a = Angle::from(PI / 2.0);
 //! let rotated = a.rotate(&v);
-//! rotated is approximately [0.0, -1.0]
+//! assert_relative_eq!(rotated, [0.0, -1.0].into());
 //! ```
 //!
 //! [`Versor`] implements rotations on [`Cartesian<3>`] vectors.
 //! ```
 //! use hoomd_vector::{Versor, Rotate, Rotation, Cartesian};
 //! use std::f64::consts::PI;
+//! use ::approx::assert_relative_eq;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let a = Cartesian::from([-1.0, 0.0, 0.0]);
 //! let v = Versor::from_axis_angle([0.0, 0.0, 1.0].try_into()?, PI / 2.0);
 //! let b = v.rotate(&a);
-//! b is approximately [0.0, -1.0, 0.0]
+//! assert_relative_eq!(b, [0.0, -1.0, 0.0].into());
 //! # Ok(())
 //! # }
 //! ```
@@ -177,9 +179,9 @@
 //! These unstable features are intended for internal use. `hoomd-vector` may make
 //! breaking changes to the code gated behind unstable features in any release.
 //!
-//! `approx`: Enable `assert_relative_eq` and `assert_abs_diff_eq` from the
-//! [`approx`](https://docs.rs/approx/latest/approx/) crate on [`Cartesian`],
-//! [`Quaternion`] and [`Versor`].
+//! * `approx`: Enable `assert_relative_eq` and `assert_abs_diff_eq` from the
+//!   [`approx`](https://docs.rs/approx/latest/approx/) crate on [`Cartesian`],
+//!   [`Quaternion`] and [`Versor`].
 
 mod angle;
 mod cartesian;
@@ -614,11 +616,12 @@ pub trait Rotate<V: Vector> {
     /// # Example
     /// ```
     /// use hoomd_vector::{Angle, Rotate, Rotation, Cartesian};
+    /// use ::approx::assert_relative_eq;
     ///
     /// let v = Cartesian::from([-1.0, 0.0]);
     /// let a = Angle::from(std::f64::consts::PI / 2.0);
     /// let rotated = a.rotate(&v);
-    /// rotated is approximately [0.0, -1.0]
+    /// assert_relative_eq!(rotated, [0.0, -1.0].into());
     /// ```
     #[must_use]
     fn rotate(&self, vector: &V) -> V;

--- a/hoomd-vector/src/quaternion.rs
+++ b/hoomd-vector/src/quaternion.rs
@@ -1,8 +1,7 @@
 // Copyright (c) 2024-2025 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-/*! Implement [`Quaternion`] and related types.
- */
+//! Implement [`Quaternion`] and related types.
 use rand::{
     Rng,
     distr::{Distribution, StandardUniform, Uniform},
@@ -14,145 +13,144 @@ use std::{
 
 use crate::{Cartesian, Cross, Error, InnerProduct, Rotate, Rotation, RotationMatrix, Unit};
 
-/** Extended complex number.
-
-A quaternion has a real value and three complex values, represented by scalar and 3-vector
-respectively:
-```math
-\mathbf{q} = (s, \vec{v})
-```
-
-Looking for the quaternion representation of 3D rotations? See [`Versor`].
-
-## Constructing quaternions
-
-Create a quaternion with an array of coordinates (`[scalar, vector_0, vector_1, vector_2]`).
-```
-use hoomd_vector::Quaternion;
-
-let q = Quaternion::from([1.0, 2.0, 3.0, 4.0]);
-assert_eq!(q.scalar, 1.0);
-assert_eq!(q.vector, [2.0, 3.0, 4.0].into());
-```
-
-## Quaternion properties
-
-Compute a quaternion's norm:
-```
-use hoomd_vector::Quaternion;
-
-let q = Quaternion::from([3.0, 0.0, 4.0, 0.0]);
-let norm = q.norm();
-assert_eq!(norm, 5.0);
-```
-
-Form the conjugate:
-```
-use hoomd_vector::Quaternion;
-
-let q = Quaternion::from([1.0, 2.0, 3.0, 4.0]);
-let q_star = q.conjugate();
-assert_eq!(q_star, [1.0, -2.0, -3.0, -4.0].into());
-```
-
-## Operating on quaternions
-
-All operation examples use the following two quaternions:
-```
-use hoomd_vector::Quaternion;
-
-let a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
-let b = Quaternion::from([-2.0, 6.0, 4.0, 1.0]);
-```
-
-Addition:
-
-```
-# use hoomd_vector::Quaternion;
-# let a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
-# let b = Quaternion::from([-2.0, 6.0, 4.0, 1.0]);
-let c = a + b;
-assert_eq!(c, [-1.0, 4.0, 10.0, -3.0].into());
-```
-
-```
-# use hoomd_vector::Quaternion;
-# let mut a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
-# let b = Quaternion::from([-2.0, 6.0, 4.0, 1.0]);
-a += b;
-assert_eq!(a, [-1.0, 4.0, 10.0, -3.0].into());
-```
-
-Subtraction:
-
-```
-# use hoomd_vector::Quaternion;
-# let a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
-# let b = Quaternion::from([-2.0, 6.0, 4.0, 1.0]);
-let c = a - b;
-assert_eq!(c, [3.0, -8.0, 2.0, -5.0].into());
-```
-
-```
-# use hoomd_vector::Quaternion;
-# let mut a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
-# let b = Quaternion::from([-2.0, 6.0, 4.0, 1.0]);
-a -= b;
-assert_eq!(a, [3.0, -8.0, 2.0, -5.0].into());
-```
-
-Multiplication by a scalar:
-
-```
-# use hoomd_vector::Quaternion;
-# let a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
-let c = a * 2.0;
-assert_eq!(c, [2.0, -4.0, 12.0, -8.0].into());
-```
-
-```
-# use hoomd_vector::Quaternion;
-# let mut a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
-# let b = Quaternion::from([-2.0, 6.0, 4.0, 1.0]);
-a *= 2.0;
-assert_eq!(a, [2.0, -4.0, 12.0, -8.0].into());
-```
-
-Division by a scalar:
-
-```
-# use hoomd_vector::Quaternion;
-# let a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
-let c = a / 2.0;
-assert_eq!(c, [0.5, -1.0, 3.0, -2.0].into());
-```
-
-```
-# use hoomd_vector::Quaternion;
-# let mut a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
-# let b = Quaternion::from([-2.0, 6.0, 4.0, 1.0]);
-a /= 2.0;
-assert_eq!(a, [0.5, -1.0, 3.0, -2.0].into());
-```
-
-Quaternion multiplication:
-
-```
-# use hoomd_vector::Quaternion;
-# let a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
-# let b = Quaternion::from([-2.0, 6.0, 4.0, 1.0]);
-let c = a * b;
-assert_eq!(c, [-10.0, 32.0, -30.0, -35.0].into());
-```
-
-```
-# use hoomd_vector::Quaternion;
-# let mut a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
-# let b = Quaternion::from([-2.0, 6.0, 4.0, 1.0]);
-a *= b;
-assert_eq!(a, [-10.0, 32.0, -30.0, -35.0].into());
-```
-*/
+/// Extended complex number.
+///
+/// A quaternion has a real value and three complex values, represented by scalar and 3-vector
+/// respectively:
+/// ```math
+/// \mathbf{q} = (s, \vec{v})
+/// ```
+///
+/// Looking for the quaternion representation of 3D rotations? See [`Versor`].
+///
+/// ## Constructing quaternions
+///
+/// Create a quaternion with an array of coordinates (`[scalar, vector_0, vector_1, vector_2]`).
+/// ```
+/// use hoomd_vector::Quaternion;
+///
+/// let q = Quaternion::from([1.0, 2.0, 3.0, 4.0]);
+/// assert_eq!(q.scalar, 1.0);
+/// assert_eq!(q.vector, [2.0, 3.0, 4.0].into());
+/// ```
+///
+/// ## Quaternion properties
+///
+/// Compute a quaternion's norm:
+/// ```
+/// use hoomd_vector::Quaternion;
+///
+/// let q = Quaternion::from([3.0, 0.0, 4.0, 0.0]);
+/// let norm = q.norm();
+/// assert_eq!(norm, 5.0);
+/// ```
+///
+/// Form the conjugate:
+/// ```
+/// use hoomd_vector::Quaternion;
+///
+/// let q = Quaternion::from([1.0, 2.0, 3.0, 4.0]);
+/// let q_star = q.conjugate();
+/// assert_eq!(q_star, [1.0, -2.0, -3.0, -4.0].into());
+/// ```
+///
+/// ## Operating on quaternions
+///
+/// All operation examples use the following two quaternions:
+/// ```
+/// use hoomd_vector::Quaternion;
+///
+/// let a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
+/// let b = Quaternion::from([-2.0, 6.0, 4.0, 1.0]);
+/// ```
+///
+/// Addition:
+///
+/// ```
+/// # use hoomd_vector::Quaternion;
+/// # let a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
+/// # let b = Quaternion::from([-2.0, 6.0, 4.0, 1.0]);
+/// let c = a + b;
+/// assert_eq!(c, [-1.0, 4.0, 10.0, -3.0].into());
+/// ```
+///
+/// ```
+/// # use hoomd_vector::Quaternion;
+/// # let mut a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
+/// # let b = Quaternion::from([-2.0, 6.0, 4.0, 1.0]);
+/// a += b;
+/// assert_eq!(a, [-1.0, 4.0, 10.0, -3.0].into());
+/// ```
+///
+/// Subtraction:
+///
+/// ```
+/// # use hoomd_vector::Quaternion;
+/// # let a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
+/// # let b = Quaternion::from([-2.0, 6.0, 4.0, 1.0]);
+/// let c = a - b;
+/// assert_eq!(c, [3.0, -8.0, 2.0, -5.0].into());
+/// ```
+///
+/// ```
+/// # use hoomd_vector::Quaternion;
+/// # let mut a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
+/// # let b = Quaternion::from([-2.0, 6.0, 4.0, 1.0]);
+/// a -= b;
+/// assert_eq!(a, [3.0, -8.0, 2.0, -5.0].into());
+/// ```
+///
+/// Multiplication by a scalar:
+///
+/// ```
+/// # use hoomd_vector::Quaternion;
+/// # let a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
+/// let c = a * 2.0;
+/// assert_eq!(c, [2.0, -4.0, 12.0, -8.0].into());
+/// ```
+///
+/// ```
+/// # use hoomd_vector::Quaternion;
+/// # let mut a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
+/// # let b = Quaternion::from([-2.0, 6.0, 4.0, 1.0]);
+/// a *= 2.0;
+/// assert_eq!(a, [2.0, -4.0, 12.0, -8.0].into());
+/// ```
+///
+/// Division by a scalar:
+///
+/// ```
+/// # use hoomd_vector::Quaternion;
+/// # let a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
+/// let c = a / 2.0;
+/// assert_eq!(c, [0.5, -1.0, 3.0, -2.0].into());
+/// ```
+///
+/// ```
+/// # use hoomd_vector::Quaternion;
+/// # let mut a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
+/// # let b = Quaternion::from([-2.0, 6.0, 4.0, 1.0]);
+/// a /= 2.0;
+/// assert_eq!(a, [0.5, -1.0, 3.0, -2.0].into());
+/// ```
+///
+/// Quaternion multiplication:
+///
+/// ```
+/// # use hoomd_vector::Quaternion;
+/// # let a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
+/// # let b = Quaternion::from([-2.0, 6.0, 4.0, 1.0]);
+/// let c = a * b;
+/// assert_eq!(c, [-10.0, 32.0, -30.0, -35.0].into());
+/// ```
+///
+/// ```
+/// # use hoomd_vector::Quaternion;
+/// # let mut a = Quaternion::from([1.0, -2.0, 6.0, -4.0]);
+/// # let b = Quaternion::from([-2.0, 6.0, 4.0, 1.0]);
+/// a *= b;
+/// assert_eq!(a, [-10.0, 32.0, -30.0, -35.0].into());
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Quaternion {
     /// Scalar component
@@ -163,60 +161,57 @@ pub struct Quaternion {
 }
 
 impl Quaternion {
-    /** The norm of the quaternion, squared.
-    ```math
-    |\mathbf{q}|^2
-    ```
-
-    # Example
-    ```
-    use hoomd_vector::Quaternion;
-
-    let q = Quaternion::from([3.0, 0.0, 4.0, 0.0]);
-    let norm_squared = q.norm_squared();
-    assert_eq!(norm_squared, 25.0);
-    ```
-    */
+    /// The norm of the quaternion, squared.
+    /// ```math
+    /// |\mathbf{q}|^2
+    /// ```
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::Quaternion;
+    ///
+    /// let q = Quaternion::from([3.0, 0.0, 4.0, 0.0]);
+    /// let norm_squared = q.norm_squared();
+    /// assert_eq!(norm_squared, 25.0);
+    /// ```
     #[inline]
     #[must_use]
     pub fn norm_squared(&self) -> f64 {
         self.scalar * self.scalar + self.vector.dot(&self.vector)
     }
 
-    /** The norm of the quaternion.
-    ```math
-    |\mathbf{q}|
-    ```
-
-    # Example
-    ```
-    use hoomd_vector::Quaternion;
-
-    let q = Quaternion::from([3.0, 0.0, 4.0, 0.0]);
-    let norm = q.norm();
-    assert_eq!(norm, 5.0);
-    ```
-     */
+    /// The norm of the quaternion.
+    /// ```math
+    /// |\mathbf{q}|
+    /// ```
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::Quaternion;
+    ///
+    /// let q = Quaternion::from([3.0, 0.0, 4.0, 0.0]);
+    /// let norm = q.norm();
+    /// assert_eq!(norm, 5.0);
+    /// ```
     #[inline]
     #[must_use]
     pub fn norm(&self) -> f64 {
         self.norm_squared().sqrt()
     }
 
-    /** Construct the conjugate of this quaternion.
-    ```math
-    \mathbf{q}^* = (s, -\vec{v})
-    ```
-
-    # Example
-    ```
-    use hoomd_vector::Quaternion;
-
-    let q = Quaternion::from([1.0, 2.0, 3.0, 4.0]);
-    let q_star = q.conjugate();
-    assert_eq!(q_star, [1.0, -2.0, -3.0, -4.0].into());
-    ```
-    */
+    /// Construct the conjugate of this quaternion.
+    /// ```math
+    /// \mathbf{q}^* = (s, -\vec{v})
+    /// ```
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::Quaternion;
+    ///
+    /// let q = Quaternion::from([1.0, 2.0, 3.0, 4.0]);
+    /// let q_star = q.conjugate();
+    /// assert_eq!(q_star, [1.0, -2.0, -3.0, -4.0].into());
+    /// ```
     #[inline]
     #[must_use]
     pub fn conjugate(self) -> Self {
@@ -226,29 +221,28 @@ impl Quaternion {
         }
     }
 
-    /** Create a [`Versor`] by normalizing the given quaternion.
-
-    ```math
-    \mathbf{v} = \frac{\mathbf{q}}{|\mathbf{q}|}
-    ```
-
-    # Example
-
-    ```
-    use hoomd_vector::{Quaternion, Versor};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let q = Quaternion::from([3.0, 0.0, 0.0, 4.0]);
-    let v = q.to_versor()?;
-    assert_eq!(*v.get(), [3.0/5.0, 0.0, 0.0, 4.0/5.0].into());
-    # Ok(())
-    # }
-    ```
-
-    # Errors
-
-    [`Error::InvalidQuaternionMagnitude`] when `self` is the 0 quaternion.
-    */
+    /// Create a [`Versor`] by normalizing the given quaternion.
+    ///
+    /// ```math
+    /// \mathbf{v} = \frac{\mathbf{q}}{|\mathbf{q}|}
+    /// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_vector::{Quaternion, Versor};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let q = Quaternion::from([3.0, 0.0, 0.0, 4.0]);
+    /// let v = q.to_versor()?;
+    /// assert_eq!(*v.get(), [3.0 / 5.0, 0.0, 0.0, 4.0 / 5.0].into());
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// [`Error::InvalidQuaternionMagnitude`] when `self` is the 0 quaternion.
     #[inline]
     pub fn to_versor(self) -> Result<Versor, Error> {
         let mag = self.norm();
@@ -259,29 +253,28 @@ impl Quaternion {
         }
     }
 
-    /** Create a [`Versor`] by normalizing the given quaternion.
-
-    ```math
-    \mathbf{v} = \frac{\mathbf{q}}{|\mathbf{q}|}
-    ```
-
-    # Example
-
-    ```
-    use hoomd_vector::{Quaternion, Versor};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let q = Quaternion::from([3.0, 0.0, 0.0, 4.0]);
-    let v = q.to_versor_unchecked();
-    assert_eq!(*v.get(), [3.0/5.0, 0.0, 0.0, 4.0/5.0].into());
-    # Ok(())
-    # }
-    ```
-
-    # Panics
-
-    Divide by 0 when `self` is the 0 quaternion.
-    */
+    /// Create a [`Versor`] by normalizing the given quaternion.
+    ///
+    /// ```math
+    /// \mathbf{v} = \frac{\mathbf{q}}{|\mathbf{q}|}
+    /// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_vector::{Quaternion, Versor};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let q = Quaternion::from([3.0, 0.0, 0.0, 4.0]);
+    /// let v = q.to_versor_unchecked();
+    /// assert_eq!(*v.get(), [3.0 / 5.0, 0.0, 0.0, 4.0 / 5.0].into());
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Divide by 0 when `self` is the 0 quaternion.
     #[inline]
     #[must_use]
     pub fn to_versor_unchecked(self) -> Versor {
@@ -290,20 +283,19 @@ impl Quaternion {
 }
 
 impl From<[f64; 4]> for Quaternion {
-    /** Construct a [`Quaternion`] from 4 values.
-
-    The first value is the real part. The 2nd through 4th are the complex vector part:
-    `[scalar, vector_0, vector_1, vector_2]`.
-
-    # Example
-    ```
-    use hoomd_vector::Quaternion;
-
-    let q = Quaternion::from([1.0, 2.0, 3.0, 4.0]);
-    assert_eq!(q.scalar, 1.0);
-    assert_eq!(q.vector, [2.0, 3.0, 4.0].into());
-    ```
-    */
+    /// Construct a [`Quaternion`] from 4 values.
+    ///
+    /// The first value is the real part. The 2nd through 4th are the complex vector part:
+    /// `[scalar, vector_0, vector_1, vector_2]`.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::Quaternion;
+    ///
+    /// let q = Quaternion::from([1.0, 2.0, 3.0, 4.0]);
+    /// assert_eq!(q.scalar, 1.0);
+    /// assert_eq!(q.vector, [2.0, 3.0, 4.0].into());
+    /// ```
     #[inline]
     fn from(value: [f64; 4]) -> Self {
         Self {
@@ -424,107 +416,111 @@ impl SubAssign for Quaternion {
     }
 }
 
-/** A unit [`Quaternion`] that represents a 3D rotation.
-
-[`Versor`] represents a 3D rotation with a **unit quaternion**. Rotation follows the Hamilton
-convention.
-
-## Constructing a [`Versor`]:
-
-The default [`Versor`] is the identity:
-
-```
-use hoomd_vector::Versor;
-
-let v = Versor::default();
-assert_eq!(*v.get(), [1.0, 0.0, 0.0, 0.0].into());
-```
-
-Create a [`Versor`] that rotates by an angle about an axis:
-```
-use hoomd_vector::Versor;
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let v = Versor::from_axis_angle([0.0, 1.0, 0.0].try_into()?, PI / 2.0);
-assert_eq!(*v.get(), [(PI / 4.0).cos(), 0.0, (PI / 4.0).sin(), 0.0].into());
-# Ok(())
-# }
-```
-
-Create a [`Versor`] by normalizing a [`Quaternion`]:
-```
-use hoomd_vector::{Quaternion, Versor};
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let q = Quaternion::from([3.0, 0.0, 0.0, 4.0]);
-let v = q.to_versor()?;
-assert_eq!(*v.get(), [3.0/5.0, 0.0, 0.0, 4.0/5.0].into());
-# Ok(())
-# }
-```
-
-Create a random [`Versor`]:
-```
-use hoomd_vector::Versor;
-use rand::{rngs::StdRng, Rng, SeedableRng};
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let mut rng = StdRng::seed_from_u64(1);
-let v: Versor = rng.random( );
-# Ok(())
-# }
-```
-
-## Operations using [`Versor`]
-
-Rotate a [`Cartesian<3>`] by a [`Versor`]:
-```
-use hoomd_vector::{Versor, Rotate, Rotation, Cartesian};
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let a = Cartesian::from([-1.0, 0.0, 0.0]);
-let v = Versor::from_axis_angle([0.0, 0.0, 1.0].try_into()?, PI / 2.0);
-let b = v.rotate(&a);
-// b is approximately [0.0, -1.0, 0.0]
-# Ok(())
-# }
-```
-
-Combine two rotations together:
-```
-use hoomd_vector::{Versor, Rotation};
-use std::f64::consts::PI;
-
-# fn main() -> Result<(), Box<dyn std::error::Error>> {
-let a = Versor::from_axis_angle([1.0, 0.0, 1.0].try_into()?, PI / 2.0);
-let b = Versor::from_axis_angle([0.0, 0.0, 1.0].try_into()?, PI / 4.0);
-let c = a.combine(&b);
-# Ok(())
-# }
-```
-*/
+/// A unit [`Quaternion`] that represents a 3D rotation.
+///
+/// [`Versor`] represents a 3D rotation with a **unit quaternion**. Rotation follows the Hamilton
+/// convention.
+///
+/// ## Constructing a [`Versor`]:
+///
+/// The default [`Versor`] is the identity:
+///
+/// ```
+/// use hoomd_vector::Versor;
+///
+/// let v = Versor::default();
+/// assert_eq!(*v.get(), [1.0, 0.0, 0.0, 0.0].into());
+/// ```
+///
+/// Create a [`Versor`] that rotates by an angle about an axis:
+/// ```
+/// use hoomd_vector::Versor;
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let v = Versor::from_axis_angle([0.0, 1.0, 0.0].try_into()?, PI / 2.0);
+/// assert_eq!(
+///     *v.get(),
+///     [(PI / 4.0).cos(), 0.0, (PI / 4.0).sin(), 0.0].into()
+/// );
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Create a [`Versor`] by normalizing a [`Quaternion`]:
+/// ```
+/// use hoomd_vector::{Quaternion, Versor};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let q = Quaternion::from([3.0, 0.0, 0.0, 4.0]);
+/// let v = q.to_versor()?;
+/// assert_eq!(*v.get(), [3.0 / 5.0, 0.0, 0.0, 4.0 / 5.0].into());
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Create a random [`Versor`]:
+/// ```
+/// use hoomd_vector::Versor;
+/// use rand::{Rng, SeedableRng, rngs::StdRng};
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut rng = StdRng::seed_from_u64(1);
+/// let v: Versor = rng.random();
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ## Operations using [`Versor`]
+///
+/// Rotate a [`Cartesian<3>`] by a [`Versor`]:
+/// ```
+/// use hoomd_vector::{Versor, Rotate, Rotation, Cartesian};
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let a = Cartesian::from([-1.0, 0.0, 0.0]);
+/// let v = Versor::from_axis_angle([0.0, 0.0, 1.0].try_into()?, PI / 2.0);
+/// let b = v.rotate(&a);
+/// b is approximately [0.0, -1.0, 0.0]
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Combine two rotations together:
+/// ```
+/// use hoomd_vector::{Rotation, Versor};
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let a = Versor::from_axis_angle([1.0, 0.0, 1.0].try_into()?, PI / 2.0);
+/// let b = Versor::from_axis_angle([0.0, 0.0, 1.0].try_into()?, PI / 4.0);
+/// let c = a.combine(&b);
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Versor(Quaternion);
 
 impl Versor {
-    /** Create a [`Versor`] that rotates by an angle (in radians)
-    counterclockwise about an axis.
-
-    # Example
-
-    ```
-    use hoomd_vector::Versor;
-    use std::f64::consts::PI;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let v = Versor::from_axis_angle([0.0, 1.0, 0.0].try_into()?, PI / 2.0);
-    assert_eq!(*v.get(), [(PI / 4.0).cos(), 0.0, (PI / 4.0).sin(), 0.0].into());
-    # Ok(())
-    # }
-    ```
-    */
+    /// Create a [`Versor`] that rotates by an angle (in radians)
+    /// counterclockwise about an axis.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_vector::Versor;
+    /// use std::f64::consts::PI;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let v = Versor::from_axis_angle([0.0, 1.0, 0.0].try_into()?, PI / 2.0);
+    /// assert_eq!(
+    ///     *v.get(),
+    ///     [(PI / 4.0).cos(), 0.0, (PI / 4.0).sin(), 0.0].into()
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     #[must_use]
     pub fn from_axis_angle(axis: Unit<Cartesian<3>>, angle: f64) -> Self {
@@ -536,25 +532,24 @@ impl Versor {
         })
     }
 
-    /** Normalize the versor.
-
-    Nominally, all [`Versor`] instances retain a unit norm. Due to limited
-    floating point precision, this assumption may not hold after repeated
-    operations. Normalize versors when needed to correct this issue.
-
-    # Example
-
-    ```
-    use hoomd_vector::Versor;
-    use std::f64::consts::PI;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let a = Versor::from_axis_angle([0.0, 1.0, 0.0].try_into()?, PI / 2.0);
-    let b = a.normalized();
-    # Ok(())
-    # }
-    ```
-    */
+    /// Normalize the versor.
+    ///
+    /// Nominally, all [`Versor`] instances retain a unit norm. Due to limited
+    /// floating point precision, this assumption may not hold after repeated
+    /// operations. Normalize versors when needed to correct this issue.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_vector::Versor;
+    /// use std::f64::consts::PI;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let a = Versor::from_axis_angle([0.0, 1.0, 0.0].try_into()?, PI / 2.0);
+    /// let b = a.normalized();
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     #[must_use]
     pub fn normalized(self) -> Self {
@@ -575,27 +570,26 @@ impl Versor {
 }
 
 impl From<Versor> for RotationMatrix<3> {
-    /** Construct a rotation matrix equivalent to this versor's rotation.
-
-    When rotating many vectors by the same [`Versor`], improve performance
-    by converting to a matrix first and applying that matrix to the vectors.
-
-    # Example
-    ```
-    use hoomd_vector::{Versor, Rotate, RotationMatrix, Cartesian};
-    use std::f64::consts::PI;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let a = Cartesian::from([-1.0, 0.0, 0.0]);
-    let v = Versor::from_axis_angle([0.0, 0.0, 1.0].try_into()?, PI / 2.0);
-
-    let matrix = RotationMatrix::from(v);
-    let b = matrix.rotate(&a);
-    // b is approximately [0.0, -1.0, 0.0]
-    # Ok(())
-    # }
-    ```
-    */
+    /// Construct a rotation matrix equivalent to this versor's rotation.
+    ///
+    /// When rotating many vectors by the same [`Versor`], improve performance
+    /// by converting to a matrix first and applying that matrix to the vectors.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Versor, Rotate, RotationMatrix, Cartesian};
+    /// use std::f64::consts::PI;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let a = Cartesian::from([-1.0, 0.0, 0.0]);
+    /// let v = Versor::from_axis_angle([0.0, 0.0, 1.0].try_into()?, PI / 2.0);
+    ///
+    /// let matrix = RotationMatrix::from(v);
+    /// let b = matrix.rotate(&a);
+    /// b is approximately [0.0, -1.0, 0.0]
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn from(versor: Versor) -> RotationMatrix<3> {
         let Versor(quaternion) = versor;
@@ -630,15 +624,14 @@ impl From<Versor> for RotationMatrix<3> {
 }
 
 impl Default for Versor {
-    /** Create an identity rotation.
-
-    # Example
-    ```
-    use hoomd_vector::Versor;
-
-    let v = Versor::default();
-    ```
-    */
+    /// Create an identity rotation.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::Versor;
+    ///
+    /// let v = Versor::default();
+    /// ```
     #[inline]
     fn default() -> Self {
         Self(Quaternion {
@@ -651,27 +644,26 @@ impl Default for Versor {
 impl Rotate<Cartesian<3>> for Versor {
     type Matrix = RotationMatrix<3>;
 
-    /** Rotate a [`Cartesian<3>`] by a [`Versor`]
-
-    ```math
-    \mathbf{q} \vec{a} \mathbf{q}^*
-    ```
-
-    # Example
-
-    ```
-    use hoomd_vector::{Versor, Rotate, Rotation, Cartesian};
-    use std::f64::consts::PI;
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let a = Cartesian::from([-1.0, 0.0, 0.0]);
-    let v = Versor::from_axis_angle([0.0, 0.0, 1.0].try_into()?, PI / 2.0);
-    let b = v.rotate(&a);
-    // b is approximately [0.0, -1.0, 0.0]
-    # Ok(())
-    # }
-    ```
-    */
+    /// Rotate a [`Cartesian<3>`] by a [`Versor`]
+    ///
+    /// ```math
+    /// \mathbf{q} \vec{a} \mathbf{q}^*
+    /// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_vector::{Versor, Rotate, Rotation, Cartesian};
+    /// use std::f64::consts::PI;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let a = Cartesian::from([-1.0, 0.0, 0.0]);
+    /// let v = Versor::from_axis_angle([0.0, 0.0, 1.0].try_into()?, PI / 2.0);
+    /// let b = v.rotate(&a);
+    /// b is approximately [0.0, -1.0, 0.0]
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn rotate(&self, vector: &Cartesian<3>) -> Cartesian<3> {
         let Versor(quaternion) = self;
@@ -684,26 +676,25 @@ impl Rotate<Cartesian<3>> for Versor {
 }
 
 impl Rotation for Versor {
-    /** Combine two rotations.
-
-    The resulting versor is obtained by quaternion multiplication.
-    ```math
-    \mathbf{q}_{ab} = \mathbf{q}_a \mathbf{q}_b
-    ```
-
-    # Example
-
-    ```
-    use hoomd_vector::{Versor, Rotation};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let q_a = Versor::from_axis_angle([0.0, 1.0, 0.0].try_into()?, 1.5);
-    let q_b = Versor::from_axis_angle([1.0, 0.0, 0.0].try_into()?, 0.125);
-    let q_ab = q_a.combine(&q_b);
-    # Ok(())
-    # }
-    ```
-    */
+    /// Combine two rotations.
+    ///
+    /// The resulting versor is obtained by quaternion multiplication.
+    /// ```math
+    /// \mathbf{q}_{ab} = \mathbf{q}_a \mathbf{q}_b
+    /// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_vector::{Rotation, Versor};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let q_a = Versor::from_axis_angle([0.0, 1.0, 0.0].try_into()?, 1.5);
+    /// let q_b = Versor::from_axis_angle([1.0, 0.0, 0.0].try_into()?, 0.125);
+    /// let q_ab = q_a.combine(&q_b);
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn combine(&self, other: &Self) -> Self {
         let Versor(a) = self;
@@ -712,39 +703,37 @@ impl Rotation for Versor {
         Versor(a.mul(*b))
     }
 
-    /** Create the identity [`Versor`]: [1, [0, 0, 0]]
-
-    # Example
-
-    ```
-    use hoomd_vector::{Versor, Rotation};
-
-    let identity = Versor::identity();
-    ```
-    */
+    /// Create the identity [`Versor`]: [1, [0, 0, 0]]
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_vector::{Rotation, Versor};
+    ///
+    /// let identity = Versor::identity();
+    /// ```
     #[inline]
     fn identity() -> Self {
         Self::default()
     }
 
-    /** Create a [`Versor`] that performs the inverse rotation of the given versor.
-
-    ```math
-    \mathbf{q}^*
-    ```
-
-    # Example
-
-    ```
-    use hoomd_vector::{Versor, Rotation};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let v = Versor::from_axis_angle([0.0, 1.0, 0.0].try_into()?, 1.5);
-    let v_star = v.inverted();
-    # Ok(())
-    # }
-    ```
-    */
+    /// Create a [`Versor`] that performs the inverse rotation of the given versor.
+    ///
+    /// ```math
+    /// \mathbf{q}^*
+    /// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_vector::{Rotation, Versor};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let v = Versor::from_axis_angle([0.0, 1.0, 0.0].try_into()?, 1.5);
+    /// let v_star = v.inverted();
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn inverted(self) -> Self {
         let Versor(quaternion) = self;
@@ -762,21 +751,20 @@ impl fmt::Display for Versor {
 }
 
 impl Distribution<Versor> for StandardUniform {
-    /** Sample a random [`Versor`] from the uniform distribution over all rotations.
-
-    # Example
-
-    ```
-    use hoomd_vector::Versor;
-    use rand::{rngs::StdRng, Rng, SeedableRng};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut rng = StdRng::seed_from_u64(1);
-    let v: Versor = rng.random();
-    # Ok(())
-    # }
-    ```
-    */
+    /// Sample a random [`Versor`] from the uniform distribution over all rotations.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_vector::Versor;
+    /// use rand::{Rng, SeedableRng, rngs::StdRng};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut rng = StdRng::seed_from_u64(1);
+    /// let v: Versor = rng.random();
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Versor {
         // Algorithm from: https://stackoverflow.com/questions/31600717/how-to-generate-a-random-quaternion-quickly

--- a/hoomd-vector/src/quaternion.rs
+++ b/hoomd-vector/src/quaternion.rs
@@ -475,9 +475,9 @@ impl SubAssign for Quaternion {
 ///
 /// Rotate a [`Cartesian<3>`] by a [`Versor`]:
 /// ```
-/// use hoomd_vector::{Versor, Rotate, Rotation, Cartesian};
-/// use std::f64::consts::PI;
 /// use ::approx::assert_relative_eq;
+/// use hoomd_vector::{Cartesian, Rotate, Rotation, Versor};
+/// use std::f64::consts::PI;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let a = Cartesian::from([-1.0, 0.0, 0.0]);
@@ -578,9 +578,9 @@ impl From<Versor> for RotationMatrix<3> {
     ///
     /// # Example
     /// ```
-    /// use hoomd_vector::{Versor, Rotate, RotationMatrix, Cartesian};
-    /// use std::f64::consts::PI;
     /// use ::approx::assert_relative_eq;
+    /// use hoomd_vector::{Cartesian, Rotate, RotationMatrix, Versor};
+    /// use std::f64::consts::PI;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let a = Cartesian::from([-1.0, 0.0, 0.0]);
@@ -655,9 +655,9 @@ impl Rotate<Cartesian<3>> for Versor {
     /// # Example
     ///
     /// ```
-    /// use hoomd_vector::{Versor, Rotate, Rotation, Cartesian};
-    /// use std::f64::consts::PI;
     /// use ::approx::assert_relative_eq;
+    /// use hoomd_vector::{Cartesian, Rotate, Rotation, Versor};
+    /// use std::f64::consts::PI;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let a = Cartesian::from([-1.0, 0.0, 0.0]);

--- a/hoomd-vector/src/quaternion.rs
+++ b/hoomd-vector/src/quaternion.rs
@@ -477,12 +477,13 @@ impl SubAssign for Quaternion {
 /// ```
 /// use hoomd_vector::{Versor, Rotate, Rotation, Cartesian};
 /// use std::f64::consts::PI;
+/// use ::approx::assert_relative_eq;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let a = Cartesian::from([-1.0, 0.0, 0.0]);
 /// let v = Versor::from_axis_angle([0.0, 0.0, 1.0].try_into()?, PI / 2.0);
 /// let b = v.rotate(&a);
-/// b is approximately [0.0, -1.0, 0.0]
+/// assert_relative_eq!(b, [0.0, -1.0, 0.0].into());
 /// # Ok(())
 /// # }
 /// ```
@@ -579,6 +580,7 @@ impl From<Versor> for RotationMatrix<3> {
     /// ```
     /// use hoomd_vector::{Versor, Rotate, RotationMatrix, Cartesian};
     /// use std::f64::consts::PI;
+    /// use ::approx::assert_relative_eq;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let a = Cartesian::from([-1.0, 0.0, 0.0]);
@@ -586,7 +588,7 @@ impl From<Versor> for RotationMatrix<3> {
     ///
     /// let matrix = RotationMatrix::from(v);
     /// let b = matrix.rotate(&a);
-    /// b is approximately [0.0, -1.0, 0.0]
+    /// assert_relative_eq!(b, [0.0, -1.0, 0.0].into());
     /// # Ok(())
     /// # }
     /// ```
@@ -655,12 +657,13 @@ impl Rotate<Cartesian<3>> for Versor {
     /// ```
     /// use hoomd_vector::{Versor, Rotate, Rotation, Cartesian};
     /// use std::f64::consts::PI;
+    /// use ::approx::assert_relative_eq;
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let a = Cartesian::from([-1.0, 0.0, 0.0]);
     /// let v = Versor::from_axis_angle([0.0, 0.0, 1.0].try_into()?, PI / 2.0);
     /// let b = v.rotate(&a);
-    /// b is approximately [0.0, -1.0, 0.0]
+    /// assert_relative_eq!(b, [0.0, -1.0, 0.0].into());
     /// # Ok(())
     /// # }
     /// ```

--- a/tools/build-wasm-doc-examples/src/main.rs
+++ b/tools/build-wasm-doc-examples/src/main.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::print_stdout, reason = "Provide status updates in tool output")]
 
-/*! Tool that builds all examples with WASM for use in the web docs */
+//! Tool that builds all examples with WASM for use in the web docs
 
 use std::{fs, process::Command};
 


### PR DESCRIPTION
Unfortunately, `rustfmt` doesn't format block doc comments unless you prefix every line with a `*` like this:

<pre>
    /** Construct an empty microstate with open boundary conditions.
     *
     * The microstate starts at step 0, substep 0, random number seed 0,
     * and has no bodies.
     *
     * # Example
     *
     * ```
     * use hoomd_microstate::Microstate;
     * # use hoomd_microstate::{Body, property::Point};
     * # use hoomd_vector::Cartesian;
     *
     * let mut microstate = Microstate::new();
     * assert_eq!(microstate.step(), 0);
     * assert_eq!(microstate.substep(), 0);
     * assert_eq!(microstate.seed(), 0);
     * assert_eq!(microstate.bodies().len(), 0);
     * assert_eq!(microstate.sites().len(),0);
     * # microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])));
     * ```
     */
</pre>

There seems to be a lot of inconsistency in the rust tooling surrounding this type of comment. The `*` are not supposed to be there (https://github.com/rust-lang/rust/issues/92872), yet `rustfmt` will not format the code unless they are. `rustdoc` at times has stripped the leading `*` and included them as part of the markdown at other times. Also, the latest version of `helix` doesn't recognize `/**` styles comments properly for syntax highlighting.

The best solution I can come up with is to enable `normalize_comments` which rewrites all the doc comments with `///` and then formats them.