### PR TITLE
Deploy interactive examples on GitHub Pages

### DIFF
--- a/.github/workflows/interactive-examples.yaml
+++ b/.github/workflows/interactive-examples.yaml
@@ -104,9 +104,11 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    if: github.ref == 'refs/heads/trunk'
     steps:
       - name: Deploy
         id: deployment
+        if: 
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   tests_complete:

--- a/.github/workflows/interactive-examples.yaml
+++ b/.github/workflows/interactive-examples.yaml
@@ -1,4 +1,4 @@
-name: Deploy Interactive Examples
+name: Interactive Examples
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -102,6 +102,7 @@ jobs:
         path: ./web
 
   deploy:
+    name: Deploy
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/interactive-examples.yaml
+++ b/.github/workflows/interactive-examples.yaml
@@ -31,7 +31,7 @@ jobs:
       number: 1
 
   build:
-    name: Build Interactive Examples
+    name: Build
     runs-on: [self-hosted, jetstream2, CPU]
 
     steps:
@@ -53,10 +53,10 @@ jobs:
       run: rustup default 1.92.0
     - name: Check rust installation
       run: rustc -vV
-    - name: Check wasm-bindgen version
-      run: cargo info wasm-bindgen -q
-    - name: Install matching wasm-bindgen cli
-      run: cargo binstall wasm-bindgen-cli@`cargo info wasm-bindgen -q | grep "^version:" | cut -f 2 -d " "` --no-confirm --disable-strategies=compile --disable-telemetry
+    - name: Install cargo-binstall
+      run: curl -sSL "https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-gnu.tgz" | tar -xvz --directory "$HOME/.cargo/bin"
+    - name: Install wasm-bindgen
+      run: cargo binstall wasm-bindgen-cli@0.2.108 --no-confirm --disable-strategies=compile --disable-telemetry
     - name: Install binaryen
       run: curl -sSL "https://github.com/WebAssembly/binaryen/releases/download/version_123/binaryen-version_123-x86_64-linux.tar.gz" | tar -xvz --strip-components 2 --directory "$HOME/.cargo/bin"
 
@@ -82,7 +82,7 @@ jobs:
       run: >
         cargo run
         --locked
-        --p build-wasm-doc-examples
+        -p build-wasm-doc-examples
         --
         --reduce-size
         --root web
@@ -105,12 +105,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Deploy to GitHub Pages
+      - name: Deploy
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   tests_complete:
-    name: All tests
+    name: All
     if: always()
     needs: [build, deploy]
     runs-on: ubuntu-latest

--- a/.github/workflows/interactive-examples.yaml
+++ b/.github/workflows/interactive-examples.yaml
@@ -117,7 +117,7 @@ jobs:
   tests_complete:
     name: All
     if: always()
-    needs: [build, deploy]
+    needs: [build]
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/interactive-examples.yaml
+++ b/.github/workflows/interactive-examples.yaml
@@ -111,7 +111,6 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        if: 
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   tests_complete:

--- a/.github/workflows/interactive-examples.yaml
+++ b/.github/workflows/interactive-examples.yaml
@@ -93,6 +93,9 @@ jobs:
     - name: Show web directory size
       run: du -hsc web/*
 
+    - name: Web directory contents
+      run: ls -lR web
+
     - name: Upload artifact
       uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
       with:

--- a/.github/workflows/interactive-examples.yaml
+++ b/.github/workflows/interactive-examples.yaml
@@ -1,0 +1,125 @@
+name: Deploy Interactive Examples
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+on:
+  pull_request:
+  push:
+    branches:
+    - trunk
+
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  CARGO_TERM_COLOR: always
+  CLICOLOR: 1
+
+jobs:
+  start_action_runners:
+    name: Start
+    uses: glotzerlab/jetstream2-admin/.github/workflows/start.yaml@f6746b0a76c06e45cc1b0c5e32576dfa2c7d2d8c # v1.5.1
+    secrets: inherit
+    with:
+      number: 1
+
+  build:
+    name: Build Interactive Examples
+    runs-on: [self-hosted, jetstream2, CPU]
+
+    steps:
+    # These steps are needed on self-hosted runners and can be removed on GitHub runners
+    - name: Clean workspace
+      run: ( shopt -s dotglob nullglob; rm -rf ./* )
+    - name: Add cargo PATH
+      run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+    - name: Checkout
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+    # This code is needed on GitHub Hosted runners, disable for now while we use private runners.
+    # - name: Update rust
+    #   run: rustup install ${{ matrix.rust }} --no-self-update
+    # - name: Install target
+    #   run: rustup target install ${{ matrix.target }} --toolchain ${{ matrix.rust }}
+    #   if: ${{ matrix.target != '' }}
+    - name: Set default target
+      run: rustup default 1.92.0
+    - name: Check rust installation
+      run: rustc -vV
+    - name: Check wasm-bindgen version
+      run: cargo info wasm-bindgen -q
+    - name: Install matching wasm-bindgen cli
+      run: cargo binstall wasm-bindgen-cli@`cargo info wasm-bindgen -q | grep "^version:" | cut -f 2 -d " "` --no-confirm --disable-strategies=compile --disable-telemetry
+    - name: Install binaryen
+      run: curl -sSL "https://github.com/WebAssembly/binaryen/releases/download/version_123/binaryen-version_123-x86_64-linux.tar.gz" | tar -xvz --strip-components 2 --directory "$HOME/.cargo/bin"
+
+    # rust-cache already includes a Cargo.lock hash in the key. However, it
+    # eagerly restores caches with previous Cargo.lock files. This causes
+    # multiple builds to be cached in target/ increasing the cache usage
+    # dramatically. Add the Cargo.lock hash again in the key portion to
+    # prevent this restoration.
+    - name: Cache
+      uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+      with:
+        key: ${{ 'wasm32-unknown-unknown' }}-${{ hashFiles('Cargo.lock') }}
+        cache-bin: false
+
+    - name: Setup Pages
+      id: pages
+      uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+
+    - name: Create output directory
+      run: mkdir -p web
+
+    - name: Build examples
+      run: >
+        cargo run
+        --locked
+        --p build-wasm-doc-examples
+        --
+        --reduce-size
+        --root web
+
+    - name: Show target directory size
+      run: du -hsc target/*
+
+    - name: Show web directory size
+      run: du -hsc web/*
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
+      with:
+        path: ./web
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+
+  tests_complete:
+    name: All tests
+    if: always()
+    needs: [build, deploy]
+    runs-on: ubuntu-latest
+
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    steps:
+    - run: jq --exit-status 'all(.result == "success")' <<< '${{ toJson(needs) }}'
+    - name: Done
+      run: exit 0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: test
+name: Test
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,13 +11,13 @@ build:
     - cargo binstall mdbook@0.5.2 --no-confirm --disable-strategies=compile --disable-telemetry --install-path "${PATH%%:*}"
     - curl -sSL "https://github.com/lzanini/mdbook-katex/releases/download/0.10.0-alpha-binaries/mdbook-katex-v0.10.0-alpha-x86_64-unknown-linux-gnu.tar.gz" | tar -xvz --directory "${PATH%%:*}"
     # Install wasm toolchain with bindgen matching the version in the lockfile
-    - rustup target install wasm32-unknown-unknown
-    - cargo info wasm-bindgen -q
-    - cargo binstall wasm-bindgen-cli@`cargo info wasm-bindgen -q | grep "^version:" | cut -f 2 -d " "` --no-confirm --disable-strategies=compile --disable-telemetry --install-path "${PATH%%:*}"
-    - curl -sSL "https://github.com/WebAssembly/binaryen/releases/download/version_123/binaryen-version_123-x86_64-linux.tar.gz" | tar -xvz --strip-components 2 --directory "${PATH%%:*}"
+    # - rustup target install wasm32-unknown-unknown
+    # - cargo info wasm-bindgen -q
+    # - cargo binstall wasm-bindgen-cli@`cargo info wasm-bindgen -q | grep "^version:" | cut -f 2 -d " "` --no-confirm --disable-strategies=compile --disable-telemetry --install-path "${PATH%%:*}"
+    # - curl -sSL "https://github.com/WebAssembly/binaryen/releases/download/version_123/binaryen-version_123-x86_64-linux.tar.gz" | tar -xvz --strip-components 2 --directory "${PATH%%:*}"
     - ls "${PATH%%:*}"
     # Build the WASM examples
-    - cargo run --locked -p build-wasm-doc-examples -- --reduce-size
+    # - cargo run --locked -p build-wasm-doc-examples -- --reduce-size
     # Build the book
     - mkdir -p $READTHEDOCS_OUTPUT/html
     - echo "site-url = \"/$READTHEDOCS_LANGUAGE/$READTHEDOCS_VERSION/\"" >> doc/book.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ rustdoc-args = [ "--html-in-header", "katex.html" ]
 # Optimize for size in wasm builds
 [profile.release-wasm]
 opt-level = 'z'
-lto = 'thin'  # TODO: Switch back to true after migrating to GitHub Pages for docs.
+lto = true
 codegen-units = 1
 inherits = "release"
 

--- a/tools/build-wasm-doc-examples/src/main.rs
+++ b/tools/build-wasm-doc-examples/src/main.rs
@@ -23,7 +23,7 @@ struct Args {
     reduce_size: bool,
 
     /// Output location.
-    #[arg(long, default_value="doc/src")]
+    #[arg(long, default_value = "doc/src")]
     root: String,
 }
 

--- a/tools/build-wasm-doc-examples/src/main.rs
+++ b/tools/build-wasm-doc-examples/src/main.rs
@@ -23,7 +23,7 @@ struct Args {
     reduce_size: bool,
 
     /// Output location.
-    #[arg(default_value="doc/src")]
+    #[arg(long, default_value="doc/src")]
     root: String,
 }
 

--- a/tools/build-wasm-doc-examples/src/main.rs
+++ b/tools/build-wasm-doc-examples/src/main.rs
@@ -21,6 +21,10 @@ struct Args {
     /// Optimize for size.
     #[arg(long)]
     reduce_size: bool,
+
+    /// Output location.
+    #[arg(default_value="doc/src")]
+    root: String,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -92,7 +96,7 @@ fn build_examples(table: &Table, args: &Args) -> anyhow::Result<()> {
                 "package.metadata.example.{name}.path is not a string"
             ))?;
 
-        let path = format!("doc/src/{subpath}");
+        let path = format!("{}/{subpath}", args.root);
         let target_wasm = format!("./target/wasm32-unknown-unknown/{profile}/examples/{name}.wasm");
 
         let status = Command::new("wasm-bindgen")


### PR DESCRIPTION
readthedocs times out while building the examples. This PR builds the examples on GitHub Actions and deploys them to GitHub pages. The readthedocs page will hopefully be able to use these. The API and mdbook docs should build within the time limit.

If an example is deleted or changed, that change will appear even when viewing old versions of the docs on readthedocs. We could avoid this problem by a) only publishing the latest docs or b) develop a complex system whereby readthedocs pulls the built examples artifact from GitHub Actions.