### PR TITLE
Site type tutorial

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -305,7 +305,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -316,7 +316,7 @@ checksum = "f548ad2c4031f2902e3edc1f29c29e835829437de49562d8eb5dc5584d3a1043"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -517,7 +517,7 @@ checksum = "ac120bfd5a74e05f96013817d28318dc716afaa68864af069c7ffc3ccaf9d153"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -616,7 +616,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -699,7 +699,7 @@ checksum = "70b6a05c31f54c83d681f1b8699bbaf581f06b25a40c9a6bb815625f731f5ba9"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -786,7 +786,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -874,7 +874,7 @@ checksum = "60bb92e0ef80ff7c59429133244765515db3d313fae77ee67ffe94dab5b2725d"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1100,7 +1100,7 @@ checksum = "0b7272fca0bf30d8ca2571a803598856104b63e5c596d52850f811ed37c5e1e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "toml_edit",
 ]
 
@@ -1311,7 +1311,7 @@ dependencies = [
  "indexmap 2.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "uuid",
 ]
 
@@ -1374,7 +1374,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1497,7 +1497,7 @@ checksum = "d733081e57e49b3c43bdf3766d1de74c7df32e0f4db20c20437c85b1d18908de"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1821,7 +1821,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1963,7 +1963,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2322,7 +2322,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2333,7 +2333,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2377,7 +2377,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.116",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -2413,7 +2413,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2444,7 +2444,7 @@ checksum = "9556bc800956545d6420a640173e5ba7dfa82f38d3ea5a167eb555bc69ac3323"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2587,7 +2587,7 @@ checksum = "c8bad72d8308f7a382de2391ec978ddd736e0103846b965d7e2a63a75768af30"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2599,7 +2599,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2675,7 +2675,7 @@ checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2755,6 +2755,7 @@ dependencies = [
  "bevy",
  "bevy_egui",
  "hoomd-bevy",
+ "hoomd-derive",
  "hoomd-geometry",
  "hoomd-gsd",
  "hoomd-interaction",
@@ -2832,7 +2833,7 @@ checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2934,7 +2935,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2994,7 +2995,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3346,7 +3347,7 @@ dependencies = [
  "inflections",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3563,6 +3564,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "hoomd-derive"
+version = "0.0.0"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "hoomd-geometry"
 version = "0.0.0"
 dependencies = [
@@ -3602,6 +3611,7 @@ dependencies = [
  "approxim",
  "assert2",
  "divan",
+ "hoomd-derive",
  "hoomd-geometry",
  "hoomd-microstate",
  "hoomd-spatial",
@@ -3678,6 +3688,7 @@ dependencies = [
  "arrayvec",
  "assert2",
  "divan",
+ "hoomd-derive",
  "hoomd-geometry",
  "hoomd-manifold",
  "hoomd-rand",
@@ -3773,7 +3784,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4010,7 +4021,7 @@ checksum = "f7946b4325269738f270bb55b3c19ab5c5040525f83fd625259422a9d25d9be5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4333,7 +4344,7 @@ checksum = "973e7178a678cfd059ccec50887658d482ce16b0aa9da3888ddeab5cd5eb4889"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4591,7 +4602,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5000,7 +5011,7 @@ dependencies = [
  "parquet",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5045,7 +5056,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5171,7 +5182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5495,7 +5506,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5590,7 +5601,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.116",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -5774,7 +5785,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5827,7 +5838,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6020,9 +6031,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6037,7 +6048,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6147,7 +6158,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6158,7 +6169,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6364,7 +6375,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6554,7 +6565,7 @@ checksum = "41b6d82be61465f97d42bd1d15bf20f3b0a3a0905018f38f9d6f6962055b0b5c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6643,7 +6654,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -7116,7 +7127,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7127,7 +7138,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7138,7 +7149,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7149,7 +7160,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7542,7 +7553,7 @@ dependencies = [
  "heck",
  "indexmap 2.13.0",
  "prettyplease",
- "syn 2.0.116",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -7558,7 +7569,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -7700,7 +7711,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -7727,7 +7738,7 @@ checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7747,7 +7758,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -7781,7 +7792,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "3"
 members = ["benchmarks",
            "examples",
            "hoomd-bevy",
+           "hoomd-derive",
            "hoomd-geometry",
            "hoomd-gsd",
            "hoomd-interaction",
@@ -24,6 +25,7 @@ members = ["benchmarks",
 # The `hoomd-bevy` crate depends on `bevy` which takes a long time to download
 # and compile.
 default-members = ["examples",
+                   "hoomd-derive",
                    "hoomd-geometry",
                    "hoomd-gsd",
                    "hoomd-interaction",
@@ -51,6 +53,7 @@ categories = ["science"]
 [workspace.dependencies]
 # Subcrates
 hoomd-bevy = { path = "hoomd-bevy", version = "0.0.0" }
+hoomd-derive = { path = "hoomd-derive", version = "0.0.0" }
 hoomd-geometry = { path = "hoomd-geometry", version = "0.0.0"}
 hoomd-gsd = { path = "hoomd-gsd", version = "0.0.0"}
 hoomd-interaction = { path = "hoomd-interaction", version = "0.0.0"}

--- a/build_api_documentation.sh
+++ b/build_api_documentation.sh
@@ -11,7 +11,7 @@
 set -euo pipefail
 
 export RUSTDOCFLAGS="--html-in-header katex.html"
-for package in gsd linear-algebra simulation utility rand vector manifold spatial \
+for package in derive gsd linear-algebra simulation utility rand vector manifold spatial \
                geometry microstate interaction mc bevy
 do
   cargo doc --package hoomd-$package --lib --no-deps

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -18,8 +18,9 @@
   - [Hard Ellipse Self-Assembly](mc-tutorial/hard-ellipse-self-assembly.md)
   - [Hard Tetrahedron Self-Assembly](mc-tutorial/hard-tetrahedron-self-assembly.md)
   - [Patchy Particle Self-Assembly](mc-tutorial/patchy-particle-self-assembly.md)
-  - [Modeling Binary Systems]()
-  - [Modeling Polydisperse Systems]()
+  - [Type-dependent Interactions](mc-tutorial/type-dependent-interactions.md)
+  - [Binary Hard Shapes]()
+  - [Polydisperse Interactions]()
 
 # Reference
 

--- a/doc/src/mc-tutorial/hard-ellipse-self-assembly.md
+++ b/doc/src/mc-tutorial/hard-ellipse-self-assembly.md
@@ -77,14 +77,16 @@ Assign all the model parameters in one code block:
 {{#rustdoc_include ../../../examples/mc-tutorial/hard-ellipse-self-assembly.rs:parameters}}
 ```
 
-`initial_packing_fraction` is the volume of the ellipses divided by the volume of
-the simulation boundary in the initial state. Choose this value so that ellipses can
-be placed easily in the microstate. During the `Initialize` phase, the microstate
-will be compressed until it reaches the packing fraction `target_packing_fraction`.
-`n_bodies` is the number of ellipses to add, `maximum_distance` is the largest distance
-a translation trial move can take, `maximum_rotation` is the largest angle possible in
-a rotation trial move, `sigma` is the major axis of the ellipse, `aspect` is the ellipse
-aspect ratio and `macrostate` holds the temperature set point (in units of energy).
+`initial_packing_fraction` is the volume of the ellipses divided by the volume
+of the simulation boundary in the initial state. Choose this value so that
+ellipses can be placed easily in the microstate. During the `Initialize`
+phase, the microstate will be compressed until it reaches the packing fraction
+`target_packing_fraction`. `n_bodies` is the number of ellipses to add,
+`maximum_distance` is the largest distance a translation trial move can take
+(initially), `maximum_rotation` is the largest angle possible in a rotation
+trial move (initially), `sigma` is the major axis of the ellipse, `aspect` is
+the ellipse aspect ratio and `macrostate` holds the temperature set point (in
+units of energy).
 
 To ensure that `sigma` is the major axis, `aspect` must be greater than or equal
 to 1.0.

--- a/doc/src/mc-tutorial/hard-tetrahedron-self-assembly.md
+++ b/doc/src/mc-tutorial/hard-tetrahedron-self-assembly.md
@@ -66,9 +66,10 @@ volume of the simulation boundary in the initial state. Choose this value so
 that tetrahedra can be placed easily in the microstate. During the `Initialize`
 phase, the microstate will be compressed until it reaches the packing fraction
 `target_packing_fraction`. `n_bodies` is the number of tetrahedra to add,
-`maximum_distance` is the largest distance a translation trial move can
-take, `maximum_rotation`controls the size of the rotation trial moves, and
-`macrostate` holds the temperature set point (in units of energy).
+`maximum_distance` is the largest distance a translation trial move can take
+(initially), `maximum_rotation`controls the size of the rotation trial moves
+(initially), and `macrostate` holds the temperature set point (in units of
+energy).
 
 ### Hamiltonian
 
@@ -81,12 +82,10 @@ Wrap it in the `Convex` newtype for use with the `HardShape` Hamiltonian:
 ## Initialization and Simulation
 
 See the [Hard Ellipse Self-Assembly] tutorial for a complete explanation of
-remaining initialization and simulation code.
-```rust,ignore
-{{#rustdoc_include ../../../examples/mc-tutorial/hard-tetrahedron-self-assembly.rs:remainder}}
-```
+remaining initialization and simulation code (see also the [complete code] below).
 
 [Hard Ellipse Self-Assembly]: hard-ellipse-self-assembly.md
+[complete code]: #complete-code
 
 ## Implement `main()`
 

--- a/doc/src/mc-tutorial/patchy-particle-self-assembly.md
+++ b/doc/src/mc-tutorial/patchy-particle-self-assembly.md
@@ -72,14 +72,15 @@ of the simulation boundary in the initial state. Choose this value so
 that disks can be placed easily in the microstate. During the `Initialize`
 phase, the microstate will be compressed until it reaches the packing
 fraction `target_packing_fraction`. `n_disks` is the number of disks to add,
-`maximum_distance` is the largest distance a translation trial move can take,
-and `maximum_rotation`controls the size of the rotation trial moves. `sigma` is
-the disk diameter, `patch_interaction_range` is largest distance at which the
-attractive interaction applies, `patch_half_angle` is the half open angle of the
-patch, and `patch_energy` is the potential energy of a pair of particles when
-their patches align. `initial_temperature` sets the temperature at step 0,
-`final_temperature` sets the temperature at step `ramp_steps`, and `macrostate`
-holds the current temperature set point (in units of energy).
+`maximum_distance` is the largest distance a translation trial move can take
+(initially), and `maximum_rotation`controls the size of the rotation trial moves
+(initially). `sigma` is the disk diameter, `patch_interaction_range` is largest
+distance at which the attractive interaction applies, `patch_half_angle` is
+the half open angle of the patch, and `patch_energy` is the potential energy
+of a pair of particles when their patches align. `initial_temperature` sets
+the temperature at step 0, `final_temperature` sets the temperature at step
+`ramp_steps`, and `macrostate` holds the current temperature set point (in units
+of energy).
 
 ### Hamiltonian
 

--- a/doc/src/mc-tutorial/type-dependent-interactions.md
+++ b/doc/src/mc-tutorial/type-dependent-interactions.md
@@ -1,0 +1,352 @@
+# Type-dependent Interactions
+
+<script type="module">
+import init from 'https://glotzerlab.github.io/hoomd-rs/mc-tutorial/type-dependent-interactions.js'
+{{#include ../../scripts/init-wasm-canvas.js}}
+</script>
+{{#include ../../scripts/canvas.html}}
+
+## Overview
+
+Some models label sites with **types** and apply interactions between sites that
+depend on those types. For example, a coarse-grained model of phase separation
+can be achieved with a system where *A-A* and *B-B* interactions attract while
+*A-B* interactions are purely repulsive. This tutorial shows you how to assign
+**types** to sites and compute type-dependent pairwise interactions.
+
+* Objectives:
+  * Show how to use an `enum` to name the possible site types.
+  * Define a custom **site properties** that includes the type.
+  * Show how to assign type-dependent pairwise interactions.
+  * Demonstrate phase separation of *A* and *B* types.
+* File: `hoomd-rs/examples/mc-tutorial/type-dependent-interactions.rs`
+* Run (interactively):
+  ```shell
+  cargo run --release --features "bevy" --example type-dependent-interactions
+  ```
+* Run (in batch mode):
+  ```shell
+  cargo run --release --example type-dependent-interactions
+  ```
+
+## Use Declarations
+
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:use}}
+```
+
+## Type Aliases
+
+Create type aliases for your model's *vector* and *body properties* so that you
+don't need to repeat the full generic type names throughout the code:
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:type_aliases}}
+```
+
+The **sites** are in this tutorial are placed at points in space and assigned a type.
+Therefore, use `Point` for the **body** properties.
+
+## Site Properties
+
+You might be familiar with simulation tools where you assign types to sites
+based on a numerical index or string name. *hoomd-rs* utilizes the language
+features of Rust itself.
+
+### Type `enum`
+
+The `Type` enum in this example enumerates all the site types:
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:type}}
+```
+
+Using an enum ensures that every site *always* has a well-defined type. If you
+fail to assign a type or set an invalid one, you will get an error *at compile
+time*.
+
+### Define `SiteProperties`
+
+Previous tutorials used the provided `OrientedPoint` or `Point` **site
+properties** to represent a site at a point in space with or without
+orientation, respectively. This tutorial defines a new `SiteProperties` struct
+that gives each site a position in space and a given **type** (named `type_` because
+`type` is a Rust keyword):
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:site_properties}}
+```
+
+The initialization, MC, and MD methods operate on a generic site properties
+type `S` with *trait bounds* as needed. The `#[derive(...)]` macro implements
+default versions of the listed traits. 
+
+> [!TIP]
+> When you get an "unsatisfied trait bounds" error on your `SiteProperties` type,
+> you need to add another entry to `#[derive(...)]` or add an
+> `impl TraitName for SiteProperties` block.
+
+> [!NOTE]
+> You can add *any* number of fields to your `SiteProperties` type and use those
+> fields when computing interactions.
+
+## Site-site Interactions
+
+### Define `SitePairInteraction`
+
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:interaction_type}}
+```
+
+### Implement `SitePairEnergy`
+
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:interaction_impl}}
+```
+
+## Construct the Simulation Model
+
+The `new()` method constructs a new simulation model:
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:simulation_new}}
+```
+
+### Parameters
+
+Assign all the model parameters in one code block:
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:parameters}}
+```
+
+`initial_packing_fraction` is the volume of the disks divided by the volume
+of the simulation boundary in the initial state. Choose this value so
+that disks can be placed easily in the microstate. During the `Initialize`
+phase, the microstate will be compressed until it reaches the packing
+fraction `target_packing_fraction`. `n_disks` is the number of disks to add,
+`maximum_distance` is the largest distance a translation trial move can take,
+and `maximum_rotation`controls the size of the rotation trial moves. `sigma` is
+the disk diameter, `patch_interaction_range` is largest distance at which the
+attractive interaction applies, `patch_half_angle` is the half open angle of the
+patch, and `patch_energy` is the potential energy of a pair of particles when
+their patches align. `initial_temperature` sets the temperature at step 0,
+`final_temperature` sets the temperature at step `ramp_steps`, and `macrostate`
+holds the current temperature set point (in units of energy).
+
+### Hamiltonian
+
+#### Hard Disk Term
+
+As in [Hard Disk Self-Assembly], use `HardSphere` to model the hard cores
+placed at each site:
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:hard_disk}}
+```
+
+[Hard Disk Self-Assembly]: hard-disk-self-assembly.md
+
+#### Patch Term
+
+Use `AngularMask` combined with `Boxcar` to compute the patch interactions
+detailed in [10.1039/C0SM01494J]. The `Boxcar` isotropic potential places an
+attractive well at all distances less than `patch_interaction_range`.
+`AngularMask` modulates that potential with oriented patches.
+Place two patches, one directed up and one directed down in the site's local
+frame.
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:patch}}
+```
+
+#### Combined Pairwise Potential
+
+The full Hamiltonian of the system is the sum of these two pairwise interaction terms.
+You could use `hamiltonian = (PairwiseCutoff(hard_disk), PairwiseCutoff(angular_mask))`
+to add the terms (as demonstrated in [Applying Interactions]), but it is slightly
+faster to use one `PairwiseCutoff` that operates on a tuple:
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:hamiltonian}}
+```
+
+The former performs two loops over nearby sites and adds the results together
+$`\left( \sum U^A_{ij} + \sum U^B_{ij} \right)`$ while the latter performs one loop and adds
+terms in the loop body $`\left( \sum U^A_{ij} + U^B_{ij} \right)`$.
+
+> [!TIP]
+> Always list hard shape potentials first in the tuple. If the hard shapes
+> overlap, *hoomd-rs* can assume that the move will be rejected and skip the
+> computation of the following terms.
+
+[Applying Interactions]: applying-interactions.md
+
+#### Overlap Penalty Hamiltonian
+
+This example uses `overlap_penalty_hamiltonian` when inserting disks randomly
+and compressing the system to the target packing fraction. Use only the hard core
+term to allow the system to arrange randomly without being hindered by the patches:
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:compress_hamiltonian}}
+```
+
+### More Initialization
+
+See the [Hard Ellipse Self-Assembly] tutorial for a complete explanation of
+remaining initialization code (see also the [complete code] below).
+
+[Hard Ellipse Self-Assembly]: hard-ellipse-self-assembly.md
+[complete code]: #complete-code
+
+## Implement `Simulation`
+
+To implement the temperature ramp, modify `macrostate` at the start of
+`advance()`.  This code implements a linear ramp from `initial_temperature` to
+`final_temperature` as a function of the current simulation step:
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:simulation}}
+```
+
+The remainder of the simulation code is identical to that in the
+[Hard Ellipse Self-Assembly] tutorial (see also the [complete code] below).
+
+## Log the Potential Energy and Temperature
+
+When running simulations in batch mode, you often want to write a **log** file
+for later analysis. In this system of patchy particles, the total system
+potential energy indicates how many bonds have formed and therefore what
+fraction of the system is part of the kagome structure.
+
+### Log Record
+
+Define a struct that records all quantities of interest:
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:log_record}}
+```
+
+This tutorial writes the log to a [parquet] file (you may choose any file format
+you like in your own projects). Parquet is a binary, column-oriented format
+that preserves the full precision of every record value and can be written and read
+efficiently. It is supported by R, pandas, MATLAB, and many other tools.
+`#[derive(ParquetRecordWriter)]` generates code that writes each field of the
+struct to a column with the same name.
+
+[parquet]: https://parquet.apache.org/
+
+### `main()`
+
+The `main()` function executes when your binary in batch mode:
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:main}}
+```
+
+> [!NOTE]
+> This `main()` function runs in batch mode. There is a different `main()` (not
+> shown here) used in the interactive example.
+
+### Open the Log File
+
+`ParquetLogger` from the `hoomd_utility` crate helps you write [parquet] files.
+Use it to create a new parquet file:
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:log_open}}
+```
+
+### Simulation Steps
+
+To run the simulation, construct the `PatchyParticleSelfAssembly` simulation model.
+Then call `advance()` many times:
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:run_simulation}}
+```
+
+Write the sites to a GSD file periodically so that you can inspect the results
+of the simulation.
+
+### Write Log Records
+
+On desired simulation steps, construct a `LogRecord` and call `parquet_logger.log`
+to add it to the log file:
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:write_log}}
+```
+
+> [!NOTE]
+> Log records will not immediately appear in the file. `ParquetLogger` buffers
+> log records in memory and writes them in batches.
+
+### Exit `main()`
+
+`ParquetWriter` writes all buffered log entries and closes the file when it
+is dropped, which occurs automatically when `main()` returns:
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:exit}}
+```
+
+## Conclusion
+
+This tutorial showed you how to perform patchy particle self-assembly
+simulations using a shape overlap potential with attractive patches.
+
+Navigate to the top of the page and refresh to see the simulation in action
+again. Notice that the disks quickly form random chains and clusters. Over
+time, hexagons will appear and the kagome structure will begin to grow. Run
+the simulation long enough, and the system will equilibrate to a single large
+crystal as shown in [10.1039/D2SM01593E].
+
+You can also run the example in batch mode and then open
+the generated `trajectory.gsd` in [Ovito] or another visualization tool:
+```shell
+cargo run --release --example type-dependent-interactions
+```
+
+Open the log file `type-dependent-interactions.parquet` and plot it using the
+tool of your choice. It will look something like this:
+<script src="https://cdn.jsdelivr.net/npm/vega@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/vega-lite@6"></script>
+<script src="https://cdn.jsdelivr.net/npm/vega-embed@7"></script>
+
+<div id="vis" style="width: 100%"></div>
+
+<script type="text/javascript">
+  var spec = {
+    $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
+    description: 'Potential energy versus step for patchy particle self-assembly.',
+    data: {"name": "data", "url": "type-dependent-interactions.csv"} ,
+    "vconcat": [{
+    width: "container",
+    height: 200,
+    "layer": [{
+    mark: { type: 'line', tooltip: true},
+    encoding: {
+      x: {field: 'step', type: 'quantitative'},
+      y: {field: 'potential_energy', type: 'quantitative'},
+    }},
+    {
+    mark: { type: 'line', tooltip: true},
+    encoding: {
+      x: {field: 'step', type: 'quantitative'},
+      y: {field: 'no_ramp', type: 'quantitative'},
+    }},
+
+    ]},
+    {
+    width: "container",
+    height: 200,
+    mark: { type: 'line', tooltip: true},
+    encoding: {
+      x: {field: 'step', type: 'quantitative'},
+      y: {field: 'temperature', type: 'quantitative'},
+    }}
+    ],
+  };
+  var tooltipOptions = {
+    theme: 'dark'
+  };
+  vegaEmbed('#vis', spec, {theme: 'dark', actions: false, tooltip: tooltipOptions} )
+    .then(function (result) {
+      // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
+    })
+    .catch(console.error);
+</script>
+
+
+[Ovito]: https://www.ovito.org/
+
+## Complete Code
+
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:all}}

--- a/doc/src/mc-tutorial/type-dependent-interactions.md
+++ b/doc/src/mc-tutorial/type-dependent-interactions.md
@@ -8,17 +8,17 @@ import init from 'https://glotzerlab.github.io/hoomd-rs/mc-tutorial/type-depende
 
 ## Overview
 
-Some models label each site with **types** and apply interactions as a function
-of type. For example, you can model coarse-grained phase separation with
-attractive *A-A* and *B-B* interactions and purely repulsive *A-B* interactions.
-This tutorial shows you how to assign **types** to sites and compute
-type-dependent pairwise interactions.
+Some models label each site with a **site type** and apply interactions as
+a function of the site type. For example, you can model coarse-grained phase
+separation with attractive *A-A* and *B-B* interactions and purely repulsive
+*A-B* interactions. This tutorial shows you how to define **site types** and
+compute type-dependent pairwise interactions.
 
 * Objectives:
-  * Show how to use an `enum` to name all the site types.
-  * Define a custom **site properties** struct that includes the type.
+  * Show how to use an `enum` to name the possible **site types**.
+  * Define a custom **site properties** struct that includes the **site type**.
   * Show how to compute type-dependent pairwise interactions.
-  * Demonstrate phase separation of *A* and *B* types.
+  * Demonstrate phase separation of *A* and *B* **site types**.
 * File: `hoomd-rs/examples/mc-tutorial/type-dependent-interactions.rs`
 * Run (interactively):
   ```shell
@@ -43,20 +43,21 @@ don't need to repeat the full generic type names throughout the code:
 {{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:type_aliases}}
 ```
 
-The **sites** are in this tutorial are placed at points in space and assigned a type.
-Therefore, use `Point` for the **body** properties.
+The **sites** are in this tutorial are placed at points in space and assigned a site
+type. Therefore, use `Point` for the **body** properties.
 
 ## Site Properties
 
 You might be familiar with simulation tools where you assign types to sites
 based on a numerical index or string name. In *hoomd-rs*, you can assign
-type (and any other site-specific parameter(s)) using any Rust datatype.
+the **site type** (and any other site-specific parameter(s)) using any Rust
+datatype.
 
-### Type `enum`
+### SiteType `enum`
 
-Using an enum ensures that every site *always* has a well-defined type. If you
-fail to assign a type or set an invalid one, Rust will issue an error *at compile
-time*. In this example, `Type` enumerates all the site types:
+Using an enum ensures that every site *always* has a well-defined **site type**.
+If you fail to assign a type or set an invalid one, Rust will issue an error *at
+compile time*. In this example, `SiteType` enumerates all the site types:
 ```rust,ignore
 {{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:type}}
 ```
@@ -67,7 +68,7 @@ Previous tutorials used one of the built-in structures (`Point` or
 `OrientedPoint`) to represent the **site properties**. These types are limited
 as they represent only a site's position (or position and orientation). This
 tutorial defines a new `SiteProperties` struct that gives each site a position
-in space and a given **type** (named `type_` because `type` is a Rust keyword):
+in space and a given **site type**:
 ```rust,ignore
 {{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:site_properties}}
 ```
@@ -126,17 +127,16 @@ and compute the type-dependent interactions:
 ```rust,ignore
 {{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:interaction_impl}}
 ```
-This example uses isotropic interactions that depend only on the distance between
-the two sites and their types. Use Rust's `match` expression to compute the desired
-potential for every combination of types. Rust will produce a helpful compile error
-should you miss one or more cases. You can compute interactions
-that are not included in `hoomd-interaction` by writing the expression
-directly, as demonstrated in the B-B case.
+First, compute the distance between the two sites. Then use Rust's `match`
+expression to compute the desired potential as a function of the two **site
+types**. Rust will produce a compile error should you miss one or more cases.
+You can compute interactions that are not included in `hoomd-interaction` by
+writing the expression directly, as demonstrated in the B-B case.
 
 > [!IMPORTANT]
 > Ensure that `site_pair_energy(i,j)` computes the same energy as
 > `site_pair_energy(j,i)`. Rust does not enforce this symmetry and *hoomd-rs*
-> cannot detect the problem.
+> cannot detect when there is a problem.
 
 ## Construct the Simulation Model
 
@@ -173,7 +173,7 @@ form the system's Hamiltonian:
 
 Even though `SitePairInteraction` treats all sites as points with well-defined
 potentials at all distances $` r \ne 0 `$, it is helpful to place sites where
-$` r \ge \sigma `$. It can take many steps to relax high energy states.
+$` r \ge \sigma `$ as it can take many steps to relax high energy states.
 Use the hard disk `OverlapPenalty` as a Hamiltonian when initializing:
 ```rust,ignore
 {{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:compress_hamiltonian}}
@@ -188,19 +188,18 @@ Place all bodies in periodic square boundary conditions at the chosen packing fr
 
 ### Place A and B bodies with `QuickInsert`
 
-One `QuickInsert` randomly places a number of copies of the given template body.
-Use one `QuickInsert` to place half of the bodies with type *A* and a second
-`QuickInsert` to place the remainder with type *B*:
+Use one `QuickInsert` to place half of the bodies with **site type** *A* and a
+second to place the remainder with **site type** *B*:
 ```rust,ignore
 {{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:quick_insert}}
 ```
 
 ## Initialization and Simulation
 
-The remaining initialization and simulation code is very similar to that
-in the [Hard Ellipse Self-Assembly] tutorial. The differences are that
-rotation moves are not present here, and there are two `quick_insert`
-methods to apply instead of one (see also the [complete code] below).
+The remaining initialization and simulation code is very similar to that in the
+[Hard Ellipse Self-Assembly] tutorial. The differences are that rotation moves
+are not present here and there are two `quick_insert` methods to apply instead
+of one (see also the [complete code] below).
 
 [Hard Ellipse Self-Assembly]: hard-ellipse-self-assembly.md
 [complete code]: #complete-code

--- a/doc/src/mc-tutorial/type-dependent-interactions.md
+++ b/doc/src/mc-tutorial/type-dependent-interactions.md
@@ -8,16 +8,16 @@ import init from 'https://glotzerlab.github.io/hoomd-rs/mc-tutorial/type-depende
 
 ## Overview
 
-Some models label sites with **types** and apply interactions between sites that
-depend on those types. For example, a coarse-grained model of phase separation
-can be achieved with a system where *A-A* and *B-B* interactions attract while
-*A-B* interactions are purely repulsive. This tutorial shows you how to assign
-**types** to sites and compute type-dependent pairwise interactions.
+Some models label each site with **types** and apply interactions as a function
+of type. For example, you can model coarse-grained phase separation with
+attractive *A-A* and *B-B* interactions and purely repulsive *A-B* interactions.
+This tutorial shows you how to assign **types** to sites and compute
+type-dependent pairwise interactions.
 
 * Objectives:
-  * Show how to use an `enum` to name the possible site types.
-  * Define a custom **site properties** that includes the type.
-  * Show how to assign type-dependent pairwise interactions.
+  * Show how to use an `enum` to name all the site types.
+  * Define a custom **site properties** struct that includes the type.
+  * Show how to compute type-dependent pairwise interactions.
   * Demonstrate phase separation of *A* and *B* types.
 * File: `hoomd-rs/examples/mc-tutorial/type-dependent-interactions.rs`
 * Run (interactively):
@@ -49,57 +49,94 @@ Therefore, use `Point` for the **body** properties.
 ## Site Properties
 
 You might be familiar with simulation tools where you assign types to sites
-based on a numerical index or string name. *hoomd-rs* utilizes the language
-features of Rust itself.
+based on a numerical index or string name. In *hoomd-rs*, you can assign
+type (and any other site-specific parameter(s)) using any Rust datatype.
 
 ### Type `enum`
 
-The `Type` enum in this example enumerates all the site types:
+Using an enum ensures that every site *always* has a well-defined type. If you
+fail to assign a type or set an invalid one, Rust will issue an error *at compile
+time*. In this example, `Type` enumerates all the site types:
 ```rust,ignore
 {{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:type}}
 ```
 
-Using an enum ensures that every site *always* has a well-defined type. If you
-fail to assign a type or set an invalid one, you will get an error *at compile
-time*.
-
 ### Define `SiteProperties`
 
-Previous tutorials used the provided `OrientedPoint` or `Point` **site
-properties** to represent a site at a point in space with or without
-orientation, respectively. This tutorial defines a new `SiteProperties` struct
-that gives each site a position in space and a given **type** (named `type_` because
-`type` is a Rust keyword):
+Previous tutorials used one of the built-in structures (`Point` or
+`OrientedPoint`) to represent the **site properties**. These types are limited
+as they represent only a site's position (or position and orientation). This
+tutorial defines a new `SiteProperties` struct that gives each site a position
+in space and a given **type** (named `type_` because `type` is a Rust keyword):
 ```rust,ignore
 {{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:site_properties}}
 ```
 
-The initialization, MC, and MD methods operate on a generic site properties
-type `S` with *trait bounds* as needed. The `#[derive(...)]` macro implements
-default versions of the listed traits. 
-
-> [!TIP]
-> When you get an "unsatisfied trait bounds" error on your `SiteProperties` type,
-> you need to add another entry to `#[derive(...)]` or add an
-> `impl TraitName for SiteProperties` block.
+Initialization, MC, and MD methods operate on a generic site properties type
+`S` with *trait bounds* set as needed. The `derive` macro implements the
+listed traits for `SiteProperties` automatically. All the types listed in the
+above code block are required by at least one method in this example. Rust
+provides the `Clone`, `Copy`, `Default` traits (and their `derive` macros).
+`hoomd_microstate` defines `Position` and `Orientation` along with their
+corresponding `derive` macros.
 
 > [!NOTE]
-> You can add *any* number of fields to your `SiteProperties` type and use those
-> fields when computing interactions.
+> You can add any fields to your `SiteProperties` type and use those fields when
+> computing interactions. `position` is the only required field.
+
+### Transforming Sites
+
+*Body* stores each of its **sites** in the *body frame* of reference. The
+`Transform` trait (implemented for the **body properties** type) transforms
+site properties from the *body frame* to the *system frame*. You must implement
+`Transform<SiteProperties>` for the body properties type to use `Microstate`:
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:site_transform}}
+```
+
+This implementation is suitable for point bodies with point sites in Euclidean
+space as it transforms from one frame to the other by vector addition and copies
+all other fields. See the `hoomd_microstate::property` module documentation for
+code that works with oriented bodies and/or sites.
 
 ## Site-site Interactions
 
+For demonstration purposes, this tutorial shows you how to implement a coarse-grained
+model where *A-A* interactions attract via the Lennard-Jones potential, *B-B* interact
+via the sum of a power law and a Gaussian, and *A-B* interact with the
+Weeks-Chandler-Anderson potential.
+
 ### Define `SitePairInteraction`
 
+Define a new struct to hold the interaction parameters. Use the provided
+types for the `LennardJones` and `WeeksChandlerAnderson` interactions:
 ```rust,ignore
 {{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:interaction_type}}
 ```
+Every site-site interaction type must implement `MaximumInteractionRange`
+which sets the distance above which the interactions go to zero. You can implement
+this trait directly, or add the `maximum_interaction_range` field and
+`#derive[(MaximumInteractionRange)]` as shown here.
 
 ### Implement `SitePairEnergy`
 
+`PairwiseCutoff` uses the `SitePairEnergy` trait to calculate the interaction
+energy that each pair of sites contributes to the total. Implement the trait
+and compute the type-dependent interactions:
 ```rust,ignore
 {{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:interaction_impl}}
 ```
+This example uses isotropic interactions that depend only on the distance between
+the two sites and their types. Use Rust's `match` expression to compute the desired
+potential for every combination of types. Rust will produce a helpful compile error
+should you miss one or more cases. You can compute interactions
+that are not included in `hoomd-interaction` by writing the expression
+directly, as demonstrated in the B-B case.
+
+> [!IMPORTANT]
+> Ensure that `site_pair_energy(i,j)` computes the same energy as
+> `site_pair_energy(j,i)`. Rust does not enforce this symmetry and *hoomd-rs*
+> cannot detect the problem.
 
 ## Construct the Simulation Model
 
@@ -120,229 +157,88 @@ of the simulation boundary in the initial state. Choose this value so
 that disks can be placed easily in the microstate. During the `Initialize`
 phase, the microstate will be compressed until it reaches the packing
 fraction `target_packing_fraction`. `n_disks` is the number of disks to add,
-`maximum_distance` is the largest distance a translation trial move can take,
-and `maximum_rotation`controls the size of the rotation trial moves. `sigma` is
-the disk diameter, `patch_interaction_range` is largest distance at which the
-attractive interaction applies, `patch_half_angle` is the half open angle of the
-patch, and `patch_energy` is the potential energy of a pair of particles when
-their patches align. `initial_temperature` sets the temperature at step 0,
-`final_temperature` sets the temperature at step `ramp_steps`, and `macrostate`
-holds the current temperature set point (in units of energy).
+`maximum_distance` is the largest distance a translation trial move can take
+(initially), `sigma` is the disk diameter, and `macrostate` holds the current
+temperature set point (in units of energy).
 
 ### Hamiltonian
 
-#### Hard Disk Term
-
-As in [Hard Disk Self-Assembly], use `HardSphere` to model the hard cores
-placed at each site:
-```rust,ignore
-{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:hard_disk}}
-```
-
-[Hard Disk Self-Assembly]: hard-disk-self-assembly.md
-
-#### Patch Term
-
-Use `AngularMask` combined with `Boxcar` to compute the patch interactions
-detailed in [10.1039/C0SM01494J]. The `Boxcar` isotropic potential places an
-attractive well at all distances less than `patch_interaction_range`.
-`AngularMask` modulates that potential with oriented patches.
-Place two patches, one directed up and one directed down in the site's local
-frame.
-```rust,ignore
-{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:patch}}
-```
-
-#### Combined Pairwise Potential
-
-The full Hamiltonian of the system is the sum of these two pairwise interaction terms.
-You could use `hamiltonian = (PairwiseCutoff(hard_disk), PairwiseCutoff(angular_mask))`
-to add the terms (as demonstrated in [Applying Interactions]), but it is slightly
-faster to use one `PairwiseCutoff` that operates on a tuple:
+Construct the `SitePairInteraction` type and use it with `PairwiseCutoff` to
+form the system's Hamiltonian:
 ```rust,ignore
 {{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:hamiltonian}}
 ```
 
-The former performs two loops over nearby sites and adds the results together
-$`\left( \sum U^A_{ij} + \sum U^B_{ij} \right)`$ while the latter performs one loop and adds
-terms in the loop body $`\left( \sum U^A_{ij} + U^B_{ij} \right)`$.
+### Overlap Penalty Hamiltonian
 
-> [!TIP]
-> Always list hard shape potentials first in the tuple. If the hard shapes
-> overlap, *hoomd-rs* can assume that the move will be rejected and skip the
-> computation of the following terms.
-
-[Applying Interactions]: applying-interactions.md
-
-#### Overlap Penalty Hamiltonian
-
-This example uses `overlap_penalty_hamiltonian` when inserting disks randomly
-and compressing the system to the target packing fraction. Use only the hard core
-term to allow the system to arrange randomly without being hindered by the patches:
+Even though `SitePairInteraction` treats all sites as points with well-defined
+potentials at all distances $` r \ne 0 `$, it is helpful to place sites where
+$` r \ge \sigma `$. It can take many steps to relax high energy states.
+Use the hard disk `OverlapPenalty` as a Hamiltonian when initializing:
 ```rust,ignore
 {{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:compress_hamiltonian}}
 ```
 
-### More Initialization
+### Construct the Boundary
 
-See the [Hard Ellipse Self-Assembly] tutorial for a complete explanation of
-remaining initialization code (see also the [complete code] below).
+Place all bodies in periodic square boundary conditions at the chosen packing fraction:
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:boundary}}
+```
+
+### Place A and B bodies with `QuickInsert`
+
+One `QuickInsert` randomly places a number of copies of the given template body.
+Use one `QuickInsert` to place half of the bodies with type *A* and a second
+`QuickInsert` to place the remainder with type *B*:
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:quick_insert}}
+```
+
+## Initialization and Simulation
+
+The remaining initialization and simulation code is very similar to that
+in the [Hard Ellipse Self-Assembly] tutorial. The differences are that
+rotation moves are not present here, and there are two `quick_insert`
+methods to apply instead of one (see also the [complete code] below).
 
 [Hard Ellipse Self-Assembly]: hard-ellipse-self-assembly.md
 [complete code]: #complete-code
 
-## Implement `Simulation`
 
-To implement the temperature ramp, modify `macrostate` at the start of
-`advance()`.  This code implements a linear ramp from `initial_temperature` to
-`final_temperature` as a function of the current simulation step:
-```rust,ignore
-{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:simulation}}
-```
+## Implement `main()`
 
-The remainder of the simulation code is identical to that in the
-[Hard Ellipse Self-Assembly] tutorial (see also the [complete code] below).
-
-## Log the Potential Energy and Temperature
-
-When running simulations in batch mode, you often want to write a **log** file
-for later analysis. In this system of patchy particles, the total system
-potential energy indicates how many bonds have formed and therefore what
-fraction of the system is part of the kagome structure.
-
-### Log Record
-
-Define a struct that records all quantities of interest:
-```rust,ignore
-{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:log_record}}
-```
-
-This tutorial writes the log to a [parquet] file (you may choose any file format
-you like in your own projects). Parquet is a binary, column-oriented format
-that preserves the full precision of every record value and can be written and read
-efficiently. It is supported by R, pandas, MATLAB, and many other tools.
-`#[derive(ParquetRecordWriter)]` generates code that writes each field of the
-struct to a column with the same name.
-
-[parquet]: https://parquet.apache.org/
-
-### `main()`
-
-The `main()` function executes when your binary in batch mode:
-```rust,ignore
-{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:main}}
-```
-
-> [!NOTE]
-> This `main()` function runs in batch mode. There is a different `main()` (not
-> shown here) used in the interactive example.
-
-### Open the Log File
-
-`ParquetLogger` from the `hoomd_utility` crate helps you write [parquet] files.
-Use it to create a new parquet file:
-```rust,ignore
-{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:log_open}}
-```
-
-### Simulation Steps
-
-To run the simulation, construct the `PatchyParticleSelfAssembly` simulation model.
+To run the simulation, construct the `TypeDependentInteractions` simulation model.
 Then call `advance()` many times:
 ```rust,ignore
-{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:run_simulation}}
+{{#rustdoc_include ../../../examples/mc-tutorial/hard-ellipse-self-assembly.rs:main}}
 ```
 
 Write the sites to a GSD file periodically so that you can inspect the results
 of the simulation.
 
-### Write Log Records
-
-On desired simulation steps, construct a `LogRecord` and call `parquet_logger.log`
-to add it to the log file:
-```rust,ignore
-{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:write_log}}
-```
-
 > [!NOTE]
-> Log records will not immediately appear in the file. `ParquetLogger` buffers
-> log records in memory and writes them in batches.
-
-### Exit `main()`
-
-`ParquetWriter` writes all buffered log entries and closes the file when it
-is dropped, which occurs automatically when `main()` returns:
-```rust,ignore
-{{#rustdoc_include ../../../examples/mc-tutorial/type-dependent-interactions.rs:exit}}
-```
+> This `main()` function runs in batch mode. There is a different `main()` (not
+> shown here) used in the interactive example.
 
 ## Conclusion
 
-This tutorial showed you how to perform patchy particle self-assembly
-simulations using a shape overlap potential with attractive patches.
+This tutorial showed you how to implement custom site properties and
+site-site interaction types. Specifically, it demonstrated the addition
+of a site type field and showed how you can use that when computing
+the interaction energies.
 
 Navigate to the top of the page and refresh to see the simulation in action
-again. Notice that the disks quickly form random chains and clusters. Over
-time, hexagons will appear and the kagome structure will begin to grow. Run
-the simulation long enough, and the system will equilibrate to a single large
-crystal as shown in [10.1039/D2SM01593E].
+again. Notice that the sites quickly phase separate. Wait long enough and the
+system should form two stripes. Due to the differently shaped potentials, the
+*A* and *B* domains are distinct. The *A* sites form a hexagonal solid and *B*
+form a lower density fluid.
 
 You can also run the example in batch mode and then open
 the generated `trajectory.gsd` in [Ovito] or another visualization tool:
 ```shell
 cargo run --release --example type-dependent-interactions
 ```
-
-Open the log file `type-dependent-interactions.parquet` and plot it using the
-tool of your choice. It will look something like this:
-<script src="https://cdn.jsdelivr.net/npm/vega@6"></script>
-<script src="https://cdn.jsdelivr.net/npm/vega-lite@6"></script>
-<script src="https://cdn.jsdelivr.net/npm/vega-embed@7"></script>
-
-<div id="vis" style="width: 100%"></div>
-
-<script type="text/javascript">
-  var spec = {
-    $schema: 'https://vega.github.io/schema/vega-lite/v6.json',
-    description: 'Potential energy versus step for patchy particle self-assembly.',
-    data: {"name": "data", "url": "type-dependent-interactions.csv"} ,
-    "vconcat": [{
-    width: "container",
-    height: 200,
-    "layer": [{
-    mark: { type: 'line', tooltip: true},
-    encoding: {
-      x: {field: 'step', type: 'quantitative'},
-      y: {field: 'potential_energy', type: 'quantitative'},
-    }},
-    {
-    mark: { type: 'line', tooltip: true},
-    encoding: {
-      x: {field: 'step', type: 'quantitative'},
-      y: {field: 'no_ramp', type: 'quantitative'},
-    }},
-
-    ]},
-    {
-    width: "container",
-    height: 200,
-    mark: { type: 'line', tooltip: true},
-    encoding: {
-      x: {field: 'step', type: 'quantitative'},
-      y: {field: 'temperature', type: 'quantitative'},
-    }}
-    ],
-  };
-  var tooltipOptions = {
-    theme: 'dark'
-  };
-  vegaEmbed('#vis', spec, {theme: 'dark', actions: false, tooltip: tooltipOptions} )
-    .then(function (result) {
-      // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
-    })
-    .catch(console.error);
-</script>
-
 
 [Ovito]: https://www.ovito.org/
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -24,6 +24,7 @@ doc-example = ["bevy", "hoomd-bevy/doc-example"]
 
 [dependencies]
 hoomd-bevy = { workspace =  true, optional = true }
+hoomd-derive.workspace = true
 hoomd-geometry.workspace = true
 hoomd-gsd.workspace = true
 hoomd-interaction.workspace = true

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -104,3 +104,10 @@ path = "mc-tutorial/patchy-particle-self-assembly.rs"
 
 [package.metadata.example.patchy-particle-self-assembly]
 path = "mc-tutorial"
+
+[[example]]
+name = "type-dependent-interactions"
+path = "mc-tutorial/type-dependent-interactions.rs"
+
+[package.metadata.example.type-dependent-interactions]
+path = "mc-tutorial"

--- a/examples/mc-tutorial/hard-ellipse-self-assembly.rs
+++ b/examples/mc-tutorial/hard-ellipse-self-assembly.rs
@@ -51,7 +51,7 @@ struct HardEllipseSelfAssembly {
     /// Quick compress algorithm.
     quick_compress: QuickCompress<Periodic<Rectangle>>,
     /// Quick insert algorithm.
-    quick_insert: QuickInsert<UniformIn<BodyProperties, Periodic<Rectangle>>>,
+    quick_insert: QuickInsert<UniformIn<SiteProperties, Periodic<Rectangle>>>,
     /// How sites interact when inserted and compressed.
     overlap_penalty_hamiltonian: PairwiseCutoff<
         Anisotropic<ApproximateShapeOverlap<OverlapPenalty, Ellipse>>,

--- a/examples/mc-tutorial/hard-tetrahedron-self-assembly.rs
+++ b/examples/mc-tutorial/hard-tetrahedron-self-assembly.rs
@@ -143,7 +143,7 @@ struct HardTetrahedronSelfAssembly {
     /// Quick compress algorithm.
     quick_compress: QuickCompress<Periodic<Cuboid>>,
     /// Quick insert algorithm.
-    quick_insert: QuickInsert<UniformIn<BodyProperties, Periodic<Cuboid>>>,
+    quick_insert: QuickInsert<UniformIn<SiteProperties, Periodic<Cuboid>>>,
     /// How sites interact when inserted and compressed.
     overlap_penalty_hamiltonian: PairwiseCutoff<
         Anisotropic<

--- a/examples/mc-tutorial/patchy-particle-self-assembly.rs
+++ b/examples/mc-tutorial/patchy-particle-self-assembly.rs
@@ -39,7 +39,7 @@ type SiteProperties = OrientedPoint<PositionVector, Orientation>;
 
 // ANCHOR: simulation_new
 impl PatchyParticleSelfAssembly {
-    /// Construct a new hard disk self-assembly simulation.
+    /// Construct a new patchy particle self-assembly simulation.
     fn new() -> anyhow::Result<PatchyParticleSelfAssembly> {
         // ANCHOR_END: simulation_new
         // ANCHOR: parameters
@@ -181,7 +181,7 @@ struct PatchyParticleSelfAssembly {
     /// Temperature set point.
     macrostate: Isothermal,
     /// Quick insert algorithm.
-    quick_insert: QuickInsert<UniformIn<BodyProperties, Periodic<Rectangle>>>,
+    quick_insert: QuickInsert<UniformIn<SiteProperties, Periodic<Rectangle>>>,
     /// Quick compress algorithm
     quick_compress: QuickCompress<Periodic<Rectangle>>,
     /// How sites interact during compression.

--- a/examples/mc-tutorial/type-dependent-interactions.rs
+++ b/examples/mc-tutorial/type-dependent-interactions.rs
@@ -33,7 +33,7 @@ type BodyProperties = Point<PositionVector>;
 // ANCHOR_END: type_aliases
 
 // ANCHOR: type
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Copy, Default, PartialEq)]
 enum Type {
     #[default]
     A,
@@ -42,14 +42,16 @@ enum Type {
 // ANCHOR_END: type
 
 // ANCHOR: site_properties
-#[derive(Clone, Copy, Debug, Default, Position)]
+#[derive(Clone, Copy, Default, Position)]
 struct SiteProperties {
     /// The site's position
     position: PositionVector,
     /// The site's type
     type_: Type,
 }
+// ANCHOR_END: site_properties
 
+// ANCHOR: site_transform
 impl Transform<SiteProperties> for BodyProperties {
     fn transform(&self, site_properties: &SiteProperties) -> SiteProperties {
         SiteProperties {
@@ -58,7 +60,7 @@ impl Transform<SiteProperties> for BodyProperties {
         }
     }
 }
-// ANCHOR_END: site_properties
+// ANCHOR_END: site_transform
 
 // ANCHOR: interaction_type
 #[derive(MaximumInteractionRange)]
@@ -100,8 +102,8 @@ impl TypeDependentInteractions {
         let initial_packing_fraction = 0.3;
         let target_packing_fraction = 0.5;
         let n_disks = 512;
-        let sigma = 1.0;
         let maximum_distance = 0.07;
+        let sigma = 1.0;
         let macrostate = Isothermal { temperature: 1.0 };
         // ANCHOR_END: parameters
 

--- a/examples/mc-tutorial/type-dependent-interactions.rs
+++ b/examples/mc-tutorial/type-dependent-interactions.rs
@@ -1,0 +1,342 @@
+// ANCHOR: all
+// ANCHOR: use
+use anyhow::{Context, anyhow};
+
+use hoomd_geometry::{
+    Volume,
+    shape::{Circle, Rectangle},
+};
+use hoomd_interaction::{
+    MaximumInteractionRange, PairwiseCutoff, SitePairEnergy,
+    pairwise::Isotropic,
+    univariate::{
+        Expanded, LennardJones, OverlapPenalty, UnivariateEnergy,
+        WeeksChandlerAnderson,
+    },
+};
+use hoomd_mc::{
+    QuickCompress, QuickInsert, Sweep, Translate, Trial, Tune, UniformIn,
+};
+use hoomd_microstate::{
+    Microstate, SiteKey, Transform,
+    boundary::Periodic,
+    property::{Point, Position},
+};
+use hoomd_simulation::{Simulation, macrostate::Isothermal};
+use hoomd_spatial::VecCell;
+use hoomd_vector::{Cartesian, Metric};
+// ANCHOR_END: use
+
+// ANCHOR: type_aliases
+type PositionVector = Cartesian<2>;
+type BodyProperties = Point<PositionVector>;
+// ANCHOR_END: type_aliases
+
+// ANCHOR: type
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+enum Type {
+    #[default]
+    A,
+    B,
+}
+// ANCHOR_END: type
+
+// ANCHOR: site_properties
+#[derive(Clone, Copy, Debug, Default)]
+struct SiteProperties {
+    /// The site's position
+    position: PositionVector,
+    /// The site's type
+    type_: Type,
+}
+
+impl Position for SiteProperties {
+    type Position = PositionVector;
+    fn position(&self) -> &PositionVector {
+        &self.position
+    }
+
+    fn position_mut(&mut self) -> &mut Self::Position {
+        &mut self.position
+    }
+}
+
+impl Transform<SiteProperties> for BodyProperties {
+    fn transform(&self, site_properties: &SiteProperties) -> SiteProperties {
+        SiteProperties {
+            position: self.position + site_properties.position,
+            ..*site_properties
+        }
+    }
+}
+// ANCHOR_END: site_properties
+
+// ANCHOR: interaction
+struct SitePairInteraction;
+
+impl SitePairEnergy<SiteProperties> for SitePairInteraction {
+    fn site_pair_energy(
+        &self,
+        site_properties_i: &SiteProperties,
+        site_properties_j: &SiteProperties,
+    ) -> f64 {
+        let r = site_properties_i
+            .position
+            .distance(&site_properties_j.position);
+
+        match (site_properties_i.type_, site_properties_j.type_) {
+            (Type::A, Type::A) => LennardJones::<12, 6> {
+                epsilon: 2.0,
+                sigma: 1.0,
+            }
+            .energy(r),
+            (Type::A, Type::B) | (Type::B, Type::A) => WeeksChandlerAnderson {
+                epsilon: 1.0,
+                sigma: 1.0,
+            }
+            .energy(r),
+            (Type::B, Type::B) => {
+                1.0 / r.powi(12) - f64::exp(-1.0 / 2.0 * r.powi(2))
+            }
+        }
+    }
+}
+// ANCHOR_END: interaction
+// ANCHOR: maximum_interaction_range
+impl MaximumInteractionRange for SitePairInteraction {
+    fn maximum_interaction_range(&self) -> f64 {
+        2.5
+    }
+}
+// ANCHOR_END: maximum_interaction_range
+
+// ANCHOR: simulation_new
+impl TypeDependentInteractions {
+    /// Construct a new type-dependent interactions simulation.
+    fn new() -> anyhow::Result<TypeDependentInteractions> {
+        // ANCHOR_END: simulation_new
+        // ANCHOR: parameters
+        let initial_packing_fraction = 0.3;
+        let target_packing_fraction = 0.5;
+        let n_disks = 512;
+        let sigma = 1.0;
+        let maximum_distance = 0.07;
+        let macrostate = Isothermal { temperature: 1.0 };
+        // ANCHOR_END: parameters
+
+        // ANCHOR: hamiltonian
+        let hamiltonian = PairwiseCutoff(SitePairInteraction);
+        // ANCHOR_END: hamiltonian
+
+        // ANCHOR: compress_hamiltonian
+        let overlap_penalty = Isotropic {
+            interaction: Expanded {
+                delta: sigma,
+                f: OverlapPenalty::default(),
+            },
+            r_cut: sigma,
+        };
+
+        let overlap_penalty_hamiltonian = PairwiseCutoff(overlap_penalty);
+        // ANCHOR_END: compress_hamiltonian
+
+        // ANCHOR: boundary
+        let circle = Circle {
+            radius: (sigma / 2.0).try_into()?,
+        };
+        let initial_box_volume =
+            n_disks as f64 * circle.volume() / initial_packing_fraction;
+        let initial_box_edge_length = initial_box_volume.sqrt();
+        let square =
+            Rectangle::with_equal_edges(initial_box_edge_length.try_into()?);
+        let periodic_square =
+            Periodic::new(hamiltonian.maximum_interaction_range(), square)?;
+        // ANCHOR_END: boundary
+
+        // ANCHOR: quick_insert
+        let distribution = UniformIn {
+            boundary: periodic_square.clone(),
+            template_sites: vec![SiteProperties {
+                type_: Type::A,
+                ..SiteProperties::default()
+            }],
+        };
+        let quick_insert_a = QuickInsert::new(distribution, n_disks / 2);
+
+        let distribution = UniformIn {
+            boundary: periodic_square.clone(),
+            template_sites: vec![SiteProperties {
+                type_: Type::B,
+                ..SiteProperties::default()
+            }],
+        };
+        let quick_insert_b = QuickInsert::new(distribution, n_disks - quick_insert_a.target());
+        // ANCHOR_END: quick_insert
+
+        let vec_cell = VecCell::builder()
+            .nominal_search_radius(
+                hamiltonian.maximum_interaction_range().try_into()?,
+            )
+            .build();
+        let microstate = Microstate::builder()
+            .boundary(periodic_square)
+            .spatial_data(vec_cell)
+            .try_build()?;
+
+        let translate =
+            Translate::with_maximum_distance(maximum_distance.try_into()?);
+        let translate_sweep = Sweep(translate);
+
+        let target_box_volume =
+            n_disks as f64 * circle.volume() / target_packing_fraction;
+        let quick_compress =
+            QuickCompress::with_target_volume(target_box_volume.try_into()?);
+
+        Ok(TypeDependentInteractions {
+            microstate,
+            overlap_penalty_hamiltonian,
+            hamiltonian,
+            translate_sweep,
+            quick_insert_a,
+            quick_insert_b,
+            quick_compress,
+            macrostate,
+            phase: Phase::Initialize,
+        })
+    }
+}
+
+#[cfg_attr(feature = "bevy", derive(Resource))]
+struct TypeDependentInteractions {
+    /// Positions of all the bodies in the simulation.
+    microstate: Microstate<
+        BodyProperties,
+        SiteProperties,
+        VecCell<SiteKey, 2>,
+        Periodic<Rectangle>,
+    >,
+    /// How sites interact with other sites and fields.
+    hamiltonian: PairwiseCutoff<SitePairInteraction>,
+    /// Trial moves to apply.
+    translate_sweep: Sweep<Translate<PositionVector>>,
+    /// Temperature set point.
+    macrostate: Isothermal,
+    /// Quick insert algorithm for A bodies.
+    quick_insert_a: QuickInsert<UniformIn<SiteProperties, Periodic<Rectangle>>>,
+    /// Quick insert algorithm for B bodies.
+    quick_insert_b: QuickInsert<UniformIn<SiteProperties, Periodic<Rectangle>>>,
+    /// Quick compress algorithm
+    quick_compress: QuickCompress<Periodic<Rectangle>>,
+    /// How sites interact during compression.
+    overlap_penalty_hamiltonian:
+        PairwiseCutoff<Isotropic<Expanded<OverlapPenalty>>>,
+    /// The current phase of the simulation.
+    phase: Phase,
+}
+
+enum Phase {
+    Initialize,
+    Equilibrate,
+}
+
+impl Simulation for TypeDependentInteractions {
+    /// Advance the simulation forward one step.
+    fn advance(&mut self) -> anyhow::Result<()> {
+        match self.phase {
+            Phase::Initialize => {
+                self.initialize().context("failed to initialize")?
+            }
+            Phase::Equilibrate => self.equilibrate(),
+        }
+
+        self.microstate.increment_step();
+
+        Ok(())
+    }
+
+    /// Get the current simulation step.
+    fn step(&self) -> u64 {
+        self.microstate.step()
+    }
+}
+
+impl TypeDependentInteractions {
+    fn initialize(&mut self) -> anyhow::Result<()> {
+        if self.quick_insert_a.is_complete()
+            && self.quick_insert_b.is_complete()
+        {
+            self.quick_compress.apply(
+                &mut self.microstate,
+                &self.overlap_penalty_hamiltonian,
+                |_| true,
+            );
+        } else {
+            self.quick_insert_a
+                .apply(&mut self.microstate, &self.overlap_penalty_hamiltonian);
+            self.quick_insert_b
+                .apply(&mut self.microstate, &self.overlap_penalty_hamiltonian);
+        }
+
+        self.translate_sweep.apply(
+            &mut self.microstate,
+            &self.overlap_penalty_hamiltonian,
+            &Isothermal { temperature: 1.0 },
+        );
+
+        if self.quick_compress.is_complete() {
+            self.translate_sweep.tune_default(
+                &self.microstate,
+                &self.hamiltonian,
+                &self.macrostate,
+            );
+
+            self.phase = Phase::Equilibrate;
+            println!(
+                "Initialization complete at step {}.",
+                self.microstate.step()
+            );
+        }
+
+        if self.step() >= 20_000 {
+            let n = self.microstate.bodies().len();
+            let target_n =
+                self.quick_insert_a.target() + self.quick_insert_b.target();
+            let volume = self.microstate.boundary().volume();
+            let target_volume = self.quick_compress.target_volume();
+            return Err(anyhow!(
+                "inserted {n}/{target_n} bodies and compressed to {volume} / {target_volume}"
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn equilibrate(&mut self) {
+        self.translate_sweep.apply(
+            &mut self.microstate,
+            &self.hamiltonian,
+            &self.macrostate,
+        );
+    }
+}
+
+// Remove the cfg(not(...)) line when using this code outside the hoomd-rs/examples directory.
+#[cfg(not(feature = "bevy"))]
+fn main() -> anyhow::Result<()> {
+    let mut simulation = TypeDependentInteractions::new()?;
+    // TODO: Write GSD file.
+
+    for _ in 0..1_000_000 {
+        simulation.advance()?;
+        }
+
+    Ok(())
+}
+// ANCHOR_END: all
+
+#[cfg(feature = "bevy")]
+mod type_dependent_interactions_interactive;
+#[cfg(feature = "bevy")]
+use bevy::prelude::Resource;
+#[cfg(feature = "bevy")]
+use type_dependent_interactions_interactive::main;

--- a/examples/mc-tutorial/type-dependent-interactions.rs
+++ b/examples/mc-tutorial/type-dependent-interactions.rs
@@ -34,7 +34,7 @@ type BodyProperties = Point<PositionVector>;
 
 // ANCHOR: type
 #[derive(Clone, Copy, Default, PartialEq)]
-enum Type {
+enum SiteType {
     #[default]
     A,
     B,
@@ -44,10 +44,10 @@ enum Type {
 // ANCHOR: site_properties
 #[derive(Clone, Copy, Default, Position)]
 struct SiteProperties {
-    /// The site's position
+    /// The site's position.
     position: PositionVector,
-    /// The site's type
-    type_: Type,
+    /// The site's type.
+    site_type: SiteType,
 }
 // ANCHOR_END: site_properties
 
@@ -82,10 +82,12 @@ impl SitePairEnergy<SiteProperties> for SitePairInteraction {
             .position
             .distance(&site_properties_j.position);
 
-        match (site_properties_i.type_, site_properties_j.type_) {
-            (Type::A, Type::A) => self.lj_aa.energy(r),
-            (Type::A, Type::B) | (Type::B, Type::A) => self.wca_ab.energy(r),
-            (Type::B, Type::B) => {
+        match (site_properties_i.site_type, site_properties_j.site_type) {
+            (SiteType::A, SiteType::A) => self.lj_aa.energy(r),
+            (SiteType::A, SiteType::B) | (SiteType::B, SiteType::A) => {
+                self.wca_ab.energy(r)
+            }
+            (SiteType::B, SiteType::B) => {
                 1.0 / r.powi(12) - f64::exp(-1.0 / 2.0 * r.powi(2))
             }
         }
@@ -152,7 +154,7 @@ impl TypeDependentInteractions {
         let distribution = UniformIn {
             boundary: periodic_square.clone(),
             template_sites: vec![SiteProperties {
-                type_: Type::A,
+                site_type: SiteType::A,
                 ..SiteProperties::default()
             }],
         };
@@ -161,7 +163,7 @@ impl TypeDependentInteractions {
         let distribution = UniformIn {
             boundary: periodic_square.clone(),
             template_sites: vec![SiteProperties {
-                type_: Type::B,
+                site_type: SiteType::B,
                 ..SiteProperties::default()
             }],
         };

--- a/examples/mc-tutorial/type-dependent-interactions.rs
+++ b/examples/mc-tutorial/type-dependent-interactions.rs
@@ -42,23 +42,12 @@ enum Type {
 // ANCHOR_END: type
 
 // ANCHOR: site_properties
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, Position)]
 struct SiteProperties {
     /// The site's position
     position: PositionVector,
     /// The site's type
     type_: Type,
-}
-
-impl Position for SiteProperties {
-    type Position = PositionVector;
-    fn position(&self) -> &PositionVector {
-        &self.position
-    }
-
-    fn position_mut(&mut self) -> &mut Self::Position {
-        &mut self.position
-    }
 }
 
 impl Transform<SiteProperties> for BodyProperties {
@@ -72,16 +61,11 @@ impl Transform<SiteProperties> for BodyProperties {
 // ANCHOR_END: site_properties
 
 // ANCHOR: interaction_type
+#[derive(MaximumInteractionRange)]
 struct SitePairInteraction {
     lj_aa: LennardJones<12, 6>,
     wca_ab: WeeksChandlerAnderson,
     maximum_interaction_range: f64,
-}
-
-impl MaximumInteractionRange for SitePairInteraction {
-    fn maximum_interaction_range(&self) -> f64 {
-        self.maximum_interaction_range
-    }
 }
 // ANCHOR_END: interaction_type
 

--- a/examples/mc-tutorial/type-dependent-interactions.rs
+++ b/examples/mc-tutorial/type-dependent-interactions.rs
@@ -71,9 +71,21 @@ impl Transform<SiteProperties> for BodyProperties {
 }
 // ANCHOR_END: site_properties
 
-// ANCHOR: interaction
-struct SitePairInteraction;
+// ANCHOR: interaction_type
+struct SitePairInteraction {
+    lj_aa: LennardJones<12, 6>,
+    wca_ab: WeeksChandlerAnderson,
+    maximum_interaction_range: f64,
+}
 
+impl MaximumInteractionRange for SitePairInteraction {
+    fn maximum_interaction_range(&self) -> f64 {
+        self.maximum_interaction_range
+    }
+}
+// ANCHOR_END: interaction_type
+
+// ANCHOR: interaction_impl
 impl SitePairEnergy<SiteProperties> for SitePairInteraction {
     fn site_pair_energy(
         &self,
@@ -85,30 +97,15 @@ impl SitePairEnergy<SiteProperties> for SitePairInteraction {
             .distance(&site_properties_j.position);
 
         match (site_properties_i.type_, site_properties_j.type_) {
-            (Type::A, Type::A) => LennardJones::<12, 6> {
-                epsilon: 2.0,
-                sigma: 1.0,
-            }
-            .energy(r),
-            (Type::A, Type::B) | (Type::B, Type::A) => WeeksChandlerAnderson {
-                epsilon: 1.0,
-                sigma: 1.0,
-            }
-            .energy(r),
+            (Type::A, Type::A) => self.lj_aa.energy(r),
+            (Type::A, Type::B) | (Type::B, Type::A) => self.wca_ab.energy(r),
             (Type::B, Type::B) => {
                 1.0 / r.powi(12) - f64::exp(-1.0 / 2.0 * r.powi(2))
             }
         }
     }
 }
-// ANCHOR_END: interaction
-// ANCHOR: maximum_interaction_range
-impl MaximumInteractionRange for SitePairInteraction {
-    fn maximum_interaction_range(&self) -> f64 {
-        2.5
-    }
-}
-// ANCHOR_END: maximum_interaction_range
+// ANCHOR_END: interaction_impl
 
 // ANCHOR: simulation_new
 impl TypeDependentInteractions {
@@ -125,7 +122,19 @@ impl TypeDependentInteractions {
         // ANCHOR_END: parameters
 
         // ANCHOR: hamiltonian
-        let hamiltonian = PairwiseCutoff(SitePairInteraction);
+        let lj_aa = LennardJones {
+            epsilon: 2.0,
+            sigma: 1.0,
+        };
+        let wca_ab = WeeksChandlerAnderson {
+            epsilon: 1.0,
+            sigma: 1.0,
+        };
+        let hamiltonian = PairwiseCutoff(SitePairInteraction {
+            lj_aa,
+            wca_ab,
+            maximum_interaction_range: 2.5,
+        });
         // ANCHOR_END: hamiltonian
 
         // ANCHOR: compress_hamiltonian
@@ -170,7 +179,8 @@ impl TypeDependentInteractions {
                 ..SiteProperties::default()
             }],
         };
-        let quick_insert_b = QuickInsert::new(distribution, n_disks - quick_insert_a.target());
+        let quick_insert_b =
+            QuickInsert::new(distribution, n_disks - quick_insert_a.target());
         // ANCHOR_END: quick_insert
 
         let vec_cell = VecCell::builder()
@@ -328,7 +338,7 @@ fn main() -> anyhow::Result<()> {
 
     for _ in 0..1_000_000 {
         simulation.advance()?;
-        }
+    }
 
     Ok(())
 }

--- a/examples/mc-tutorial/type_dependent_interactions_interactive.rs
+++ b/examples/mc-tutorial/type_dependent_interactions_interactive.rs
@@ -8,7 +8,7 @@ use anyhow::Context;
 use bevy::prelude::*;
 use bevy_egui::EguiPlugin;
 
-use super::{Type, TypeDependentInteractions};
+use super::{SiteType, TypeDependentInteractions};
 
 /// Mark the circle representation type.
 struct A;
@@ -93,7 +93,7 @@ fn sync_a_sites(
         site_query,
         sites
             .iter()
-            .filter(|s| s.properties.type_ == Type::A)
+            .filter(|s| s.properties.site_type == SiteType::A)
             .map(|site| {
                 (
                     Vec3::new(
@@ -121,7 +121,7 @@ fn sync_b_sites(
         site_query,
         sites
             .iter()
-            .filter(|s| s.properties.type_ == Type::B)
+            .filter(|s| s.properties.site_type == SiteType::B)
             .map(|site| {
                 (
                     Vec3::new(

--- a/examples/mc-tutorial/type_dependent_interactions_interactive.rs
+++ b/examples/mc-tutorial/type_dependent_interactions_interactive.rs
@@ -1,0 +1,173 @@
+use hoomd_bevy::{
+    AdvanceSet, HIGHLIGHT_COLOR, HoomdBevyPlugin, InitialCamera, MUTED_COLOR,
+    Settings,
+    representation::{RectangularBoundary, disk},
+};
+
+use anyhow::Context;
+use bevy::prelude::*;
+use bevy_egui::EguiPlugin;
+
+use super::{Type, TypeDependentInteractions};
+
+/// Mark the circle representation type.
+struct A;
+
+/// Mark the top patch representation type.
+struct B;
+
+/// Mark the ghost representation type.
+struct Ghost;
+
+pub(crate) fn main() -> anyhow::Result<()> {
+    let simulation = TypeDependentInteractions::new()
+        .context("failed to setup simulation")?;
+
+    let l =
+        simulation.microstate.boundary().shape().edge_lengths[1].get() as f32;
+    let hoomd_bevy_plugin = HoomdBevyPlugin {
+        initial_settings: Settings {
+            camera: InitialCamera::Orthographic2d(l + 2.0),
+            ..default()
+        },
+        simulation,
+    };
+
+    let mut app = App::new();
+    hoomd_bevy::add_default_plugins(&mut app);
+    app.add_plugins(EguiPlugin::default());
+    hoomd_bevy_plugin.build(&mut app);
+
+    app.add_systems(
+        Startup,
+        (|| disk::MaterialParameters::default()).pipe(disk::Disk::<A>::setup),
+    );
+    app.add_systems(
+        Startup,
+        (|| disk::MaterialParameters {
+            background_color: HIGHLIGHT_COLOR.into(),
+            ..default()
+        })
+        .pipe(disk::Disk::<B>::setup),
+    );
+    app.add_systems(
+        Startup,
+        (|| disk::MaterialParameters {
+            background_color: MUTED_COLOR.into(),
+            ..default()
+        })
+        .pipe(disk::Disk::<Ghost>::setup),
+    );
+    app.add_systems(
+        Startup,
+        (move || RectangularBoundary {
+            width: l,
+            height: l,
+            ..default()
+        })
+        .pipe(RectangularBoundary::setup),
+    );
+    app.add_systems(
+        Update,
+        (sync_a_sites, sync_b_sites, sync_ghosts, sync_boundary)
+            .run_if(resource_changed::<TypeDependentInteractions>)
+            .after(AdvanceSet),
+    );
+
+    app.run();
+
+    Ok(())
+}
+
+/// Copy the current positions of simulation sites to bevy entities.
+fn sync_a_sites(
+    mut commands: Commands,
+    site_representation: Res<disk::Representation<A>>,
+    site_query: Query<(Entity, &mut Transform), With<disk::Disk<A>>>,
+    simulation: Res<TypeDependentInteractions>,
+) {
+    let sites = simulation.microstate.sites();
+    disk::Disk::sync(
+        &mut commands,
+        site_representation,
+        site_query,
+        sites
+            .iter()
+            .filter(|s| s.properties.type_ == Type::A)
+            .map(|site| {
+                (
+                    Vec3::new(
+                        site.properties.position[0] as f32,
+                        site.properties.position[1] as f32,
+                        0.0,
+                    ),
+                    1.0_f32,
+                )
+            }),
+    );
+}
+
+/// Copy the current positions of simulation sites to bevy entities.
+fn sync_b_sites(
+    mut commands: Commands,
+    site_representation: Res<disk::Representation<B>>,
+    site_query: Query<(Entity, &mut Transform), With<disk::Disk<B>>>,
+    simulation: Res<TypeDependentInteractions>,
+) {
+    let sites = simulation.microstate.sites();
+    disk::Disk::sync(
+        &mut commands,
+        site_representation,
+        site_query,
+        sites
+            .iter()
+            .filter(|s| s.properties.type_ == Type::B)
+            .map(|site| {
+                (
+                    Vec3::new(
+                        site.properties.position[0] as f32,
+                        site.properties.position[1] as f32,
+                        0.0,
+                    ),
+                    1.0_f32,
+                )
+            }),
+    );
+}
+
+/// Copy the current positions of simulation ghosts to bevy entities.
+fn sync_ghosts(
+    mut commands: Commands,
+    ghost_representation: Res<disk::Representation<Ghost>>,
+    ghost_query: Query<(Entity, &mut Transform), With<disk::Disk<Ghost>>>,
+    simulation: Res<TypeDependentInteractions>,
+) {
+    let ghosts = simulation.microstate.ghosts();
+    disk::Disk::sync(
+        &mut commands,
+        ghost_representation,
+        ghost_query,
+        ghosts.iter().map(|site| {
+            (
+                Vec3::new(
+                    site.properties.position[0] as f32,
+                    site.properties.position[1] as f32,
+                    0.0,
+                ),
+                1.0_f32,
+            )
+        }),
+    );
+}
+
+/// Draw the simulation boundary at its current size.
+fn sync_boundary(
+    entity_rectangle: Single<(Entity, &RectangularBoundary)>,
+    children: Query<&Children>,
+    transforms: Query<&mut Transform>,
+    simulation: Res<TypeDependentInteractions>,
+) {
+    let l =
+        simulation.microstate.boundary().shape().edge_lengths[1].get() as f32;
+    RectangularBoundary::sync(entity_rectangle, children, transforms, l, l);
+}

--- a/hoomd-derive/Cargo.toml
+++ b/hoomd-derive/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "hoomd-derive"
+categories.workspace = true
+description = "Derive macros."
+edition.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "2.0.117"
+quote = "1.0.44"

--- a/hoomd-derive/README.md
+++ b/hoomd-derive/README.md
@@ -1,0 +1,5 @@
+# hoomd-derive
+
+Derive macros for [hoomd-rs].
+
+[hoomd-rs]: https://github.com/glotzerlab/hoomd-rs

--- a/hoomd-derive/src/lib.rs
+++ b/hoomd-derive/src/lib.rs
@@ -1,0 +1,33 @@
+//! TODO
+
+#![allow(clippy::missing_inline_in_public_items, reason = "No need to inline macros")]
+
+use proc_macro::TokenStream;
+use syn::{DeriveInput, parse_macro_input};
+
+mod maximum_interaction_range;
+mod orientation;
+mod position;
+
+/// TODO
+#[proc_macro_derive(MaximumInteractionRange)]
+pub fn maximum_interaction_range_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    maximum_interaction_range::maximum_interaction_range(&input)
+}
+
+/// TODO
+#[proc_macro_derive(Orientation)]
+pub fn orientation_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    orientation::orientation(input)
+}
+
+/// TODO
+#[proc_macro_derive(Position)]
+pub fn position_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    position::position(input)
+}
+
+

--- a/hoomd-derive/src/lib.rs
+++ b/hoomd-derive/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 The Regents of the University of Michigan.
+// Part of hoomd-rs, released under the BSD 3-Clause License.
+
 //! TODO
 
 #![allow(

--- a/hoomd-derive/src/lib.rs
+++ b/hoomd-derive/src/lib.rs
@@ -1,6 +1,9 @@
 //! TODO
 
-#![allow(clippy::missing_inline_in_public_items, reason = "No need to inline macros")]
+#![allow(
+    clippy::missing_inline_in_public_items,
+    reason = "No need to inline macros"
+)]
 
 use proc_macro::TokenStream;
 use syn::{DeriveInput, parse_macro_input};
@@ -29,5 +32,3 @@ pub fn position_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     position::position(input)
 }
-
-

--- a/hoomd-derive/src/maximum_interaction_range.rs
+++ b/hoomd-derive/src/maximum_interaction_range.rs
@@ -13,11 +13,11 @@ pub(crate) fn maximum_interaction_range(input: &DeriveInput) -> TokenStream {
     match input.data {
         Data::Struct(_) => {
             quote! {
-                    impl #impl_generics ::hoomd_interaction::MaximumInteractionRange for #name #ty_generics #where_clause {
-                        fn maximum_interaction_range(&self) -> f64 {
-                            self.maximum_interaction_range
-                        }
+                impl #impl_generics ::hoomd_interaction::MaximumInteractionRange for #name #ty_generics #where_clause {
+                    fn maximum_interaction_range(&self) -> f64 {
+                        self.maximum_interaction_range
                     }
+                }
             }.into()
         },
         Data::Enum(_) | Data::Union(_) => {

--- a/hoomd-derive/src/maximum_interaction_range.rs
+++ b/hoomd-derive/src/maximum_interaction_range.rs
@@ -1,0 +1,30 @@
+//! Implement the derive(Position) macro
+
+use proc_macro::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::{Data, DeriveInput};
+
+/// Implement the derive(MaximumInteractionRange) macro.
+pub(crate) fn maximum_interaction_range(input: &DeriveInput) -> TokenStream {
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let name = &input.ident;
+
+    match input.data {
+        Data::Struct(_) => {
+            quote! {
+                    impl #impl_generics ::hoomd_interaction::MaximumInteractionRange for #name #ty_generics #where_clause {
+                        fn maximum_interaction_range(&self) -> f64 {
+                            self.maximum_interaction_range
+                        }
+                    }
+            }.into()
+        },
+        Data::Enum(_) | Data::Union(_) => {
+            quote_spanned! {
+                name.span() =>
+                compile_error!("derive(Position) applies only to struct types.");
+            }.into()
+        },
+        }
+}

--- a/hoomd-derive/src/maximum_interaction_range.rs
+++ b/hoomd-derive/src/maximum_interaction_range.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 The Regents of the University of Michigan.
+// Part of hoomd-rs, released under the BSD 3-Clause License.
+
 //! Implement the derive(Position) macro
 
 use proc_macro::TokenStream;

--- a/hoomd-derive/src/orientation.rs
+++ b/hoomd-derive/src/orientation.rs
@@ -33,13 +33,13 @@ pub(crate) fn orientation(input: DeriveInput) -> TokenStream {
 
     let generated = quote! {
         impl #impl_generics ::hoomd_microstate::property::Orientation for #name #ty_generics #where_clause {
-            type orientation = #orientation_type;
+            type Rotation = #orientation_type;
 
-            fn orientation(&self) -> &Self::orientation {
+            fn orientation(&self) -> &Self::Rotation {
                 &self.orientation
             }
 
-            fn orientation_mut(&mut self) -> &mut Self::orientation {
+            fn orientation_mut(&mut self) -> &mut Self::Rotation {
                 &mut self.orientation
             }
         }

--- a/hoomd-derive/src/orientation.rs
+++ b/hoomd-derive/src/orientation.rs
@@ -1,0 +1,57 @@
+//! Implement the derive(Orientation) macro
+
+use proc_macro::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::{Data, DeriveInput, Fields, Type};
+
+/// Implement the derive(orientation) macro.
+pub(crate) fn orientation(input: DeriveInput) -> TokenStream {
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let name = &input.ident;
+
+    let orientation_type = match input.data {
+
+        Data::Struct(data) => {
+            if let Ok(type_) = get_orientation_type(&data.fields) {
+                type_
+            } else {
+            return quote_spanned! {
+                name.span() =>
+                compile_error!("derive(Orientation) requires a field named orientation.");
+            }.into()                    
+            }
+        },
+        Data::Enum(_) | Data::Union(_) => {
+            return quote_spanned! {
+                name.span() =>
+                compile_error!("derive(Orientation) applies only to struct types.");
+            }.into()
+        },
+        };
+    
+    let generated = quote! {
+        impl #impl_generics ::hoomd_microstate::property::Orientation for #name #ty_generics #where_clause {
+            type orientation = #orientation_type;
+            
+            fn orientation(&self) -> &Self::orientation {
+                &self.orientation
+            }
+            
+            fn orientation_mut(&mut self) -> &mut Self::orientation {
+                &mut self.orientation
+            }
+        }
+    };
+    generated.into()
+}
+
+/// Get the type of the field named `orientation`.
+fn get_orientation_type(fields: &Fields) -> Result<Type, ()> {
+    for field in fields {
+        if let Some(ref ident) = field.ident && ident == "orientation" {
+            return Ok(field.ty.clone());
+        }
+    }
+    Err(())
+}

--- a/hoomd-derive/src/orientation.rs
+++ b/hoomd-derive/src/orientation.rs
@@ -11,33 +11,34 @@ pub(crate) fn orientation(input: DeriveInput) -> TokenStream {
     let name = &input.ident;
 
     let orientation_type = match input.data {
-
         Data::Struct(data) => {
             if let Ok(type_) = get_orientation_type(&data.fields) {
                 type_
             } else {
-            return quote_spanned! {
-                name.span() =>
-                compile_error!("derive(Orientation) requires a field named orientation.");
-            }.into()                    
+                return quote_spanned! {
+                    name.span() =>
+                    compile_error!("derive(Orientation) requires a field named orientation.");
+                }
+                .into();
             }
-        },
+        }
         Data::Enum(_) | Data::Union(_) => {
             return quote_spanned! {
                 name.span() =>
                 compile_error!("derive(Orientation) applies only to struct types.");
-            }.into()
-        },
-        };
-    
+            }
+            .into();
+        }
+    };
+
     let generated = quote! {
         impl #impl_generics ::hoomd_microstate::property::Orientation for #name #ty_generics #where_clause {
             type orientation = #orientation_type;
-            
+
             fn orientation(&self) -> &Self::orientation {
                 &self.orientation
             }
-            
+
             fn orientation_mut(&mut self) -> &mut Self::orientation {
                 &mut self.orientation
             }
@@ -49,7 +50,9 @@ pub(crate) fn orientation(input: DeriveInput) -> TokenStream {
 /// Get the type of the field named `orientation`.
 fn get_orientation_type(fields: &Fields) -> Result<Type, ()> {
     for field in fields {
-        if let Some(ref ident) = field.ident && ident == "orientation" {
+        if let Some(ref ident) = field.ident
+            && ident == "orientation"
+        {
             return Ok(field.ty.clone());
         }
     }

--- a/hoomd-derive/src/orientation.rs
+++ b/hoomd-derive/src/orientation.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 The Regents of the University of Michigan.
+// Part of hoomd-rs, released under the BSD 3-Clause License.
+
 //! Implement the derive(Orientation) macro
 
 use proc_macro::TokenStream;

--- a/hoomd-derive/src/position.rs
+++ b/hoomd-derive/src/position.rs
@@ -11,33 +11,34 @@ pub(crate) fn position(input: DeriveInput) -> TokenStream {
     let name = &input.ident;
 
     let position_type = match input.data {
-
         Data::Struct(data) => {
             if let Ok(type_) = get_position_type(&data.fields) {
                 type_
             } else {
-            return quote_spanned! {
-                name.span() =>
-                compile_error!("derive(Position) requires a field named position.");
-            }.into()                    
+                return quote_spanned! {
+                    name.span() =>
+                    compile_error!("derive(Position) requires a field named position.");
+                }
+                .into();
             }
-        },
+        }
         Data::Enum(_) | Data::Union(_) => {
             return quote_spanned! {
                 name.span() =>
                 compile_error!("derive(Position) applies only to struct types.");
-            }.into()
-        },
-        };
-    
+            }
+            .into();
+        }
+    };
+
     let generated = quote! {
         impl #impl_generics ::hoomd_microstate::property::Position for #name #ty_generics #where_clause {
             type Position = #position_type;
-            
+
             fn position(&self) -> &Self::Position {
                 &self.position
             }
-            
+
             fn position_mut(&mut self) -> &mut Self::Position {
                 &mut self.position
             }
@@ -49,7 +50,9 @@ pub(crate) fn position(input: DeriveInput) -> TokenStream {
 /// Get the type of the field named `position`.
 fn get_position_type(fields: &Fields) -> Result<Type, ()> {
     for field in fields {
-        if let Some(ref ident) = field.ident && ident == "position" {
+        if let Some(ref ident) = field.ident
+            && ident == "position"
+        {
             return Ok(field.ty.clone());
         }
     }

--- a/hoomd-derive/src/position.rs
+++ b/hoomd-derive/src/position.rs
@@ -1,0 +1,57 @@
+//! Implement the derive(Position) macro
+
+use proc_macro::TokenStream;
+use quote::{quote, quote_spanned};
+use syn::{Data, DeriveInput, Fields, Type};
+
+/// Implement the derive(Position) macro.
+pub(crate) fn position(input: DeriveInput) -> TokenStream {
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let name = &input.ident;
+
+    let position_type = match input.data {
+
+        Data::Struct(data) => {
+            if let Ok(type_) = get_position_type(&data.fields) {
+                type_
+            } else {
+            return quote_spanned! {
+                name.span() =>
+                compile_error!("derive(Position) requires a field named position.");
+            }.into()                    
+            }
+        },
+        Data::Enum(_) | Data::Union(_) => {
+            return quote_spanned! {
+                name.span() =>
+                compile_error!("derive(Position) applies only to struct types.");
+            }.into()
+        },
+        };
+    
+    let generated = quote! {
+        impl #impl_generics ::hoomd_microstate::property::Position for #name #ty_generics #where_clause {
+            type Position = #position_type;
+            
+            fn position(&self) -> &Self::Position {
+                &self.position
+            }
+            
+            fn position_mut(&mut self) -> &mut Self::Position {
+                &mut self.position
+            }
+        }
+    };
+    generated.into()
+}
+
+/// Get the type of the field named `position`.
+fn get_position_type(fields: &Fields) -> Result<Type, ()> {
+    for field in fields {
+        if let Some(ref ident) = field.ident && ident == "position" {
+            return Ok(field.ty.clone());
+        }
+    }
+    Err(())
+}

--- a/hoomd-derive/src/position.rs
+++ b/hoomd-derive/src/position.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 The Regents of the University of Michigan.
+// Part of hoomd-rs, released under the BSD 3-Clause License.
+
 //! Implement the derive(Position) macro
 
 use proc_macro::TokenStream;

--- a/hoomd-interaction/Cargo.toml
+++ b/hoomd-interaction/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 [dependencies]
 serde.workspace = true
 
+hoomd-derive.workspace = true
 hoomd-microstate.workspace = true
 hoomd-vector.workspace = true
 hoomd-geometry.workspace = true

--- a/hoomd-interaction/src/lib.rs
+++ b/hoomd-interaction/src/lib.rs
@@ -24,9 +24,9 @@ mod pairwise_cutoff;
 mod zero;
 
 pub use external_type::External;
+pub use hoomd_derive::MaximumInteractionRange;
 pub use pairwise_cutoff::PairwiseCutoff;
 pub use zero::Zero;
-pub use hoomd_derive::MaximumInteractionRange;
 
 /// Compute the total energy of a potential applied to the microstate.
 ///
@@ -283,7 +283,10 @@ pub trait SiteEnergy<S> {
 ///     Body::point(Cartesian::from([0.0, 1.0])),
 /// ])?;
 ///
-/// let custom = Custom { epsilon: 1.0, maximum_interaction_range: 2.5 };
+/// let custom = Custom {
+///     epsilon: 1.0,
+///     maximum_interaction_range: 2.5,
+/// };
 /// let site_pair_energy = custom.site_pair_energy(
 ///     &microstate.sites()[0].properties,
 ///     &microstate.sites()[1].properties,

--- a/hoomd-interaction/src/lib.rs
+++ b/hoomd-interaction/src/lib.rs
@@ -26,6 +26,7 @@ mod zero;
 pub use external_type::External;
 pub use pairwise_cutoff::PairwiseCutoff;
 pub use zero::Zero;
+pub use hoomd_derive::MaximumInteractionRange;
 
 /// Compute the total energy of a potential applied to the microstate.
 ///
@@ -253,8 +254,10 @@ pub trait SiteEnergy<S> {
 /// };
 /// use hoomd_vector::{Cartesian, InnerProduct};
 ///
+/// #[derive(MaximumInteractionRange)]
 /// struct Custom {
 ///     epsilon: f64,
+///     maximum_interaction_range: f64,
 /// }
 ///
 /// impl<S> SitePairEnergy<S> for Custom
@@ -273,12 +276,6 @@ pub trait SiteEnergy<S> {
 ///     }
 /// }
 ///
-/// impl MaximumInteractionRange for Custom {
-///     fn maximum_interaction_range(&self) -> f64 {
-///         2.5
-///     }
-/// }
-///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut microstate = Microstate::new();
 /// microstate.extend_bodies([
@@ -286,7 +283,7 @@ pub trait SiteEnergy<S> {
 ///     Body::point(Cartesian::from([0.0, 1.0])),
 /// ])?;
 ///
-/// let custom = Custom { epsilon: 1.0 };
+/// let custom = Custom { epsilon: 1.0, maximum_interaction_range: 2.5 };
 /// let site_pair_energy = custom.site_pair_energy(
 ///     &microstate.sites()[0].properties,
 ///     &microstate.sites()[1].properties,
@@ -311,22 +308,10 @@ pub trait SiteEnergy<S> {
 /// use hoomd_utility::valid::PositiveReal;
 /// use hoomd_vector::{self, Angle, Cartesian};
 ///
-/// #[derive(Default)]
+/// #[derive(Default, Position)]
 /// struct CircleSiteProperties {
 ///     position: Cartesian<2>,
 ///     radius: PositiveReal,
-/// }
-///
-/// impl Position for CircleSiteProperties {
-///     type Position = Cartesian<2>;
-///
-///     fn position(&self) -> &Cartesian<2> {
-///         &self.position
-///     }
-///
-///     fn position_mut(&mut self) -> &mut Cartesian<2> {
-///         &mut self.position
-///     }
 /// }
 ///
 /// impl Transform<CircleSiteProperties> for Point<Cartesian<2>> {

--- a/hoomd-microstate/Cargo.toml
+++ b/hoomd-microstate/Cargo.toml
@@ -19,6 +19,7 @@ rand.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 
+hoomd-derive.workspace = true
 hoomd-geometry.workspace = true
 hoomd-manifold.workspace = true
 hoomd-spatial.workspace = true

--- a/hoomd-microstate/src/property.rs
+++ b/hoomd-microstate/src/property.rs
@@ -45,34 +45,11 @@
 //! use hoomd_microstate::property::{Orientation, Position};
 //! use hoomd_vector::{Cartesian, Versor};
 //!
+//! #[derive(Position, Orientation)]
 //! struct Custom {
 //!     position: Cartesian<3>,
 //!     orientation: Versor,
 //!     custom: f64,
-//! }
-//!
-//! impl Orientation for Custom {
-//!     type Rotation = Versor;
-//!
-//!     fn orientation(&self) -> &Versor {
-//!         &self.orientation
-//!     }
-//!
-//!     fn orientation_mut(&mut self) -> &mut Versor {
-//!         &mut self.orientation
-//!     }
-//! }
-//!
-//! impl Position for Custom {
-//!     type Position = Cartesian<3>;
-//!
-//!     fn position(&self) -> &Cartesian<3> {
-//!         &self.position
-//!     }
-//!
-//!     fn position_mut(&mut self) -> &mut Cartesian<3> {
-//!         &mut self.position
-//!     }
 //! }
 //! ```
 //!
@@ -90,6 +67,7 @@
 //! };
 //! use hoomd_vector::{Cartesian, Rotate, Rotation, Versor};
 //!
+//! #[derive(Position, Orientation)]
 //! struct Custom {
 //!     position: Cartesian<3>,
 //!     orientation: Versor,
@@ -115,6 +93,8 @@ pub use point::Point;
 
 mod oriented_point;
 pub use oriented_point::OrientedPoint;
+
+pub use hoomd_derive::{Position, Orientation};
 
 /// Locate sites and bodies.
 ///

--- a/hoomd-microstate/src/property.rs
+++ b/hoomd-microstate/src/property.rs
@@ -94,7 +94,7 @@ pub use point::Point;
 mod oriented_point;
 pub use oriented_point::OrientedPoint;
 
-pub use hoomd_derive::{Position, Orientation};
+pub use hoomd_derive::{Orientation, Position};
 
 /// Locate sites and bodies.
 ///

--- a/hoomd-microstate/src/property.rs
+++ b/hoomd-microstate/src/property.rs
@@ -55,11 +55,64 @@
 //!
 //! ## Transformations
 //!
-//!
 //! Implement `Transform` to take sites from the body frame to the system frame.
 //! Typically, this involves transforming position and orientation while leaving
-//! all other fields unchanged:
+//! all other fields unchanged. The three most common implementations of `Transform`
+//! follow. All these examples are in 3D. To convert to 2D, replace `Cartesian<3>`
+//! with `Cartesian<2>` and `Versor` with `Angle`.
 //!
+//! Non-oriented bodies and sites (i.e. point particles or non-rotating rigid bodies):
+//! ```
+//! use hoomd_microstate::{
+//!     Transform,
+//!     property::{Point, Position},
+//! };
+//! use hoomd_vector::Cartesian;
+//!
+//! #[derive(Position)]
+//! struct Custom {
+//!     position: Cartesian<3>,
+//!     custom: f64,
+//! }
+//!
+//! impl Transform<Custom> for Point<Cartesian<3>> {
+//!     fn transform(&self, site_properties: &Custom) -> Custom {
+//!         Custom {
+//!             position: self.position + site_properties.position,
+//!             ..*site_properties
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! Oriented bodies and non-oriented sites (i.e. rotating rigid bodies with
+//! isotropic site-site interactions):
+//! ```
+//! use hoomd_microstate::{
+//!     Transform,
+//!     property::{OrientedPoint, Position},
+//! };
+//! use hoomd_vector::{Cartesian, Rotate, Rotation, Versor};
+//!
+//! #[derive(Position)]
+//! struct Custom {
+//!     position: Cartesian<3>,
+//!     custom: f64,
+//! }
+//!
+//! impl Transform<Custom> for OrientedPoint<Cartesian<3>, Versor> {
+//!     fn transform(&self, site_properties: &Custom) -> Custom {
+//!         Custom {
+//!             position: self.position
+//!                 + self.orientation.rotate(&site_properties.position),
+//!             ..*site_properties
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! Oriented bodies and oriented sites (i.e. rotating rigid bodies with
+//! anisotropic site-site interactions):
 //! ```
 //! use hoomd_microstate::{
 //!     Transform,


### PR DESCRIPTION
Demonstrate the use of site types in a tutorial. Also implement `derive` macros for traits commonly used with custom site properties.

closes #12.