### PR TITLE
Add collision tests for elongated bodies

### DIFF
--- a/hoomd-geometry/benches/overlaps.rs
+++ b/hoomd-geometry/benches/overlaps.rs
@@ -359,11 +359,7 @@ mod ellipsoid {
                     create_offset_2d(&mut rng),
                 )
             })
-            .bench_local_values(|((e0, e1), (t, r))| {
-                let e0 = Convex(e0);
-                let e1 = Convex(e1);
-                black_box(e0.intersects_at(&e1, &t, &r))
-            });
+            .bench_local_values(|((e0, e1), (t, r))| black_box(e0.intersects_at(&e1, &t, &r)));
     }
 
     #[divan::bench]
@@ -379,6 +375,21 @@ mod ellipsoid {
                 )
             })
             .bench_local_values(|((t0, t1), (t, r))| black_box(collide3d(&t0, &t1, &t, &r)));
+    }
+
+    #[divan::bench]
+    fn fast_3d(bencher: Bencher) {
+        let mut rng = StdRng::seed_from_u64(1);
+
+        bencher
+            .counter(ItemsCount::from(1_u32))
+            .with_inputs(|| {
+                (
+                    create_ellipsoid_pair::<3, _>(&mut rng),
+                    create_offset_3d(&mut rng),
+                )
+            })
+            .bench_local_values(|((e0, e1), (t, r))| black_box(e0.intersects_at(&e1, &t, &r)));
     }
 }
 

--- a/hoomd-geometry/benches/overlaps.rs
+++ b/hoomd-geometry/benches/overlaps.rs
@@ -17,9 +17,8 @@ use hoomd_geometry::{
     },
     xenocollide::{collide2d, collide3d},
 };
-use rand::{Rng, SeedableRng, rngs::StdRng};
-
 use hoomd_vector::{Angle, Cartesian, Versor};
+use rand::{Rng, SeedableRng, rngs::StdRng};
 
 #[inline(never)]
 fn asm_collide3d() {
@@ -162,180 +161,223 @@ fn create_offset_3d<R: Rng>(rng: &mut R) -> (Cartesian<3>, Versor) {
 const DIMENSIONS: &[usize] = &[2, 3, 4];
 const NUM_VERTICES: &[usize] = &[3, 4, 8, 16, 64, 256];
 
-#[divan::bench(consts = DIMENSIONS)]
-fn sphere_fast_nd<const N: usize>(bencher: Bencher) {
-    let mut rng = StdRng::seed_from_u64(1);
+#[divan::bench_group]
+mod sphere {
+    use super::*;
 
-    bencher
-        .counter(ItemsCount::from(1_u32))
-        .with_inputs(|| {
-            (
-                create_sphere_pair::<N, _>(&mut rng),
-                create_offset::<N, _>(&mut rng),
-            )
-        })
-        .bench_local_values(|((s0, s1), t)| black_box(s0.intersects(&s1, &t)));
+    #[divan::bench(consts = DIMENSIONS)]
+    fn fast_nd<const N: usize>(bencher: Bencher) {
+        let mut rng = StdRng::seed_from_u64(1);
+
+        bencher
+            .counter(ItemsCount::from(1_u32))
+            .with_inputs(|| {
+                (
+                    create_sphere_pair::<N, _>(&mut rng),
+                    create_offset::<N, _>(&mut rng),
+                )
+            })
+            .bench_local_values(|((s0, s1), t)| black_box(s0.intersects(&s1, &t)));
+    }
+
+    #[divan::bench]
+    fn xenocollide_2d(bencher: Bencher) {
+        let mut rng = StdRng::seed_from_u64(1);
+
+        bencher
+            .counter(ItemsCount::from(1_u32))
+            .with_inputs(|| {
+                (
+                    shapes_to_convex(create_sphere_pair::<2, _>(&mut rng)),
+                    create_offset_2d(&mut rng),
+                )
+            })
+            .bench_local_values(|((s0, s1), (t, r))| black_box(collide2d(&s0, &s1, &t, &r)));
+    }
+
+    #[divan::bench(sample_size = 10_000)]
+    fn xenocollide_3d(bencher: Bencher) {
+        let mut rng = StdRng::seed_from_u64(1);
+
+        bencher
+            .counter(ItemsCount::from(1_u32))
+            .with_inputs(|| {
+                (
+                    shapes_to_convex(create_sphere_pair::<3, _>(&mut rng)),
+                    create_offset_3d(&mut rng),
+                )
+            })
+            .bench_local_values(|((s0, s1), (t, r))| black_box(collide3d(&s0, &s1, &t, &r)));
+    }
 }
 
-#[divan::bench]
-fn sphere_xenocollide_2d(bencher: Bencher) {
-    let mut rng = StdRng::seed_from_u64(1);
+#[divan::bench_group]
+mod cuboid {
+    use super::*;
 
-    bencher
-        .counter(ItemsCount::from(1_u32))
-        .with_inputs(|| {
-            (
-                shapes_to_convex(create_sphere_pair::<2, _>(&mut rng)),
-                create_offset_2d(&mut rng),
-            )
-        })
-        .bench_local_values(|((s0, s1), (t, r))| black_box(collide2d(&s0, &s1, &t, &r)));
+    #[divan::bench(consts = DIMENSIONS)]
+    fn aligned_nd<const N: usize>(bencher: Bencher) {
+        let mut rng = StdRng::seed_from_u64(1);
+
+        bencher
+            .counter(ItemsCount::from(1_u32))
+            .with_inputs(|| {
+                (
+                    create_cuboid_pair::<N, _>(&mut rng),
+                    create_offset::<N, _>(&mut rng),
+                )
+            })
+            .bench_local_values(|((s0, s1), t)| black_box(s0.intersects_aligned(&s1, &t)));
+    }
+
+    #[divan::bench]
+    fn xenocollide_2d(bencher: Bencher) {
+        let mut rng = StdRng::seed_from_u64(1);
+
+        bencher
+            .counter(ItemsCount::from(1_u32))
+            .with_inputs(|| {
+                (
+                    shapes_to_convex(create_cuboid_pair::<2, _>(&mut rng)),
+                    create_offset_2d(&mut rng),
+                )
+            })
+            .bench_local_values(|((c0, c1), (t, r))| black_box(c0.intersects_at(&c1, &t, &r)));
+    }
+
+    #[divan::bench]
+    fn xenocollide_3d(bencher: Bencher) {
+        let mut rng = StdRng::seed_from_u64(1);
+
+        bencher
+            .counter(ItemsCount::from(1_u32))
+            .with_inputs(|| {
+                (
+                    shapes_to_convex(create_cuboid_pair::<3, _>(&mut rng)),
+                    create_offset_3d(&mut rng),
+                )
+            })
+            .bench_local_values(|((c0, c1), (t, r))| black_box(c0.intersects_at(&c1, &t, &r)));
+    }
 }
 
-#[divan::bench(sample_size = 10_000)]
-fn sphere_xenocollide_3d(bencher: Bencher) {
-    let mut rng = StdRng::seed_from_u64(1);
+#[divan::bench_group()]
+mod polytopes {
 
-    bencher
-        .counter(ItemsCount::from(1_u32))
-        .with_inputs(|| {
-            (
-                shapes_to_convex(create_sphere_pair::<3, _>(&mut rng)),
-                create_offset_3d(&mut rng),
-            )
-        })
-        .bench_local_values(|((s0, s1), (t, r))| black_box(collide3d(&s0, &s1, &t, &r)));
+    use super::*;
+
+    #[divan::bench(consts = NUM_VERTICES)]
+    fn polygon_2d<const N: usize>(bencher: Bencher) {
+        let mut rng = StdRng::seed_from_u64(1);
+
+        bencher
+            .counter(ItemsCount::from(1_u32))
+            .with_inputs(|| {
+                (
+                    shapes_to_convex(create_polygon_pair::<N>()),
+                    create_offset_2d(&mut rng),
+                )
+            })
+            .bench_local_values(|((p0, p1), (t, r))| black_box(collide2d(&p0, &p1, &t, &r)));
+    }
+
+    #[divan::bench(consts = NUM_VERTICES)]
+    fn dipyramid_3d<const N: usize>(bencher: Bencher) {
+        let mut rng = StdRng::seed_from_u64(1);
+
+        bencher
+            .counter(ItemsCount::from(1_u32))
+            .with_inputs(|| {
+                (
+                    shapes_to_convex(create_dipyramid_pair::<N, _>(&mut rng, 10.0)),
+                    create_offset_3d(&mut rng),
+                )
+            })
+            .bench_local_values(|((p0, p1), (t, r))| black_box(collide3d(&p0, &p1, &t, &r)));
+    }
 }
 
-/// Note this is not 1:1 with the naive test, as this uses oriented cuboids!
-#[divan::bench]
-fn cuboid_xenocollide_2d(bencher: Bencher) {
-    let mut rng = StdRng::seed_from_u64(1);
+#[divan::bench_group]
+mod simplex {
+    use super::*;
+    #[divan::bench]
+    fn xenocollide_3d(bencher: Bencher) {
+        let mut rng = StdRng::seed_from_u64(1);
 
-    bencher
-        .counter(ItemsCount::from(1_u32))
-        .with_inputs(|| {
-            (
-                shapes_to_convex(create_cuboid_pair::<2, _>(&mut rng)),
-                create_offset_2d(&mut rng),
-            )
-        })
-        .bench_local_values(|((c0, c1), (t, r))| black_box(c0.intersects_at(&c1, &t, &r)));
+        bencher
+            .counter(ItemsCount::from(1_u32))
+            .with_inputs(|| {
+                (
+                    shapes_to_convex(create_simplex_pair(&mut rng)),
+                    create_offset_3d(&mut rng),
+                )
+            })
+            .bench_local_values(|((t0, t1), (t, r))| black_box(collide3d(&t0, &t1, &t, &r)));
+    }
+
+    #[divan::bench]
+    fn fast_3d(bencher: Bencher) {
+        let mut rng = StdRng::seed_from_u64(1);
+
+        bencher
+            .counter(ItemsCount::from(1_u32))
+            .with_inputs(|| (create_simplex_pair(&mut rng), create_offset_3d(&mut rng)))
+            .bench_local_values(|((t0, t1), (t, r))| black_box(t0.intersects_at(&t1, &t, &r)));
+    }
 }
 
-#[divan::bench]
-fn cuboid_xenocollide_3d(bencher: Bencher) {
-    let mut rng = StdRng::seed_from_u64(1);
+#[divan::bench_group]
+mod ellipsoid {
+    use super::*;
 
-    bencher
-        .counter(ItemsCount::from(1_u32))
-        .with_inputs(|| {
-            (
-                shapes_to_convex(create_cuboid_pair::<3, _>(&mut rng)),
-                create_offset_3d(&mut rng),
-            )
-        })
-        .bench_local_values(|((c0, c1), (t, r))| black_box(c0.intersects_at(&c1, &t, &r)));
-}
+    #[divan::bench]
+    fn xenocollide_2d(bencher: Bencher) {
+        let mut rng = StdRng::seed_from_u64(1);
 
-#[divan::bench(consts = NUM_VERTICES, )]
-fn polygon_xenocollide_2d<const N: usize>(bencher: Bencher) {
-    let mut rng = StdRng::seed_from_u64(1);
+        bencher
+            .counter(ItemsCount::from(1_u32))
+            .with_inputs(|| {
+                (
+                    shapes_to_convex(create_ellipsoid_pair::<2, _>(&mut rng)),
+                    create_offset_2d(&mut rng),
+                )
+            })
+            .bench_local_values(|((t0, t1), (t, r))| black_box(collide2d(&t0, &t1, &t, &r)));
+    }
 
-    bencher
-        .counter(ItemsCount::from(1_u32))
-        .with_inputs(|| {
-            (
-                shapes_to_convex(create_polygon_pair::<N>()),
-                create_offset_2d(&mut rng),
-            )
-        })
-        .bench_local_values(|((p0, p1), (t, r))| black_box(collide2d(&p0, &p1, &t, &r)));
-}
+    #[divan::bench]
+    fn fast_2d(bencher: Bencher) {
+        let mut rng = StdRng::seed_from_u64(1);
 
-#[divan::bench(consts = NUM_VERTICES, )]
-fn dipyramid_xenocollide_3d<const N: usize>(bencher: Bencher) {
-    let mut rng = StdRng::seed_from_u64(1);
+        bencher
+            .counter(ItemsCount::from(1_u32))
+            .with_inputs(|| {
+                (
+                    create_ellipsoid_pair::<2, _>(&mut rng),
+                    create_offset_2d(&mut rng),
+                )
+            })
+            .bench_local_values(|((e0, e1), (t, r))| {
+                let e0 = Convex(e0);
+                let e1 = Convex(e1);
+                black_box(e0.intersects_at(&e1, &t, &r))
+            });
+    }
 
-    bencher
-        .counter(ItemsCount::from(1_u32))
-        .with_inputs(|| {
-            (
-                shapes_to_convex(create_dipyramid_pair::<N, _>(&mut rng, 10.0)),
-                create_offset_3d(&mut rng),
-            )
-        })
-        .bench_local_values(|((p0, p1), (t, r))| black_box(collide3d(&p0, &p1, &t, &r)));
-}
+    #[divan::bench]
+    fn xenocollide_3d(bencher: Bencher) {
+        let mut rng = StdRng::seed_from_u64(1);
 
-#[divan::bench]
-fn simplex_xenocollide_3d(bencher: Bencher) {
-    let mut rng = StdRng::seed_from_u64(1);
-
-    bencher
-        .counter(ItemsCount::from(1_u32))
-        .with_inputs(|| {
-            (
-                shapes_to_convex(create_simplex_pair(&mut rng)),
-                create_offset_3d(&mut rng),
-            )
-        })
-        .bench_local_values(|((t0, t1), (t, r))| black_box(collide3d(&t0, &t1, &t, &r)));
-}
-
-#[divan::bench]
-fn ellipsoid_xenocollide_2d(bencher: Bencher) {
-    let mut rng = StdRng::seed_from_u64(1);
-
-    bencher
-        .counter(ItemsCount::from(1_u32))
-        .with_inputs(|| {
-            (
-                shapes_to_convex(create_ellipsoid_pair::<2, _>(&mut rng)),
-                create_offset_2d(&mut rng),
-            )
-        })
-        .bench_local_values(|((t0, t1), (t, r))| black_box(collide2d(&t0, &t1, &t, &r)));
-}
-
-#[divan::bench]
-fn ellipsoid_fast_2d(bencher: Bencher) {
-    let mut rng = StdRng::seed_from_u64(1);
-
-    bencher
-        .counter(ItemsCount::from(1_u32))
-        .with_inputs(|| {
-            (
-                shapes_to_convex(create_ellipsoid_pair::<2, _>(&mut rng)),
-                create_offset_2d(&mut rng),
-            )
-        })
-        .bench_local_values(|((e0, e1), (t, r))| black_box(e0.intersects_at(&e1, &t, &r)));
-}
-
-#[divan::bench]
-fn ellipsoid_xenocollide_3d(bencher: Bencher) {
-    let mut rng = StdRng::seed_from_u64(1);
-
-    bencher
-        .counter(ItemsCount::from(1_u32))
-        .with_inputs(|| {
-            (
-                shapes_to_convex(create_ellipsoid_pair::<3, _>(&mut rng)),
-                create_offset_3d(&mut rng),
-            )
-        })
-        .bench_local_values(|((t0, t1), (t, r))| black_box(collide3d(&t0, &t1, &t, &r)));
-}
-
-#[divan::bench]
-fn simplex_fast(bencher: Bencher) {
-    let mut rng = StdRng::seed_from_u64(1);
-
-    bencher
-        .counter(ItemsCount::from(1_u32))
-        .with_inputs(|| (create_simplex_pair(&mut rng), create_offset_3d(&mut rng)))
-        .bench_local_values(|((t0, t1), (t, r))| black_box(t0.intersects_at(&t1, &t, &r)));
+        bencher
+            .counter(ItemsCount::from(1_u32))
+            .with_inputs(|| {
+                (
+                    shapes_to_convex(create_ellipsoid_pair::<3, _>(&mut rng)),
+                    create_offset_3d(&mut rng),
+                )
+            })
+            .bench_local_values(|((t0, t1), (t, r))| black_box(collide3d(&t0, &t1, &t, &r)));
+    }
 }
 
 fn create_cylinder_pair<R: Rng>(rng: &mut R) -> (Cylinder, Cylinder) {
@@ -363,14 +405,21 @@ fn create_cylinder_pair<R: Rng>(rng: &mut R) -> (Cylinder, Cylinder) {
     )
 }
 
-#[divan::bench]
-fn infinite_cylinder(bencher: Bencher) {
-    let mut rng = StdRng::seed_from_u64(1);
+#[divan::bench_group]
+mod cylinder {
+    use super::*;
 
-    bencher
-        .counter(ItemsCount::from(1_u32))
-        .with_inputs(|| (create_cylinder_pair(&mut rng), create_offset_3d(&mut rng)))
-        .bench_local_values(|((c0, c1), (t, r))| black_box(c0.intersects_at_infinite(&c1, &t, &r)));
+    #[divan::bench]
+    fn infinite_3d(bencher: Bencher) {
+        let mut rng = StdRng::seed_from_u64(1);
+
+        bencher
+            .counter(ItemsCount::from(1_u32))
+            .with_inputs(|| (create_cylinder_pair(&mut rng), create_offset_3d(&mut rng)))
+            .bench_local_values(|((c0, c1), (t, r))| {
+                black_box(c0.intersects_at_infinite(&c1, &t, &r))
+            });
+    }
 }
 
 fn create_capsule_pair<R: Rng>(rng: &mut R) -> (Capsule<3>, Capsule<3>) {
@@ -397,28 +446,32 @@ fn create_capsule_pair<R: Rng>(rng: &mut R) -> (Capsule<3>, Capsule<3>) {
         },
     )
 }
+#[divan::bench_group]
+mod capsule {
+    use super::*;
 
-#[divan::bench]
-fn capsule_fast_3d(bencher: Bencher) {
-    let mut rng = StdRng::seed_from_u64(1);
+    #[divan::bench]
+    fn fast_3d(bencher: Bencher) {
+        let mut rng = StdRng::seed_from_u64(1);
 
-    bencher
-        .counter(ItemsCount::from(1_u32))
-        .with_inputs(|| (create_capsule_pair(&mut rng), create_offset_3d(&mut rng)))
-        .bench_local_values(|((c0, c1), (t, r))| black_box(c0.intersects_at(&c1, &t, &r)));
-}
+        bencher
+            .counter(ItemsCount::from(1_u32))
+            .with_inputs(|| (create_capsule_pair(&mut rng), create_offset_3d(&mut rng)))
+            .bench_local_values(|((c0, c1), (t, r))| black_box(c0.intersects_at(&c1, &t, &r)));
+    }
 
-#[divan::bench]
-fn capsule_xenocollide_3d(bencher: Bencher) {
-    let mut rng = StdRng::seed_from_u64(1);
+    #[divan::bench]
+    fn xenocollide_3d(bencher: Bencher) {
+        let mut rng = StdRng::seed_from_u64(1);
 
-    bencher
-        .counter(ItemsCount::from(1_u32))
-        .with_inputs(|| {
-            (
-                shapes_to_convex(create_capsule_pair(&mut rng)),
-                create_offset_3d(&mut rng),
-            )
-        })
-        .bench_local_values(|((c0, c1), (t, r))| black_box(c0.intersects_at(&c1, &t, &r)));
+        bencher
+            .counter(ItemsCount::from(1_u32))
+            .with_inputs(|| {
+                (
+                    shapes_to_convex(create_capsule_pair(&mut rng)),
+                    create_offset_3d(&mut rng),
+                )
+            })
+            .bench_local_values(|((c0, c1), (t, r))| black_box(c0.intersects_at(&c1, &t, &r)));
+    }
 }

--- a/hoomd-geometry/benches/overlaps.rs
+++ b/hoomd-geometry/benches/overlaps.rs
@@ -12,7 +12,9 @@
 use divan::{self, Bencher, black_box, counter::ItemsCount};
 use hoomd_geometry::{
     Convex, IntersectsAt,
-    shape::{ConvexPolytope, Cylinder, Hypercuboid, Hyperellipsoid, Hypersphere, Simplex3},
+    shape::{
+        Capsule, ConvexPolytope, Cylinder, Hypercuboid, Hyperellipsoid, Hypersphere, Simplex3,
+    },
     xenocollide::{collide2d, collide3d},
 };
 use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -369,4 +371,54 @@ fn infinite_cylinder(bencher: Bencher) {
         .counter(ItemsCount::from(1_u32))
         .with_inputs(|| (create_cylinder_pair(&mut rng), create_offset_3d(&mut rng)))
         .bench_local_values(|((c0, c1), (t, r))| black_box(c0.intersects_at_infinite(&c1, &t, &r)));
+}
+
+fn create_capsule_pair<R: Rng>(rng: &mut R) -> (Capsule<3>, Capsule<3>) {
+    (
+        Capsule {
+            radius: rng
+                .random_range(0.0..10.0)
+                .try_into()
+                .expect("test value is a positive real"),
+            height: rng
+                .random_range(0.0..10.0)
+                .try_into()
+                .expect("test value is a positive real"),
+        },
+        Capsule {
+            radius: rng
+                .random_range(0.0..10.0)
+                .try_into()
+                .expect("test value is a positive real"),
+            height: rng
+                .random_range(0.0..10.0)
+                .try_into()
+                .expect("test value is a positive real"),
+        },
+    )
+}
+
+#[divan::bench]
+fn capsule_fast_3d(bencher: Bencher) {
+    let mut rng = StdRng::seed_from_u64(1);
+
+    bencher
+        .counter(ItemsCount::from(1_u32))
+        .with_inputs(|| (create_capsule_pair(&mut rng), create_offset_3d(&mut rng)))
+        .bench_local_values(|((c0, c1), (t, r))| black_box(c0.intersects_at(&c1, &t, &r)));
+}
+
+#[divan::bench]
+fn capsule_xenocollide_3d(bencher: Bencher) {
+    let mut rng = StdRng::seed_from_u64(1);
+
+    bencher
+        .counter(ItemsCount::from(1_u32))
+        .with_inputs(|| {
+            (
+                shapes_to_convex(create_capsule_pair(&mut rng)),
+                create_offset_3d(&mut rng),
+            )
+        })
+        .bench_local_values(|((c0, c1), (t, r))| black_box(c0.intersects_at(&c1, &t, &r)));
 }

--- a/hoomd-geometry/benches/overlaps.rs
+++ b/hoomd-geometry/benches/overlaps.rs
@@ -376,21 +376,6 @@ mod ellipsoid {
             })
             .bench_local_values(|((t0, t1), (t, r))| black_box(collide3d(&t0, &t1, &t, &r)));
     }
-
-    #[divan::bench]
-    fn fast_3d(bencher: Bencher) {
-        let mut rng = StdRng::seed_from_u64(1);
-
-        bencher
-            .counter(ItemsCount::from(1_u32))
-            .with_inputs(|| {
-                (
-                    create_ellipsoid_pair::<3, _>(&mut rng),
-                    create_offset_3d(&mut rng),
-                )
-            })
-            .bench_local_values(|((e0, e1), (t, r))| black_box(e0.intersects_at(&e1, &t, &r)));
-    }
 }
 
 fn create_cylinder_pair<R: Rng>(rng: &mut R) -> (Cylinder, Cylinder) {

--- a/hoomd-geometry/benches/overlaps.rs
+++ b/hoomd-geometry/benches/overlaps.rs
@@ -6,6 +6,7 @@
     reason = "benches don't need public documentation"
 )]
 #![expect(clippy::unwrap_used, reason = "benches can use unwrap where needed")]
+#![expect(clippy::wildcard_imports, reason = "simplifies code")]
 
 //! Benchmark overlaps
 
@@ -300,6 +301,7 @@ mod polytopes {
 #[divan::bench_group]
 mod simplex {
     use super::*;
+
     #[divan::bench]
     fn xenocollide_3d(bencher: Bencher) {
         let mut rng = StdRng::seed_from_u64(1);

--- a/hoomd-geometry/benches/overlaps.rs
+++ b/hoomd-geometry/benches/overlaps.rs
@@ -12,7 +12,7 @@
 use divan::{self, Bencher, black_box, counter::ItemsCount};
 use hoomd_geometry::{
     Convex, IntersectsAt,
-    shape::{ConvexPolytope, Hypercuboid, Hyperellipsoid, Hypersphere, Simplex3},
+    shape::{ConvexPolytope, Cylinder, Hypercuboid, Hyperellipsoid, Hypersphere, Simplex3},
     xenocollide::{collide2d, collide3d},
 };
 use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -334,4 +334,39 @@ fn simplex_fast(bencher: Bencher) {
         .counter(ItemsCount::from(1_u32))
         .with_inputs(|| (create_simplex_pair(&mut rng), create_offset_3d(&mut rng)))
         .bench_local_values(|((t0, t1), (t, r))| black_box(t0.intersects_at(&t1, &t, &r)));
+}
+
+fn create_cylinder_pair<R: Rng>(rng: &mut R) -> (Cylinder, Cylinder) {
+    (
+        Cylinder {
+            radius: rng
+                .random_range(0.0..10.0)
+                .try_into()
+                .expect("test value is a positive real"),
+            height: rng
+                .random_range(0.0..10.0)
+                .try_into()
+                .expect("test value is a positive real"),
+        },
+        Cylinder {
+            radius: rng
+                .random_range(0.0..10.0)
+                .try_into()
+                .expect("test value is a positive real"),
+            height: rng
+                .random_range(0.0..10.0)
+                .try_into()
+                .expect("test value is a positive real"),
+        },
+    )
+}
+
+#[divan::bench]
+fn infinite_cylinder(bencher: Bencher) {
+    let mut rng = StdRng::seed_from_u64(1);
+
+    bencher
+        .counter(ItemsCount::from(1_u32))
+        .with_inputs(|| (create_cylinder_pair(&mut rng), create_offset_3d(&mut rng)))
+        .bench_local_values(|((c0, c1), (t, r))| black_box(c0.intersects_at_infinite(&c1, &t, &r)));
 }

--- a/hoomd-geometry/src/shape.rs
+++ b/hoomd-geometry/src/shape.rs
@@ -12,7 +12,7 @@
 //! encodes the dimensionality.
 
 mod capsule;
-pub use capsule::Capsule;
+pub use capsule::{Capsule, Spherocylinder};
 
 mod convex_polytope;
 pub use convex_polytope::{ConvexPolygon, ConvexPolyhedron, ConvexPolytope};

--- a/hoomd-geometry/src/shape/capsule.rs
+++ b/hoomd-geometry/src/shape/capsule.rs
@@ -469,30 +469,13 @@ mod tests {
                 height: h2.try_into()?,
             };
 
-            let x = rng.random_range(-5.0..5.0);
-            let y = rng.random_range(-5.0..5.0);
-            let z = rng.random_range(-5.0..5.0);
-            let v_ij = [x, y, z].into();
+            let v_ij = (rng.random::<Cartesian<_>>() * 10.0) - Cartesian::from([5.0; 3]);
 
-            // Generate a random axis for rotation
-            let axis: Cartesian<3> = [
-                rng.random_range(-1.0..1.0),
-                rng.random_range(-1.0..1.0),
-                rng.random_range(-1.0..1.0),
-            ]
-            .into();
-            let axis = axis.to_unit()?.0; // Normalize
-
-            let angle = rng.random_range(0.0..2.0 * PI);
-
-            let o_ij = Versor::from_axis_angle(axis, angle);
+            let o_ij = rng.random::<Versor>();
 
             let result_direct = capsule1.intersects_at(&capsule2, &v_ij, &o_ij);
 
-            let convex_capsule1 = Convex(capsule1);
-            let convex_capsule2 = Convex(capsule2);
-            let result_xeno = convex_capsule1.intersects_at(&convex_capsule2, &v_ij, &o_ij);
-
+            let result_xeno = Convex(capsule1).intersects_at(&Convex(capsule2), &v_ij, &o_ij);
             assert_eq!(
                 result_direct, result_xeno,
                 "Failed with r1={r1}, h1={h1}, r2={r2}, h2={h2}, v_ij={v_ij:?}, o_ij={o_ij:?}"

--- a/hoomd-geometry/src/shape/capsule.rs
+++ b/hoomd-geometry/src/shape/capsule.rs
@@ -74,6 +74,8 @@ pub struct Capsule<const N: usize> {
     pub height: PositiveReal,
 }
 
+type SpheroCylinder = Capsule<3>;
+
 impl<const N: usize> SupportMapping<Cartesian<N>> for Capsule<N> {
     #[inline]
     fn support_mapping(&self, n: &Cartesian<N>) -> Cartesian<N> {

--- a/hoomd-geometry/src/shape/capsule.rs
+++ b/hoomd-geometry/src/shape/capsule.rs
@@ -151,8 +151,6 @@ where
         let d2_norm_sq = d2.dot(&d2);
         let f = d2.dot(&distance_between_centers);
 
-        let t: f64;
-
         let c = d1.dot(&distance_between_centers);
 
         // The general nondegenerate case - very small capsules are valid.
@@ -161,7 +159,7 @@ where
 
         // If segments not parallel, compute closest point on L1 to L2 and
         // clamp to segment S1. Else pick arbitrary s (here 0)
-        let mut s = if denom == 0.0 {
+        let s = if denom == 0.0 {
             0.0
         } else {
             ((d1_dot_d2 * f - c * d2_norm_sq) / denom).clamp(0.0, 1.0)
@@ -170,15 +168,14 @@ where
         // Compute point on L2 closest to S1(s) using
         // t = Dot((P1 + D1*s) - P2,D2) / Dot(D2,D2) = (b*s + f) / e
         let tnom = d1_dot_d2 * s + f;
-        if tnom < 0.0 {
-            t = 0.0;
-            s = (-c / d1_norm_sq).clamp(0.0, 1.0);
+        // let t: f64;
+        let (t, s) = if tnom < 0.0 {
+            (0.0, (-c / d1_norm_sq).clamp(0.0, 1.0))
         } else if tnom > d2_norm_sq {
-            t = 1.0;
-            s = ((d1_dot_d2 - c) / d1_norm_sq).clamp(0.0, 1.0);
+            (1.0, ((d1_dot_d2 - c) / d1_norm_sq).clamp(0.0, 1.0))
         } else {
-            t = tnom / d2_norm_sq;
-        }
+            (tnom / d2_norm_sq, s)
+        };
 
         let c1 = p1 + d1 * s;
         let c2 = p2 + d2 * t;

--- a/hoomd-geometry/src/shape/capsule.rs
+++ b/hoomd-geometry/src/shape/capsule.rs
@@ -465,7 +465,7 @@ mod tests {
                 height: h2.try_into()?,
             };
 
-            let v_ij = (rng.random::<Cartesian<N>>() * 10.0) - Cartesian::from([5.0; 3]);
+            let v_ij = (rng.random::<Cartesian<3>>() * 10.0) - Cartesian::from([5.0; 3]);
 
             let o_ij = rng.random::<Versor>();
 

--- a/hoomd-geometry/src/shape/capsule.rs
+++ b/hoomd-geometry/src/shape/capsule.rs
@@ -75,7 +75,7 @@ pub struct Capsule<const N: usize> {
 }
 
 /// A sphere swept along a line segment in $`\mathbb{R}^3`$.
-type SpheroCylinder = Capsule<3>;
+pub type Spherocylinder = Capsule<3>;
 
 impl<const N: usize> SupportMapping<Cartesian<N>> for Capsule<N> {
     #[inline]

--- a/hoomd-geometry/src/shape/capsule.rs
+++ b/hoomd-geometry/src/shape/capsule.rs
@@ -469,9 +469,9 @@ mod tests {
                 height: h2.try_into()?,
             };
 
-            let x = rng.random_range(-10.0..10.0);
-            let y = rng.random_range(-10.0..10.0);
-            let z = rng.random_range(-10.0..10.0);
+            let x = rng.random_range(-5.0..5.0);
+            let y = rng.random_range(-5.0..5.0);
+            let z = rng.random_range(-5.0..5.0);
             let v_ij = [x, y, z].into();
 
             // Generate a random axis for rotation

--- a/hoomd-geometry/src/shape/capsule.rs
+++ b/hoomd-geometry/src/shape/capsule.rs
@@ -465,7 +465,7 @@ mod tests {
                 height: h2.try_into()?,
             };
 
-            let v_ij = (rng.random::<Cartesian<_>>() * 10.0) - Cartesian::from([5.0; 3]);
+            let v_ij = (rng.random::<Cartesian<N>>() * 10.0) - Cartesian::from([5.0; 3]);
 
             let o_ij = rng.random::<Versor>();
 

--- a/hoomd-geometry/src/shape/capsule.rs
+++ b/hoomd-geometry/src/shape/capsule.rs
@@ -125,7 +125,7 @@ impl<const N: usize> Volume for Capsule<N> {
     }
 }
 
-/// .
+/// Create a `Cartesian<N>` with zeros except in the final index.
 #[inline]
 fn axis_aligned_cartesian<const N: usize>(h: f64) -> Cartesian<N> {
     Cartesian::from(std::array::from_fn(|i| if i == (N - 1) { h } else { 0.0 }))

--- a/hoomd-geometry/src/shape/capsule.rs
+++ b/hoomd-geometry/src/shape/capsule.rs
@@ -352,9 +352,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case(true, 1.9, 0.0, 0.0)]
+    #[case(true, 1.999_999, 0.0, 0.0)]
     #[case(true, 2.0, 0.0, 0.0)]
-    #[case(false, 2.1, 0.0, 0.0)]
+    #[case(false, 2.000_001, 0.0, 0.0)]
     fn test_intersect_capsule_capsule_2d(
         #[case] expected: bool,
         #[case] x: f64,
@@ -380,9 +380,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case(true, 0.0, 1.8, 90.0)]
     #[case(true, 0.0, 2.0, 90.0)]
-    #[case(true, 0.0, 2.1, 90.0)]
     #[case(true, 0.0, 3.0, 90.0)]
     #[case(false, 0.0, 3.000_001, 90.0)]
     fn test_intersect_capsule_capsule_2d_rotated(

--- a/hoomd-geometry/src/shape/capsule.rs
+++ b/hoomd-geometry/src/shape/capsule.rs
@@ -135,20 +135,58 @@ where
 {
     #[inline]
     fn intersects_at(&self, other: &Capsule<N>, v_ij: &Cartesian<N>, o_ij: &R) -> bool {
-        // https://ceng2.ktu.edu.tr/~cakir/files/grafikler/rtcd.pdf, pp 148
-        let d1 = axis_aligned_cartesian::<N>(self.height.get());
-        let d2 = o_ij.rotate(&axis_aligned_cartesian(other.height.get()));
-        let center_center_vector = d2 * -0.5; // TODO
+        // Adapted from https://ceng2.ktu.edu.tr/~cakir/files/grafikler/rtcd.pdf, pp 148
+        // Note we ignore fallbacks when the capsule length is small, as these could be
+        // valid inputs.
 
-        let d1_norm_sq = d1.norm_squared();
-        let d2_norm_sq = d2.norm_squared();
-        let f = d2.dot(&center_center_vector);
-        // Check if either or both segments degenerate into points
-        if (d1_norm_sq <= EPSILON && d2_norm_sq <= EPSILON) {
-            // Both segments degenerate into points
-            let (s, t) = (0.0, 0.0);
+        // let d1 = axis_aligned_cartesian::<N>(self.height.get());
+        // let p1 = d1 * -0.5;
+        let (d1, p1) = (Cartesian::default(), Cartesian::default());
+
+        let d2 = o_ij.rotate(&axis_aligned_cartesian(other.height.get()));
+        let p2 = *v_ij - d2 * 0.5;
+
+        let distance_between_centers = p1 - p2;
+
+        let d1_norm_sq = d1.dot(&d1); // Squared length of segment S1
+        let d2_norm_sq = d2.dot(&d2); // Squared length of segment S2
+        let f = d2.dot(&distance_between_centers);
+
+        let t: f64;
+
+        let c = d1.dot(&distance_between_centers);
+
+        // The general nondegenerate case - very small capsules are valid.
+        let d1_dot_d2 = d1.dot(&d2);
+        let denom = d1_norm_sq * d2_norm_sq - d1_dot_d2 * d1_dot_d2;
+
+        // If segments not parallel, compute closest point on L1 to L2 and
+        // clamp to segment S1. Else pick arbitrary s (here 0)
+        let mut s = if denom == 0.0 {
+            0.0
+        } else {
+            ((d1_dot_d2 * f - c * d2_norm_sq) / denom).clamp(0.0, 1.0)
+        };
+
+        // Compute point on L2 closest to S1(s) using
+        // t = Dot((P1 + D1*s) - P2,D2) / Dot(D2,D2) = (b*s + f) / e
+        let tnom = d1_dot_d2 * s + f;
+        if tnom < 0.0 {
+            t = 0.0;
+            s = (-c / d1_norm_sq).clamp(0.0, 1.0);
+        } else if tnom > d2_norm_sq {
+            t = 1.0;
+            s = ((d1_dot_d2 - c) / d1_norm_sq).clamp(0.0, 1.0);
+        } else {
+            t = tnom / d2_norm_sq;
         }
-        false // TODO
+
+        let c1 = p1 + d1 * s;
+        let c2 = p2 + d2 * t;
+        let dist_sq = (c1 - c2).norm_squared();
+
+        let total_radius = self.radius.get() + other.radius.get();
+        dist_sq <= total_radius.powi(2)
     }
 }
 #[cfg(test)]

--- a/hoomd-geometry/src/shape/capsule.rs
+++ b/hoomd-geometry/src/shape/capsule.rs
@@ -136,7 +136,9 @@ where
     #[inline]
     fn intersects_at(&self, other: &Capsule<N>, v_ij: &Cartesian<N>, o_ij: &R) -> bool {
         // Adapted from Real Time Collision Detection, D. Eberly, pp 148
-        // Note we ignore fallbacks when the capsule length is small, as these could be valid inputs. If we somehow underflow to NaN, a (possibly spurious) overlap will be detected.
+        // Note we ignore fallbacks when the capsule length is small, as these
+        // could be valid inputs. If we somehow underflow to NaN, a (possibly spurious)
+        // overlap will be detected.
 
         let d1 = axis_aligned_cartesian::<N>(self.height.get());
         let p1 = d1 * -0.5;

--- a/hoomd-geometry/src/shape/capsule.rs
+++ b/hoomd-geometry/src/shape/capsule.rs
@@ -4,9 +4,9 @@
 //! Implement [`Capsule`]
 
 use super::sphere::sphere_volume_prefactor;
-use crate::{BoundingSphereRadius, SupportMapping, Volume};
+use crate::{BoundingSphereRadius, IntersectsAt, SupportMapping, Volume};
 use hoomd_utility::valid::PositiveReal;
-use hoomd_vector::{Cartesian, InnerProduct};
+use hoomd_vector::{Cartesian, InnerProduct, Rotate, Rotation};
 
 /// All points less than or equal to a distance `r` from a line segment of length `h`.
 ///
@@ -122,6 +122,35 @@ impl<const N: usize> Volume for Capsule<N> {
     }
 }
 
+/// .
+#[inline]
+fn axis_aligned_cartesian<const N: usize>(h: f64) -> Cartesian<N> {
+    Cartesian::from(std::array::from_fn(|i| if i == (N - 1) { h } else { 0.0 }))
+}
+
+impl<const N: usize, R> IntersectsAt<Capsule<N>, Cartesian<N>, R> for Capsule<N>
+where
+    R: Rotate<Cartesian<N>> + Rotation,
+    Cartesian<N>: From<[f64; N]>,
+{
+    #[inline]
+    fn intersects_at(&self, other: &Capsule<N>, v_ij: &Cartesian<N>, o_ij: &R) -> bool {
+        // https://ceng2.ktu.edu.tr/~cakir/files/grafikler/rtcd.pdf, pp 148
+        let d1 = axis_aligned_cartesian::<N>(self.height.get());
+        let d2 = o_ij.rotate(&axis_aligned_cartesian(other.height.get()));
+        let center_center_vector = d2 * -0.5; // TODO
+
+        let d1_norm_sq = d1.norm_squared();
+        let d2_norm_sq = d2.norm_squared();
+        let f = d2.dot(&center_center_vector);
+        // Check if either or both segments degenerate into points
+        if (d1_norm_sq <= EPSILON && d2_norm_sq <= EPSILON) {
+            // Both segments degenerate into points
+            let (s, t) = (0.0, 0.0);
+        }
+        false // TODO
+    }
+}
 #[cfg(test)]
 mod tests {
 

--- a/hoomd-geometry/src/shape/capsule.rs
+++ b/hoomd-geometry/src/shape/capsule.rs
@@ -139,17 +139,16 @@ where
         // Note we ignore fallbacks when the capsule length is small, as these could be
         // valid inputs.
 
-        // let d1 = axis_aligned_cartesian::<N>(self.height.get());
-        // let p1 = d1 * -0.5;
-        let (d1, p1) = (Cartesian::default(), Cartesian::default());
+        let d1 = axis_aligned_cartesian::<N>(self.height.get());
+        let p1 = d1 * -0.5;
 
         let d2 = o_ij.rotate(&axis_aligned_cartesian(other.height.get()));
         let p2 = *v_ij - d2 * 0.5;
 
         let distance_between_centers = p1 - p2;
 
-        let d1_norm_sq = d1.dot(&d1); // Squared length of segment S1
-        let d2_norm_sq = d2.dot(&d2); // Squared length of segment S2
+        let d1_norm_sq = d1.dot(&d1);
+        let d2_norm_sq = d2.dot(&d2);
         let f = d2.dot(&distance_between_centers);
 
         let t: f64;
@@ -350,5 +349,104 @@ mod tests {
         );
 
         // on the caps is not so easy to test manually...
+    }
+
+    #[rstest]
+    #[case(true, 1.9, 0.0, 0.0)]
+    #[case(true, 2.0, 0.0, 0.0)]
+    #[case(false, 2.1, 0.0, 0.0)]
+    fn test_intersect_capsule_capsule_2d(
+        #[case] expected: bool,
+        #[case] x: f64,
+        #[case] y: f64,
+        #[case] angle: f64,
+    ) {
+        let capsule1 = Capsule::<2> {
+            radius: 1.0.try_into().unwrap(),
+            height: 2.0.try_into().unwrap(),
+        };
+        let capsule2 = Capsule::<2> {
+            radius: 1.0.try_into().unwrap(),
+            height: 2.0.try_into().unwrap(),
+        };
+
+        let v_ij = [x, y].into();
+        let o_ij = Angle::from(angle);
+        assert_eq!(capsule1.intersects_at(&capsule2, &v_ij, &o_ij), expected);
+        assert_eq!(
+            capsule2.intersects_at(&capsule1, &(-v_ij), &o_ij.inverted()),
+            expected
+        );
+    }
+
+    #[rstest]
+    #[case(true, 0.0, 1.8, 90.0)]
+    #[case(true, 0.0, 2.0, 90.0)]
+    #[case(true, 0.0, 2.1, 90.0)]
+    #[case(true, 0.0, 3.0, 90.0)]
+    #[case(false, 0.0, 3.000_001, 90.0)]
+    fn test_intersect_capsule_capsule_2d_rotated(
+        #[case] expected: bool,
+        #[case] x: f64,
+        #[case] y: f64,
+        #[case] angle: f64,
+    ) {
+        let capsule1 = Capsule::<2> {
+            radius: 1.0.try_into().unwrap(),
+            height: 2.0.try_into().unwrap(),
+        };
+        let capsule2 = Capsule::<2> {
+            radius: 1.0.try_into().unwrap(),
+            height: 2.0.try_into().unwrap(),
+        };
+
+        let v_ij = [x, y].into();
+        let o_ij = Angle::from(angle.to_radians());
+        assert_eq!(capsule1.intersects_at(&capsule2, &v_ij, &o_ij), expected);
+        assert_eq!(
+            capsule2.intersects_at(&capsule1, &(-v_ij), &o_ij.inverted()),
+            expected
+        );
+    }
+
+    /// Nearly-0 height
+    #[test]
+    fn test_intersect_degenerate_capsules() {
+        let sphere1 = Capsule::<3> {
+            radius: 1.0.try_into().unwrap(),
+            height: 1e-12.try_into().unwrap(),
+        };
+        let sphere2 = Capsule::<3> {
+            radius: 1.0.try_into().unwrap(),
+            height: 1e-12.try_into().unwrap(),
+        };
+
+        let o_ij = Versor::identity();
+        // Intersecting
+        let v_ij = [1.999_999, 0.0, 0.0].into();
+        assert!(sphere1.intersects_at(&sphere2, &v_ij, &o_ij));
+        // Touching
+        let v_ij = [2.0, 0.0, 0.0].into();
+        assert!(sphere1.intersects_at(&sphere2, &v_ij, &o_ij));
+        // Not intersecting
+        let v_ij = [2.000_001, 0.0, 0.0].into();
+        assert!(!sphere1.intersects_at(&sphere2, &v_ij, &o_ij));
+
+        let capsule = Capsule::<3> {
+            radius: 1.0.try_into().unwrap(),
+            height: 2.0.try_into().unwrap(),
+        };
+        // Intersecting
+        let v_ij = [1.999_999, 0.0, 0.0].into();
+        assert!(sphere1.intersects_at(&capsule, &v_ij, &o_ij));
+        assert!(capsule.intersects_at(&sphere1, &v_ij, &o_ij));
+        // Touching
+        let v_ij = [2.0, 0.0, 0.0].into();
+        assert!(sphere1.intersects_at(&capsule, &v_ij, &o_ij));
+        assert!(capsule.intersects_at(&sphere1, &v_ij, &o_ij));
+        // Not intersecting
+        let v_ij = [2.000_001, 0.0, 0.0].into();
+        assert!(!sphere1.intersects_at(&capsule, &v_ij, &o_ij));
+        assert!(!capsule.intersects_at(&sphere1, &v_ij, &o_ij));
     }
 }

--- a/hoomd-geometry/src/shape/capsule.rs
+++ b/hoomd-geometry/src/shape/capsule.rs
@@ -68,7 +68,7 @@ use hoomd_vector::{Cartesian, InnerProduct, Rotate, Rotation};
 /// ```
 #[derive(Clone, Debug, PartialEq)]
 pub struct Capsule<const N: usize> {
-    /// Radius of of points that are considered enclosed in the shape.
+    /// Radius of points that are considered enclosed in the shape.
     pub radius: PositiveReal,
     /// Length of the line segment.
     pub height: PositiveReal,

--- a/hoomd-geometry/src/shape/capsule.rs
+++ b/hoomd-geometry/src/shape/capsule.rs
@@ -135,9 +135,8 @@ where
 {
     #[inline]
     fn intersects_at(&self, other: &Capsule<N>, v_ij: &Cartesian<N>, o_ij: &R) -> bool {
-        // Adapted from https://ceng2.ktu.edu.tr/~cakir/files/grafikler/rtcd.pdf, pp 148
-        // Note we ignore fallbacks when the capsule length is small, as these could be
-        // valid inputs.
+        // Adapted from Real Time Collision Detection, D. Eberly, pp 148
+        // Note we ignore fallbacks when the capsule length is small, as these could be valid inputs. If we somehow underflow to NaN, a (possibly spurious) overlap will be detected.
 
         let d1 = axis_aligned_cartesian::<N>(self.height.get());
         let p1 = d1 * -0.5;
@@ -168,7 +167,6 @@ where
         // Compute point on L2 closest to S1(s) using
         // t = Dot((P1 + D1*s) - P2,D2) / Dot(D2,D2) = (b*s + f) / e
         let tnom = d1_dot_d2 * s + f;
-        // let t: f64;
         let (t, s) = if tnom < 0.0 {
             (0.0, (-c / d1_norm_sq).clamp(0.0, 1.0))
         } else if tnom > d2_norm_sq {
@@ -177,8 +175,7 @@ where
             (tnom / d2_norm_sq, s)
         };
 
-        let c1 = p1 + d1 * s;
-        let c2 = p2 + d2 * t;
+        let (c1, c2) = (p1 + d1 * s, p2 + d2 * t);
         let dist_sq = (c1 - c2).norm_squared();
 
         let total_radius = self.radius.get() + other.radius.get();

--- a/hoomd-geometry/src/shape/capsule.rs
+++ b/hoomd-geometry/src/shape/capsule.rs
@@ -196,6 +196,7 @@ mod tests {
         shape::{Circle, Cylinder, Hypersphere},
     };
     use hoomd_vector::{Angle, Versor};
+    use rand::{Rng, SeedableRng};
 
     use super::*;
     use approxim::assert_relative_eq;
@@ -446,5 +447,57 @@ mod tests {
         let v_ij = [2.000_001, 0.0, 0.0].into();
         assert!(!sphere1.intersects_at(&capsule, &v_ij, &o_ij));
         assert!(!capsule.intersects_at(&sphere1, &v_ij, &o_ij));
+    }
+
+    #[test]
+    fn test_intersect_capsule_capsule_complex_3d_random() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+
+        for _ in 0..10_000 {
+            let r1 = rng.random_range(0.1..10.0);
+            let h1 = rng.random_range(0.1..10.0);
+            let r2 = rng.random_range(0.1..10.0);
+            let h2 = rng.random_range(0.1..10.0);
+
+            let capsule1 = Capsule::<3> {
+                radius: r1.try_into()?,
+                height: h1.try_into()?,
+            };
+            let capsule2 = Capsule::<3> {
+                radius: r2.try_into()?,
+                height: h2.try_into()?,
+            };
+
+            let x = rng.random_range(-10.0..10.0);
+            let y = rng.random_range(-10.0..10.0);
+            let z = rng.random_range(-10.0..10.0);
+            let v_ij = [x, y, z].into();
+
+            // Generate a random axis for rotation
+            let axis: Cartesian<3> = [
+                rng.random_range(-1.0..1.0),
+                rng.random_range(-1.0..1.0),
+                rng.random_range(-1.0..1.0),
+            ]
+            .into();
+            let axis = axis.to_unit()?.0; // Normalize
+
+            let angle = rng.random_range(0.0..2.0 * PI);
+
+            let o_ij = Versor::from_axis_angle(axis, angle);
+
+            let result_direct = capsule1.intersects_at(&capsule2, &v_ij, &o_ij);
+
+            let convex_capsule1 = Convex(capsule1);
+            let convex_capsule2 = Convex(capsule2);
+            let result_xeno = convex_capsule1.intersects_at(&convex_capsule2, &v_ij, &o_ij);
+
+            assert_eq!(
+                result_direct, result_xeno,
+                "Failed with r1={r1}, h1={h1}, r2={r2}, h2={h2}, v_ij={v_ij:?}, o_ij={o_ij:?}"
+            );
+        }
+        Ok(())
     }
 }

--- a/hoomd-geometry/src/shape/capsule.rs
+++ b/hoomd-geometry/src/shape/capsule.rs
@@ -43,10 +43,10 @@ use hoomd_vector::{Cartesian, InnerProduct, Rotate, Rotation};
 /// use std::f64::consts::PI;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let capsule = Convex(Capsule::<2> {
+/// let capsule = Capsule::<2> {
 ///     radius: 1.0.try_into()?,
 ///     height: 8.0.try_into()?,
-/// });
+/// };
 ///
 /// assert!(capsule.intersects_at(
 ///     &capsule,
@@ -74,6 +74,7 @@ pub struct Capsule<const N: usize> {
     pub height: PositiveReal,
 }
 
+/// A sphere swept along a line segment in $`\mathbb{R}^3`$.
 type SpheroCylinder = Capsule<3>;
 
 impl<const N: usize> SupportMapping<Cartesian<N>> for Capsule<N> {

--- a/hoomd-geometry/src/shape/cylinder.rs
+++ b/hoomd-geometry/src/shape/cylinder.rs
@@ -45,8 +45,6 @@ impl Volume for Cylinder {
             * self.height.get()
     }
 }
-/// Precision below which cylinders are considered overlapping
-const _CYLINDER_OVERLAP_PRECISION_SQUARED: f64 = 1e-14;
 
 impl Cylinder {
     /// Determine whether two cylinders would intersect if they both had infinite length.

--- a/hoomd-geometry/src/shape/cylinder.rs
+++ b/hoomd-geometry/src/shape/cylinder.rs
@@ -6,6 +6,7 @@
 use super::Circle;
 use crate::Volume;
 use hoomd_utility::valid::PositiveReal;
+use hoomd_vector::{Cartesian, Rotate};
 
 /// A circle with normal `[0 0 1]` swept by `h/2` in the `+z` and `-z` directions.
 ///
@@ -42,5 +43,121 @@ impl Volume for Cylinder {
         }
         .volume()
             * self.height.get()
+    }
+}
+
+impl Cylinder {
+    /// Determine whether two infinitely long cylinders intersect
+    fn intersects_at_infinite<R>(&self, other: &Self, v_ij: &Cartesian<3>, o_ij: &R) -> bool
+    where
+        R: Rotate<Cartesian<3>>,
+    {
+        const EPSILON: f64 = 1e-9;
+        let [cx, cy, _cz] = v_ij.coordinates;
+        let [sx, sy, _sz] = o_ij.rotate(&Cartesian::from([0., 0., 1.])).coordinates;
+
+        // We only need the x and y components of the direction vector s
+        // to find the magnitude of the cross product (v1 x v2) and check for parallelism.
+        // v1 = (0, 0, 1)
+        // v2 = s = (sx, sy, sz)
+        // v1 x v2 = (-sy, sx, 0)
+        // |v1 x v2| = sqrt(sx^2 + sy^2)
+        let n_magnitude = (sx.powi(2) + sy.powi(2)).sqrt();
+
+        let distance = if n_magnitude < EPSILON {
+            // --- PARALLEL CASE ---
+            // The axes are parallel (s is parallel to the z-axis).
+            // The shortest distance `d` is just the distance from the point c
+            // to the z-axis, which is the distance in the xy-plane.
+            (cx.powi(2) + cy.powi(2)).sqrt()
+        } else {
+            // --- NON-PARALLEL CASE ---
+            // We use the full formula: d = |(p2 - p1) . (v1 x v2)| / |v1 x v2|
+            // p2 - p1 = c = (cx, cy, cz)
+            // v1 x v2 = (-sy, sx, 0)
+            // (p2 - p1) . (v1 x v2) = cx*(-sy) + cy*sx + cz*0 = cy*sx - cx*sy
+            let dot_product = cy * sx - cx * sy;
+
+            // d = |dot_product| / n_magnitude
+            dot_product.abs() / n_magnitude
+        };
+
+        // A collision occurs if the shortest distance between the axes is <= r1+r2
+        distance <= self.radius.get() + other.radius.get()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hoomd_vector::{Cartesian, InnerProduct, Versor};
+    use rstest::rstest;
+    use std::f64::consts::PI;
+
+    #[rstest]
+    // --- PARALLEL CASES ---
+    // Parallel, intersecting
+    #[case(1.0, 1.0, [1.5, 0.0, 0.0], Versor::default(), true, "parallel, intersecting")]
+    // Parallel, touching
+    #[case(1.0, 1.0, [2.0, 0.0, 5.0], Versor::default(), true, "parallel, touching")]
+    // Parallel, not intersecting
+    #[case(1.0, 1.0, [2.1, 0.0, 0.0], Versor::default(), false, "parallel, not intersecting")]
+    // Parallel, second cylinder has different radius
+    #[case(1.0, 0.5, [1.5, 0.0, 0.0], Versor::default(), true, "parallel, different radii, touching")]
+    #[case(1.0, 0.5, [1.6, 0.0, 0.0], Versor::default(), false, "parallel, different radii, not intersecting")]
+    // --- NON-PARALLEL CASES ---
+    // Perpendicular, intersecting at origin
+    #[case(1.0, 1.0, [0.0, 0.0, 0.0],
+         Versor::from_axis_angle(Cartesian::from([1., 0., 0.]).to_unit_unchecked().0, PI / 2.0),
+          true, "perpendicular, intersecting at origin")]
+    // Perpendicular, skew, intersecting
+    #[case(1.0, 1.0, [1.5, 0.0, 0.0],
+         Versor::from_axis_angle(Cartesian::from([1., 0., 0.]).to_unit_unchecked().0, PI / 2.0),
+          true, "perpendicular, skew, intersecting")]
+    // Perpendicular, skew, touching
+    #[case(1.0, 1.0, [0.0, 2.0, 0.0],
+         Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 2.0),
+          true, "perpendicular, skew, touching")]
+    // Perpendicular, skew, not intersecting
+    #[case(1.0, 1.0, [2.1, 0.0, 5.0],
+         Versor::from_axis_angle(Cartesian::from([1., 0., 0.]).to_unit_unchecked().0, PI / 2.0),
+          false, "perpendicular, skew, not intersecting")]
+    // --- GENERAL SKEW CASES ---
+    // Skew, intersecting
+    #[case(1.0, 1.0, [1.0, 1.0, 0.0],
+         Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 4.0),
+          true, "skew, intersecting")]
+    // Skew, touching
+    #[case(1.0, 1.0, [0.0, 2.0, 0.0],
+         Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 4.0),
+          true, "skew, touching")]
+    // Skew, not intersecting
+    #[case(1.0, 1.0, [0.0, 2.1, 0.0],
+         Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 4.0),
+          false, "skew, not intersecting")]
+    fn test_intersects_at_infinite(
+        #[case] r1: f64,
+        #[case] r2: f64,
+        #[case] v_ij: impl Into<Cartesian<3>>,
+        #[case] o_ij: Versor,
+        #[case] expected: bool,
+        #[case] description: &str,
+    ) {
+        let c1 = Cylinder {
+            radius: r1.try_into().unwrap(),
+            height: 1.0.try_into().unwrap(),
+        };
+        let c2 = Cylinder {
+            radius: r2.try_into().unwrap(),
+            height: 1.0.try_into().unwrap(),
+        };
+        let v_ij_cartesian = v_ij.into();
+
+        assert_eq!(
+            c1.intersects_at_infinite(&c2, &v_ij_cartesian, &o_ij),
+            expected,
+            "Failed test case: {}",
+            description
+        );
     }
 }

--- a/hoomd-geometry/src/shape/cylinder.rs
+++ b/hoomd-geometry/src/shape/cylinder.rs
@@ -66,7 +66,7 @@ impl Cylinder {
     /// ```
     /// # use hoomd_geometry::shape::Cylinder;
     /// # use hoomd_vector::{Cartesian, Versor};
-    /// // Two parallel cylinders that wrap a dipyramid of height:width ratio 5.
+    /// // Two parallel cylinders that wrap a dipyramid of height:width ratio 5:1.
     /// let c1 = Cylinder {
     ///     radius: 1.0.try_into().unwrap(),
     ///     height: 10.0.try_into().unwrap(),

--- a/hoomd-geometry/src/shape/cylinder.rs
+++ b/hoomd-geometry/src/shape/cylinder.rs
@@ -6,7 +6,7 @@
 use super::Circle;
 use crate::Volume;
 use hoomd_utility::valid::PositiveReal;
-use hoomd_vector::{Cartesian, Rotate};
+use hoomd_vector::{Cartesian, Versor};
 
 /// A circle with normal `[0 0 1]` swept by `h/2` in the `+z` and `-z` directions.
 ///
@@ -45,33 +45,29 @@ impl Volume for Cylinder {
             * self.height.get()
     }
 }
+/// Precision below which cylinders are considered overlapping
+const _CYLINDER_OVERLAP_PRECISION: f64 = 1e-9;
 
 impl Cylinder {
     /// Determine whether two infinitely long cylinders intersect
-    fn intersects_at_infinite<R>(&self, other: &Self, v_ij: &Cartesian<3>, o_ij: &R) -> bool
-    where
-        R: Rotate<Cartesian<3>>,
-    {
-        const EPSILON: f64 = 1e-9;
+    fn intersects_at_infinite(&self, other: &Self, v_ij: &Cartesian<3>, o_ij: &Versor) -> bool {
         let [cx, cy, _cz] = v_ij.coordinates;
-        let [sx, sy, _sz] = o_ij.rotate(&Cartesian::from([0., 0., 1.])).coordinates;
 
-        // We only need the x and y components of the direction vector s
-        // to find the magnitude of the cross product (v1 x v2) and check for parallelism.
-        // v1 = (0, 0, 1)
-        // v2 = s = (sx, sy, sz)
-        // v1 x v2 = (-sy, sx, 0)
-        // |v1 x v2| = sqrt(sx^2 + sy^2)
+        // Calculate sx and sy directly from the Versor components
+        // for rotating (0, 0, 1) by quaternion q = (w, x, y, z):
+        let q = o_ij.get();
+        let sx = 2.0 * (q.vector[0] * q.vector[2] + q.scalar * q.vector[1]);
+        let sy = 2.0 * (q.vector[1] * q.vector[2] - q.scalar * q.vector[0]);
+
         let n_magnitude = (sx.powi(2) + sy.powi(2)).sqrt();
 
-        let distance = if n_magnitude < EPSILON {
-            // --- PARALLEL CASE ---
+        let distance = if n_magnitude < _CYLINDER_OVERLAP_PRECISION {
             // The axes are parallel (s is parallel to the z-axis).
             // The shortest distance `d` is just the distance from the point c
             // to the z-axis, which is the distance in the xy-plane.
             (cx.powi(2) + cy.powi(2)).sqrt()
         } else {
-            // --- NON-PARALLEL CASE ---
+            // Non-Parallel
             // We use the full formula: d = |(p2 - p1) . (v1 x v2)| / |v1 x v2|
             // p2 - p1 = c = (cx, cy, cz)
             // v1 x v2 = (-sy, sx, 0)

--- a/hoomd-geometry/src/shape/cylinder.rs
+++ b/hoomd-geometry/src/shape/cylinder.rs
@@ -46,7 +46,7 @@ impl Volume for Cylinder {
     }
 }
 /// Precision below which cylinders are considered overlapping
-const _CYLINDER_OVERLAP_PRECISION: f64 = 1e-9;
+const _CYLINDER_OVERLAP_PRECISION_SQUARED: f64 = 1e-14;
 
 impl Cylinder {
     /// Determine whether two cylinders would intersect if they both had infinite length.
@@ -97,13 +97,13 @@ impl Cylinder {
         let sx = 2.0 * (q.vector[0] * q.vector[2] + q.scalar * q.vector[1]);
         let sy = 2.0 * (q.vector[1] * q.vector[2] - q.scalar * q.vector[0]);
 
-        let n_magnitude = (sx.powi(2) + sy.powi(2)).sqrt();
+        let n_magnitude_sq = sx.powi(2) + sy.powi(2);
 
-        let distance = if n_magnitude < _CYLINDER_OVERLAP_PRECISION {
+        let distance_sq = if n_magnitude_sq < _CYLINDER_OVERLAP_PRECISION_SQUARED {
             // The axes of the cylinders are parallel
             // The shortest distance `d` is just the distance from the point c
             // to the z-axis, which is the distance in the xy-plane.
-            (vx.powi(2) + vy.powi(2)).sqrt()
+            vx.powi(2) + vy.powi(2)
         } else {
             // Non-Parallel
             // We use the full formula: d = |(p2 - p1) . (v1 x v2)| / |v1 x v2|
@@ -111,11 +111,11 @@ impl Cylinder {
             // v1 x v2 = (-sy, sx, 0)
             // (p2 - p1) . (v1 x v2) = cx*(-sy) + cy*sx + cz*0 = cy*sx - cx*sy
             let dot_product = vy * sx - vx * sy;
-            dot_product.abs() / n_magnitude
+            dot_product.powi(2) / n_magnitude_sq
         };
 
         // A collision occurs if the shortest distance between the axes is <= r1+r2
-        distance <= self.radius.get() + other.radius.get()
+        distance_sq <= (self.radius.get() + other.radius.get()).powi(2)
     }
 }
 

--- a/hoomd-geometry/src/shape/cylinder.rs
+++ b/hoomd-geometry/src/shape/cylinder.rs
@@ -54,8 +54,41 @@ impl Cylinder {
     /// This implementation is based on [Collision detection of cylindrical rigid bodies for motion planning](https://doi.org/10.1109/ROBOT.2006.1641925), and provides a
     /// useful alternative to bounding sphere-based checks when the underlying bodies
     /// are highly elongated.
+    ///
+    /// # Example
+    ///
+    /// This example is based on the scenario of two highly anisotropic shapes,
+    /// whose bounding spheres have a large amount of volume relative to a tighter
+    /// fitting bounding shape. Note that the effective volume checked for the infinite
+    /// bounding cylinder is actually the intersection of that cylinder and the ball
+    /// queried in the neighbor list, so it is guaranteed to be finite.
+    ///
+    /// ```
+    /// # use hoomd_geometry::shape::Cylinder;
+    /// # use hoomd_vector::{Cartesian, Versor};
+    /// // Two parallel cylinders that wrap a dipyramid of height:width ratio 5.
+    /// let c1 = Cylinder {
+    ///     radius: 1.0.try_into().unwrap(),
+    ///     height: 10.0.try_into().unwrap(),
+    /// };
+    /// let c2 = Cylinder {
+    ///     radius: 1.0.try_into().unwrap(),
+    ///     height: 10.0.try_into().unwrap(),
+    /// };
+    /// let o_ij = Versor::default();
+    ///
+    /// // Case 1: Bounding spheres would intersect, but the bounding cylinders do not.
+    /// let v_ij_no_intersect = Cartesian::from([2.1, 0.0, 0.0]);
+    /// assert!(!c1.intersects_at_infinite(&c2, &v_ij_no_intersect, &o_ij));
+    ///
+    /// // Case 2: Infinite cylinders intersect, meaning we need to further check the
+    /// // underlying shapes for collision.
+    /// let v_ij_intersect = Cartesian::from([1.9, 0.0, 0.0]);
+    /// assert!(c1.intersects_at_infinite(&c2, &v_ij_intersect, &o_ij));
+    /// ```
+    #[must_use]
     #[inline]
-    fn intersects_at_infinite(&self, other: &Self, v_ij: &Cartesian<3>, o_ij: &Versor) -> bool {
+    pub fn intersects_at_infinite(&self, other: &Self, v_ij: &Cartesian<3>, o_ij: &Versor) -> bool {
         let [vx, vy, _vz] = v_ij.coordinates;
 
         // Calculate sx and sy directly from the Versor components

--- a/hoomd-geometry/src/shape/cylinder.rs
+++ b/hoomd-geometry/src/shape/cylinder.rs
@@ -49,9 +49,14 @@ impl Volume for Cylinder {
 const _CYLINDER_OVERLAP_PRECISION: f64 = 1e-9;
 
 impl Cylinder {
-    /// Determine whether two infinitely long cylinders intersect
+    /// Determine whether two cylinders would intersect if they both had infinite length.
+    ///
+    /// This implementation is based on [Collision detection of cylindrical rigid bodies for motion planning](https://doi.org/10.1109/ROBOT.2006.1641925), and provides a
+    /// useful alternative to bounding sphere-based checks when the underlying bodies
+    /// are highly elongated.
+    #[inline]
     fn intersects_at_infinite(&self, other: &Self, v_ij: &Cartesian<3>, o_ij: &Versor) -> bool {
-        let [cx, cy, _cz] = v_ij.coordinates;
+        let [vx, vy, _vz] = v_ij.coordinates;
 
         // Calculate sx and sy directly from the Versor components
         // for rotating (0, 0, 1) by quaternion q = (w, x, y, z):
@@ -65,16 +70,14 @@ impl Cylinder {
             // The axes of the cylinders are parallel
             // The shortest distance `d` is just the distance from the point c
             // to the z-axis, which is the distance in the xy-plane.
-            (cx.powi(2) + cy.powi(2)).sqrt()
+            (vx.powi(2) + vy.powi(2)).sqrt()
         } else {
             // Non-Parallel
             // We use the full formula: d = |(p2 - p1) . (v1 x v2)| / |v1 x v2|
             // p2 - p1 = c = (cx, cy, cz)
             // v1 x v2 = (-sy, sx, 0)
             // (p2 - p1) . (v1 x v2) = cx*(-sy) + cy*sx + cz*0 = cy*sx - cx*sy
-            let dot_product = cy * sx - cx * sy;
-
-            // d = |dot_product| / n_magnitude
+            let dot_product = vy * sx - vx * sy;
             dot_product.abs() / n_magnitude
         };
 
@@ -102,8 +105,8 @@ mod tests {
     #[case::perpendicular_skew_touching(1.0, 1.0, [0.0, 2.0, 0.0], Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 2.0), true)]
     #[case::perpendicular_skew_barely_not_touching(1.0, 0.999_999, [0.0, 2.0, 0.0], Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 2.0), false)]
     #[case::perpendicular_skew_not_intersecting(1.0, 1.0, [2.000_001, 0.0, 5.0], Versor::from_axis_angle(Cartesian::from([1., 0., 0.]).to_unit_unchecked().0, PI / 2.0), false)]
-    #[case::skew_intersecting(1.0, 1.0, [1.0, 1.0, 0.0], Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 4.0), true)]
-    #[case::skew_touching(1.0, 1.0, [0.0, 2.0, 0.0], Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 4.0), true)]
+    #[case::skew_intersecting(1.0, 1.0, [1.0, 1.0, 0.0], Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 5.0), true)]
+    #[case::skew_touching(1.0, 1.0, [0.0, 2.0, 0.0], Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 5.0), true)]
     #[case::skew_not_intersecting(1.0, 1.0, [0.0, 2.000_001, 0.0], Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 5.0), false)]
     fn test_intersects_at_infinite(
         #[case] r1: f64,

--- a/hoomd-geometry/src/shape/cylinder.rs
+++ b/hoomd-geometry/src/shape/cylinder.rs
@@ -62,7 +62,7 @@ impl Cylinder {
         let n_magnitude = (sx.powi(2) + sy.powi(2)).sqrt();
 
         let distance = if n_magnitude < _CYLINDER_OVERLAP_PRECISION {
-            // The axes are parallel (s is parallel to the z-axis).
+            // The axes of the cylinders are parallel
             // The shortest distance `d` is just the distance from the point c
             // to the z-axis, which is the distance in the xy-plane.
             (cx.powi(2) + cy.powi(2)).sqrt()

--- a/hoomd-geometry/src/shape/cylinder.rs
+++ b/hoomd-geometry/src/shape/cylinder.rs
@@ -95,35 +95,34 @@ mod tests {
     use std::f64::consts::PI;
 
     #[rstest]
-    // --- PARALLEL CASES ---
     #[case::parallel_intersecting(1.0, 1.0, [1.5, 0.0, 0.0], Versor::default(), true)]
-    #[case::parallel_touching(1.0, 1.0, [2.0, 0.0, 5.0], Versor::default(), true)]
-    #[case::parallel_not_intersecting(1.0, 1.0, [2.1, 0.0, 0.0], Versor::default(), false)]
+    #[case::parallel_touching(1.0, 1.000, [2.0, 0.0, 0.0], Versor::default(), true)]
+    #[case::parallel_barely_not_touching(1.0, 0.999_999, [2.0, 0.0, 0.0], Versor::default(), false)]
+    #[case::parallel_not_intersecting(1.0, 1.0, [2.000_001, 0.0, 0.0], Versor::default(), false)]
     #[case::parallel_different_radii_touching(1.0, 0.5, [1.5, 0.0, 0.0], Versor::default(), true)]
-    #[case::parallel_different_radii_not_intersecting(1.0, 0.5, [1.6, 0.0, 0.0], Versor::default(), false)]
-    // --- NON-PARALLEL CASES ---
+    #[case::parallel_different_radii_not_intersecting(1.0, 0.5, [1.500_001, 0.0, 0.0], Versor::default(), false)]
     #[case::perpendicular_intersecting_at_origin(1.0, 1.0, [0.0, 0.0, 0.0], Versor::from_axis_angle(Cartesian::from([1., 0., 0.]).to_unit_unchecked().0, PI / 2.0), true)]
     #[case::perpendicular_skew_intersecting(1.0, 1.0, [1.5, 0.0, 0.0], Versor::from_axis_angle(Cartesian::from([1., 0., 0.]).to_unit_unchecked().0, PI / 2.0), true)]
     #[case::perpendicular_skew_touching(1.0, 1.0, [0.0, 2.0, 0.0], Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 2.0), true)]
-    #[case::perpendicular_skew_not_intersecting(1.0, 1.0, [2.1, 0.0, 5.0], Versor::from_axis_angle(Cartesian::from([1., 0., 0.]).to_unit_unchecked().0, PI / 2.0), false)]
-    // --- GENERAL SKEW CASES ---
+    #[case::perpendicular_skew_barely_not_touching(1.0, 0.999_999, [0.0, 2.0, 0.0], Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 2.0), false)]
+    #[case::perpendicular_skew_not_intersecting(1.0, 1.0, [2.000_001, 0.0, 5.0], Versor::from_axis_angle(Cartesian::from([1., 0., 0.]).to_unit_unchecked().0, PI / 2.0), false)]
     #[case::skew_intersecting(1.0, 1.0, [1.0, 1.0, 0.0], Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 4.0), true)]
     #[case::skew_touching(1.0, 1.0, [0.0, 2.0, 0.0], Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 4.0), true)]
-    #[case::skew_not_intersecting(1.0, 1.0, [0.0, 2.1, 0.0], Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 4.0), false)]
+    #[case::skew_not_intersecting(1.0, 1.0, [0.0, 2.000_001, 0.0], Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 5.0), false)]
     fn test_intersects_at_infinite(
         #[case] r1: f64,
         #[case] r2: f64,
         #[case] v_ij: impl Into<Cartesian<3>>,
         #[case] o_ij: Versor,
         #[case] expected: bool,
-    ) {
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let c1 = Cylinder {
-            radius: r1.try_into().unwrap(),
-            height: 1.0.try_into().unwrap(),
+            radius: r1.try_into()?,
+            height: 1.0.try_into()?,
         };
         let c2 = Cylinder {
-            radius: r2.try_into().unwrap(),
-            height: 1.0.try_into().unwrap(),
+            radius: r2.try_into()?,
+            height: 1.0.try_into()?,
         };
         let v_ij_cartesian = v_ij.into();
 
@@ -131,5 +130,7 @@ mod tests {
             c1.intersects_at_infinite(&c2, &v_ij_cartesian, &o_ij),
             expected,
         );
+
+        Ok(())
     }
 }

--- a/hoomd-geometry/src/shape/cylinder.rs
+++ b/hoomd-geometry/src/shape/cylinder.rs
@@ -99,20 +99,11 @@ impl Cylinder {
 
         let n_magnitude_sq = sx.powi(2) + sy.powi(2);
 
-        let distance_sq = if n_magnitude_sq < _CYLINDER_OVERLAP_PRECISION_SQUARED {
-            // The axes of the cylinders are parallel
-            // The shortest distance `d` is just the distance from the point c
-            // to the z-axis, which is the distance in the xy-plane.
-            vx.powi(2) + vy.powi(2)
-        } else {
-            // Non-Parallel
-            // We use the full formula: d = |(p2 - p1) . (v1 x v2)| / |v1 x v2|
-            // p2 - p1 = c = (cx, cy, cz)
-            // v1 x v2 = (-sy, sx, 0)
-            // (p2 - p1) . (v1 x v2) = cx*(-sy) + cy*sx + cz*0 = cy*sx - cx*sy
-            let dot_product = vy * sx - vx * sy;
-            dot_product.powi(2) / n_magnitude_sq
-        };
+        let dot_product = vy * sx - vx * sy;
+        let mut distance_sq = dot_product.powi(2) / n_magnitude_sq;
+        if !distance_sq.is_finite() {
+            distance_sq = vx.powi(2) + vy.powi(2);
+        }
 
         // A collision occurs if the shortest distance between the axes is <= r1+r2
         distance_sq <= (self.radius.get() + other.radius.get()).powi(2)

--- a/hoomd-geometry/src/shape/cylinder.rs
+++ b/hoomd-geometry/src/shape/cylinder.rs
@@ -96,52 +96,26 @@ mod tests {
 
     #[rstest]
     // --- PARALLEL CASES ---
-    // Parallel, intersecting
-    #[case(1.0, 1.0, [1.5, 0.0, 0.0], Versor::default(), true, "parallel, intersecting")]
-    // Parallel, touching
-    #[case(1.0, 1.0, [2.0, 0.0, 5.0], Versor::default(), true, "parallel, touching")]
-    // Parallel, not intersecting
-    #[case(1.0, 1.0, [2.1, 0.0, 0.0], Versor::default(), false, "parallel, not intersecting")]
-    // Parallel, second cylinder has different radius
-    #[case(1.0, 0.5, [1.5, 0.0, 0.0], Versor::default(), true, "parallel, different radii, touching")]
-    #[case(1.0, 0.5, [1.6, 0.0, 0.0], Versor::default(), false, "parallel, different radii, not intersecting")]
+    #[case::parallel_intersecting(1.0, 1.0, [1.5, 0.0, 0.0], Versor::default(), true)]
+    #[case::parallel_touching(1.0, 1.0, [2.0, 0.0, 5.0], Versor::default(), true)]
+    #[case::parallel_not_intersecting(1.0, 1.0, [2.1, 0.0, 0.0], Versor::default(), false)]
+    #[case::parallel_different_radii_touching(1.0, 0.5, [1.5, 0.0, 0.0], Versor::default(), true)]
+    #[case::parallel_different_radii_not_intersecting(1.0, 0.5, [1.6, 0.0, 0.0], Versor::default(), false)]
     // --- NON-PARALLEL CASES ---
-    // Perpendicular, intersecting at origin
-    #[case(1.0, 1.0, [0.0, 0.0, 0.0],
-         Versor::from_axis_angle(Cartesian::from([1., 0., 0.]).to_unit_unchecked().0, PI / 2.0),
-          true, "perpendicular, intersecting at origin")]
-    // Perpendicular, skew, intersecting
-    #[case(1.0, 1.0, [1.5, 0.0, 0.0],
-         Versor::from_axis_angle(Cartesian::from([1., 0., 0.]).to_unit_unchecked().0, PI / 2.0),
-          true, "perpendicular, skew, intersecting")]
-    // Perpendicular, skew, touching
-    #[case(1.0, 1.0, [0.0, 2.0, 0.0],
-         Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 2.0),
-          true, "perpendicular, skew, touching")]
-    // Perpendicular, skew, not intersecting
-    #[case(1.0, 1.0, [2.1, 0.0, 5.0],
-         Versor::from_axis_angle(Cartesian::from([1., 0., 0.]).to_unit_unchecked().0, PI / 2.0),
-          false, "perpendicular, skew, not intersecting")]
+    #[case::perpendicular_intersecting_at_origin(1.0, 1.0, [0.0, 0.0, 0.0], Versor::from_axis_angle(Cartesian::from([1., 0., 0.]).to_unit_unchecked().0, PI / 2.0), true)]
+    #[case::perpendicular_skew_intersecting(1.0, 1.0, [1.5, 0.0, 0.0], Versor::from_axis_angle(Cartesian::from([1., 0., 0.]).to_unit_unchecked().0, PI / 2.0), true)]
+    #[case::perpendicular_skew_touching(1.0, 1.0, [0.0, 2.0, 0.0], Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 2.0), true)]
+    #[case::perpendicular_skew_not_intersecting(1.0, 1.0, [2.1, 0.0, 5.0], Versor::from_axis_angle(Cartesian::from([1., 0., 0.]).to_unit_unchecked().0, PI / 2.0), false)]
     // --- GENERAL SKEW CASES ---
-    // Skew, intersecting
-    #[case(1.0, 1.0, [1.0, 1.0, 0.0],
-         Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 4.0),
-          true, "skew, intersecting")]
-    // Skew, touching
-    #[case(1.0, 1.0, [0.0, 2.0, 0.0],
-         Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 4.0),
-          true, "skew, touching")]
-    // Skew, not intersecting
-    #[case(1.0, 1.0, [0.0, 2.1, 0.0],
-         Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 4.0),
-          false, "skew, not intersecting")]
+    #[case::skew_intersecting(1.0, 1.0, [1.0, 1.0, 0.0], Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 4.0), true)]
+    #[case::skew_touching(1.0, 1.0, [0.0, 2.0, 0.0], Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 4.0), true)]
+    #[case::skew_not_intersecting(1.0, 1.0, [0.0, 2.1, 0.0], Versor::from_axis_angle(Cartesian::from([0., 1., 0.]).to_unit_unchecked().0, PI / 4.0), false)]
     fn test_intersects_at_infinite(
         #[case] r1: f64,
         #[case] r2: f64,
         #[case] v_ij: impl Into<Cartesian<3>>,
         #[case] o_ij: Versor,
         #[case] expected: bool,
-        #[case] description: &str,
     ) {
         let c1 = Cylinder {
             radius: r1.try_into().unwrap(),
@@ -156,8 +130,6 @@ mod tests {
         assert_eq!(
             c1.intersects_at_infinite(&c2, &v_ij_cartesian, &o_ij),
             expected,
-            "Failed test case: {}",
-            description
         );
     }
 }

--- a/hoomd-geometry/src/shape/hyperellipsoid.rs
+++ b/hoomd-geometry/src/shape/hyperellipsoid.rs
@@ -301,23 +301,36 @@ where
 
         // Golden section solver for minimizing K(λ)
         let (mut b, mut a) = (_ELLIPSOID_K_MAX_BOUND, _ELLIPSOID_K_MIN_BOUND);
-        while (b - a) > _ELLIPSOID_OVERLAP_PRECISION {
-            let c = b - (b - a) * _INV_PHI;
-            let d = a + (b - a) * _INV_PHI;
+        let mut c = b - (b - a) * _INV_PHI;
+        let mut d = a + (b - a) * _INV_PHI;
+        let mut k_c = k_lambda::<2, Matrix22>(&a_inv, &b_inv, c, v_ij);
+        if k_c <= 0.0 {
+            return false;
+        }
+        let mut k_d = k_lambda::<2, Matrix22>(&a_inv, &b_inv, d, v_ij);
+        if k_d <= 0.0 {
+            return false;
+        }
 
-            // Could reuse computed k values between loops for better performance?
-            let k_c = k_lambda::<2, Matrix22>(&a_inv, &b_inv, c, v_ij);
-            if k_c <= 0.0 {
-                return false;
-            }
-            let k_d = k_lambda::<2, Matrix22>(&a_inv, &b_inv, d, v_ij);
-            if k_d <= 0.0 {
-                return false;
-            }
+        while (b - a) > _ELLIPSOID_OVERLAP_PRECISION {
             if k_c < k_d {
                 b = d;
+                d = c;
+                k_d = k_c;
+                c = b - (b - a) * _INV_PHI;
+                k_c = k_lambda::<2, Matrix22>(&a_inv, &b_inv, c, v_ij);
+                if k_c <= 0.0 {
+                    return false;
+                }
             } else {
                 a = c;
+                c = d;
+                k_c = k_d;
+                d = a + (b - a) * _INV_PHI;
+                k_d = k_lambda::<2, Matrix22>(&a_inv, &b_inv, d, v_ij);
+                if k_d <= 0.0 {
+                    return false;
+                }
             }
         }
         true // If we did not detect a negative value of K(λ), the shapes overlap


### PR DESCRIPTION
Infinite cylinder intersection test, useful as a fast early exit for HPMC with elongated shapes. This requires only a few operations, and I expect it is faster when the intersection volume of the cylinder + neighbor list ball is significantly less than that of the bounding sphere of a shape - this check takes ~4x as long as the sphere, so that seems a reasonable guess. I did not implement the finite cylinder check, as honestly it doesn't seem too interesting -- we can revisit in the future if desired.

This implementation is based on [Collision detection of cylindrical rigid bodies for motion planning](https://doi.org/10.1109/ROBOT.2006.1641925).
```
├─ infinite_cylinder         1.854 ns      │ 2.668 ns      │ 2.098 ns      │ 2.095 ns      │ 100     │ 204800
│                            539.3 Mitem/s │ 374.8 Mitem/s │ 476.6 Mitem/s │ 477.3 Mitem/s │         │
╰─ sphere_fast_nd                          │               │               │                               4.219 Gitem/s │ 827.8 Mitem/s │ 3.968 Gitem/s │ 3.676 Gitem/s │         │
   ├─ 3                      0.532 ns      │ 0.593 ns      │ 0.562 ns      │ 0.558 ns      │ 100     │ 409600
   │                         1.879 Gitem/s │ 1.686 Gitem/s │ 1.779 Gitem/s │ 1.792 Gitem/s │         │
```

This also includes code for N-Capsules, based on closest point on lines. This is in preparation for more complex swept sphere volumes.
```
├─ capsule_fast_3d           14.91 ns      │ 26.96 ns      │ 15.16 ns      │ 15.27 ns      │ 100     │ 51200
│                            67.02 Mitem/s │ 37.08 Mitem/s │ 65.95 Mitem/s │ 65.44 Mitem/s │         │
├─ capsule_xenocollide_3d    92.8 ns       │ 393.5 ns      │ 126.9 ns      │ 128.1 ns      │ 100     │ 6400
│                            10.77 Mitem/s │ 2.54 Mitem/s  │ 7.875 Mitem/s │ 7.802 Mitem/s │         │

```

Also note it looks like my 2d ellipse code is horribly inefficient -  I made the easy fixes I could, but we need to revisit in a later PR.