### PR TITLE
Add caching to CI scripts

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -22,6 +22,14 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - name: Cache
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Configure Rust
       uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
       with:

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -50,6 +50,14 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - name: Cache
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Configure Rust
       uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
       with:
@@ -68,6 +76,14 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - name: Cache
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Configure Rust
       uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
       with:

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Configure Rust
       uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
       with:
-        toolchain: 1.89.0
+        toolchain: 1.90.0
         targets: wasm32-unknown-unknown
         components: clippy
     - name: Cache

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -17,73 +17,85 @@ env:
   CLICOLOR: 1
 
 jobs:
-  cargo-check:
+  cargo-check-clippy:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - name: Cache
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Configure Rust
       uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
       with:
         toolchain: 1.89.0
         targets: wasm32-unknown-unknown
+    - name: Cache
+      uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
     # Unfortunately, it is not currently possible to mark warnings as errors: https://github.com/rust-lang/cargo/issues/8424#issuecomment-1915265827
     # The workaround does not work for hoomd-rs because we set rust configuration options.
     #
     # Check all targets in debug and release modes
-    - run: cargo check --locked --all-targets --all-features --profile release
-    - run: cargo check --locked --all-targets --all-features --profile dev
-    # Check the examples in wasm builds with and without webgpu
-    - run: cargo check --locked --examples --features "bevy" --profile dev --target wasm32-unknown-unknown
-    - run: cargo check --locked --examples --features "bevy,webgpu" --profile dev --target wasm32-unknown-unknown
+    - run: >
+        cargo check
+        --profile ci
+        --locked
+        --workspace
+        --all-targets
+        --all-features
 
-  cargo-clippy:
-    runs-on: ubuntu-24.04
-    steps:
-    - name: Checkout
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - name: Cache
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Configure Rust
-      uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
-      with:
-        toolchain: 1.89.0
-        components: clippy
-        targets: wasm32-unknown-unknown
-    # Check all targets in debug and release modes
-    - run: cargo clippy --locked --all-targets --all-features --profile release -- -Dwarnings
-    - run: cargo clippy --locked --all-targets --all-features --profile dev -- -Dwarnings
+    - run: >
+        cargo clippy
+        --profile ci
+        --locked
+        --workspace
+        --all-targets
+        --all-features
+        -- -Dwarnings
+
     # Check the examples in wasm builds with and without webgpu
-    - run: cargo clippy --locked --examples --features="bevy" --profile dev --target wasm32-unknown-unknown -- -Dwarnings
-    - run: cargo clippy --locked --examples --features="bevy,webgpu" --profile dev --target wasm32-unknown-unknown -- -Dwarnings
+    - run: >
+        cargo check
+        --profile ci
+        --features "bevy"
+        --locked
+        --workspace
+        --lib
+        --examples
+        --target wasm32-unknown-unknown
+    - run: >
+        cargo check
+        --profile ci
+        --features "bevy,webgpu"
+        --locked
+        --workspace
+        --lib
+        --examples
+        --target wasm32-unknown-unknown
+
+    - run: >
+        cargo clippy
+        --profile ci
+        --features "bevy"
+        --locked
+        --workspace
+        --lib
+        --examples
+        --target wasm32-unknown-unknown
+        -- -Dwarnings
+    - run: >
+        cargo clippy
+        --profile ci
+        --features "bevy,webgpu"
+        --locked
+        --workspace
+        --lib
+        --examples
+        --target wasm32-unknown-unknown
+        -- -Dwarnings
 
   cargo-fmt:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - name: Cache
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - name: Configure Rust
       uses: dtolnay/rust-toolchain@6d653acede28d24f02e3cd41383119e8b1b35921
       with:
@@ -103,7 +115,7 @@ jobs:
   tests_complete:
     name: All style checks
     if: always()
-    needs: [cargo-check, cargo-clippy, cargo-fmt, prek]
+    needs: [cargo-check-clippy, cargo-fmt, prek]
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -27,13 +27,16 @@ jobs:
       with:
         toolchain: 1.89.0
         targets: wasm32-unknown-unknown
+        components: clippy
     - name: Cache
       uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
-    # Unfortunately, it is not currently possible to mark warnings as errors: https://github.com/rust-lang/cargo/issues/8424#issuecomment-1915265827
+    # Unfortunately, it is not currently possible to mark warnings as errors with cargo check:
+    # https://github.com/rust-lang/cargo/issues/8424#issuecomment-1915265827
     # The workaround does not work for hoomd-rs because we set rust configuration options.
     #
     # Check all targets in debug and release modes
-    - run: >
+    - name: cargo check [native]
+      run: >
         cargo check
         --profile ci
         --locked
@@ -41,7 +44,8 @@ jobs:
         --all-targets
         --all-features
 
-    - run: >
+    - name: cargo clippy [native]
+      run: >
         cargo clippy
         --profile ci
         --locked
@@ -51,7 +55,8 @@ jobs:
         -- -Dwarnings
 
     # Check the examples in wasm builds with and without webgpu
-    - run: >
+    - name: cargo check [wasm32, features="bevy"]
+      run: >
         cargo check
         --profile ci
         --features "bevy"
@@ -60,7 +65,8 @@ jobs:
         --lib
         --examples
         --target wasm32-unknown-unknown
-    - run: >
+    - name: cargo check [wasm32, features="bevy"]
+      run: >
         cargo check
         --profile ci
         --features "bevy,webgpu"
@@ -70,7 +76,8 @@ jobs:
         --examples
         --target wasm32-unknown-unknown
 
-    - run: >
+    - name: cargo clippy [wasm32, features="bevy"]
+      run: >
         cargo clippy
         --profile ci
         --features "bevy"
@@ -80,7 +87,8 @@ jobs:
         --examples
         --target wasm32-unknown-unknown
         -- -Dwarnings
-    - run: >
+    - name: cargo clippy [wasm32, features="bevy,webgpu"]
+      run: >
         cargo clippy
         --profile ci
         --features "bevy,webgpu"

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -30,6 +30,9 @@ jobs:
         components: clippy
     - name: Cache
       uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
+      with:
+        cache-bin: false
+
     # Unfortunately, it is not currently possible to mark warnings as errors with cargo check:
     # https://github.com/rust-lang/cargo/issues/8424#issuecomment-1915265827
     # The workaround does not work for hoomd-rs because we set rust configuration options.
@@ -65,7 +68,7 @@ jobs:
         --lib
         --examples
         --target wasm32-unknown-unknown
-    - name: cargo check [wasm32, features="bevy"]
+    - name: cargo check [wasm32, features="bevy,webgpu"]
       run: >
         cargo check
         --profile ci

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,6 +69,14 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - name: Cache
+      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     # This code is needed on GitHub Hosted runners, disable for now while we use private runners.
     # - name: Update rust
     #   run: rustup install ${{ matrix.rust }} --no-self-update

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,14 +42,14 @@ jobs:
         rust:
           # Test multiple rust versions on multiple platforms in the debug profile.
           - 1.88.0
-          - 1.89.0
+          - 1.90.0
         target:
          - ''
 
         include:
         # Add a WASM build.
         - os: ubuntu-24.04
-          rust: 1.89.0
+          rust: 1.90.0
           target: wasm32-unknown-unknown
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,7 +76,7 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-${{ runner.profile }}cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.name }}cargo-${{ hashFiles('**/Cargo.lock') }}
     # This code is needed on GitHub Hosted runners, disable for now while we use private runners.
     # - name: Update rust
     #   run: rustup install ${{ matrix.rust }} --no-self-update

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
       number: 8
 
   unit_test:
-    name: Unit test [${{ matrix.profile }}-rust-${{ matrix.rust }}-${{ matrix.os }}]
+    name: Unit test [rust-${{ matrix.rust }}-${{ matrix.os }}-${{ matrix.target }}]
     runs-on: [self-hosted, jetstream2, CPU]
     strategy:
       fail-fast: false
@@ -73,7 +73,8 @@ jobs:
       run: rustc -vV
     - name: Cache
       uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
-
+      with:
+        key: ${{ matrix.target }}
     - name: Build
       run: >
         cargo build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,6 +75,8 @@ jobs:
       uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
       with:
         key: ${{ matrix.target }}
+        cache-bin: false
+
     - name: Build
       run: >
         cargo build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -89,6 +89,7 @@ jobs:
         --examples
         ${{ matrix.target != '' && '--target' || '' }} ${{ matrix.target }}
         --verbose
+      if: ${{ matrix.target == '' }}
 
     - name: Build [all features]
       run: >

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,7 +74,7 @@ jobs:
     - name: Cache
       uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
       with:
-        key: ${{ matrix.target }}
+        key: ${{ matrix.target || 'native' }}
         cache-bin: false
 
     - name: Build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,7 +76,7 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-${{ runner.profile }}cargo-${{ hashFiles('**/Cargo.lock') }}
     # This code is needed on GitHub Hosted runners, disable for now while we use private runners.
     # - name: Update rust
     #   run: rustup install ${{ matrix.rust }} --no-self-update

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,21 +43,13 @@ jobs:
           # Test multiple rust versions on multiple platforms in the debug profile.
           - 1.88.0
           - 1.89.0
-        profile:
-         - dev
         target:
          - ''
 
         include:
-        # Add a release build on linux with the latest version of rust.
-        - os: ubuntu-24.04
-          rust: 1.89.0
-          profile: release
-
         # Add a WASM build.
         - os: ubuntu-24.04
           rust: 1.89.0
-          profile: dev-wasm
           target: wasm32-unknown-unknown
 
     steps:
@@ -69,14 +61,6 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - name: Cache
-      uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.name }}cargo-${{ hashFiles('**/Cargo.lock') }}
     # This code is needed on GitHub Hosted runners, disable for now while we use private runners.
     # - name: Update rust
     #   run: rustup install ${{ matrix.rust }} --no-self-update
@@ -87,26 +71,28 @@ jobs:
       run: rustup default ${{ matrix.rust }}
     - name: Check rust installation
       run: rustc -vV
+    - name: Cache
+      uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
 
     - name: Build
       run: >
         cargo build
-        --profile ${{ matrix.profile }}
-        ${{ matrix.target != '' && '--target' || '' }}
-        ${{ matrix.target }}
+        --profile=ci
+        --all-features
         --locked
         --workspace
         --lib
         --bins
         --tests
         --examples
-        --all-features
+        ${{ matrix.target != '' && '--target' || '' }} ${{ matrix.target }}
         --verbose
 
     - name: Run tests
       run: >
         cargo test
-        --profile ${{ matrix.profile }}
+        --profile=ci
+        --all-features
         --locked
         --workspace
         --verbose
@@ -115,14 +101,20 @@ jobs:
     - name: Build API documentation
       run: >
         cargo doc
+        --profile=ci
+        --all-features
         --locked
         --workspace
-        --all-features
         --no-deps
       if: ${{ matrix.target == '' }}
 
     - name: Run benchmarks
-      run: cargo bench --locked
+      run: >
+        cargo bench
+        --profile=ci
+        --all-features
+        --locked
+        --workspace
       if: ${{ matrix.target == '' }}
 
   tests_complete:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
       number: 8
 
   unit_test:
-    name: Unit test [rust-${{ matrix.rust }}-${{ matrix.os }}-${{ matrix.target }}]
+    name: Unit test [rust-${{ matrix.rust }}-${{ matrix.os }}-${{ matrix.target || 'native' }}]
     runs-on: [self-hosted, jetstream2, CPU]
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,7 +77,20 @@ jobs:
         key: ${{ matrix.target || 'native' }}
         cache-bin: false
 
-    - name: Build
+    - name: Build [default features]
+      run: >
+        cargo build
+        --profile=ci
+        --locked
+        --workspace
+        --lib
+        --bins
+        --tests
+        --examples
+        ${{ matrix.target != '' && '--target' || '' }} ${{ matrix.target }}
+        --verbose
+
+    - name: Build [all features]
       run: >
         cargo build
         --profile=ci

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,8 +150,12 @@ lto = 'thin'  # TODO: Switch back to true after migrating to GitHub Pages for do
 codegen-units = 1
 inherits = "release"
 
-[profile.dev-wasm]
-inherits = "dev"
+# Reduce the size of binaries generated in CI builds.
+[profile.ci]
+inherits = "release"
+opt-level = 'z'
+strip = true
+codegen-units = 256
 
 # Bevy is extremely slow in debug builds, build it with optimizations
 # to avoid this: https://bevy.org/learn/quick-start/getting-started/setup/#compile-with-performance-optimizations


### PR DESCRIPTION
This definitely improves performance and does not seem to result in cache collisions between different versions of rust, although I'd love an extra pair of eyes to validate that. I used `${{ runner.name }}` for the test CI to ensure a separate cache would be kept for each matrix entry. This causes cache misses on jet stream (as the cpu index is included as part of the name it seems?) but should be fine on GitHub actions, where the naming is more consistent. It probably doesn't matter if we use `${{ runner.name }}` or `${{ runner.os }}` but I figured I'd err on the side of caution.
