### PR TITLE
Add dimensionality getter to Vector

### DIFF
--- a/hoomd-vector/src/cartesian.rs
+++ b/hoomd-vector/src/cartesian.rs
@@ -291,21 +291,20 @@ impl<const N: usize> Vector for Cartesian<N> {
             .fold(0.0, |product, x| product + (x.0 - x.1).powi(2))
     }
 
-    /** Return the number of dimensions in this Cartesian vector-space.
-    
-    # Example
-    ```
-    use hoomd_vector::{Cartesian, Vector};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let vec2 = Cartesian::<2>::default();
-    let vec3 = Cartesian::<3>::default();
-    assert_eq!(2, vec2.n_dimensions());
-    assert_eq!(3, vec3.n_dimensions());
-    # Ok(())
-    # }
-    ```
-    */
+    /// Return the number of dimensions in this Cartesian vector space.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Cartesian, Vector};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let vec2 = Cartesian::<2>::default();
+    /// let vec3 = Cartesian::<3>::default();
+    /// assert_eq!(2, vec2.n_dimensions());
+    /// assert_eq!(3, vec3.n_dimensions());
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn n_dimensions(&self) -> usize {
         N

--- a/hoomd-vector/src/cartesian.rs
+++ b/hoomd-vector/src/cartesian.rs
@@ -290,6 +290,26 @@ impl<const N: usize> Vector for Cartesian<N> {
         zip(self.coordinates.iter(), other.coordinates.iter())
             .fold(0.0, |product, x| product + (x.0 - x.1).powi(2))
     }
+
+    /** Return the number of dimensions in this Cartesian vector-space.
+    
+    # Example
+    ```
+    use hoomd_vector::{Cartesian, Vector};
+
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let vec2 = Cartesian::<2>::default();
+    let vec3 = Cartesian::<3>::default();
+    assert_eq!(2, vec2.n_dimensions());
+    assert_eq!(3, vec3.n_dimensions());
+    # Ok(())
+    # }
+    ```
+    */
+    #[inline]
+    fn n_dimensions(&self) -> usize {
+        N
+    }
 }
 
 impl<const N: usize> Add for Cartesian<N> {

--- a/hoomd-vector/src/lib.rs
+++ b/hoomd-vector/src/lib.rs
@@ -373,6 +373,24 @@ pub trait Vector:
     /// ```
     fn distance_squared(&self, other: &Self) -> f64;
 
+
+    /** Return the number of dimensions in this vector-space.
+    
+    # Example
+    ```
+    use hoomd_vector::{Cartesian, Vector};
+
+    # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let vec2 = Cartesian::<2>::default();
+    let vec3 = Cartesian::<3>::default();
+    assert_eq!(2, vec2.n_dimensions());
+    assert_eq!(3, vec3.n_dimensions());
+    # Ok(())
+    # }
+    ```
+    */
+    fn n_dimensions(&self) -> usize;
+
     /// Compute the distance between two vectors belonging to a metric space.
     /// # Example
     /// ```

--- a/hoomd-vector/src/lib.rs
+++ b/hoomd-vector/src/lib.rs
@@ -373,22 +373,20 @@ pub trait Vector:
     /// ```
     fn distance_squared(&self, other: &Self) -> f64;
 
-
-    /** Return the number of dimensions in this vector-space.
-    
-    # Example
-    ```
-    use hoomd_vector::{Cartesian, Vector};
-
-    # fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let vec2 = Cartesian::<2>::default();
-    let vec3 = Cartesian::<3>::default();
-    assert_eq!(2, vec2.n_dimensions());
-    assert_eq!(3, vec3.n_dimensions());
-    # Ok(())
-    # }
-    ```
-    */
+    /// Return the number of dimensions in this vector space.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_vector::{Cartesian, Vector};
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let vec2 = Cartesian::<2>::default();
+    /// let vec3 = Cartesian::<3>::default();
+    /// assert_eq!(2, vec2.n_dimensions());
+    /// assert_eq!(3, vec3.n_dimensions());
+    /// # Ok(())
+    /// # }
+    /// ```
     fn n_dimensions(&self) -> usize;
 
     /// Compute the distance between two vectors belonging to a metric space.


### PR DESCRIPTION
This PR adds a new method to the `Vector` trait definition. The new method returns a `usize` that specifies the dimensionality of the vector-space. For the type `Cartesian<N>`, the method simply returns `N`. This functionality is useful e.g. in the `md` crate, where integration methods require knowledge of the number of degrees of freedom in a system.