### PR TITLE
Benchmark tweaks

### DIFF
--- a/.codebook.toml
+++ b/.codebook.toml
@@ -6,6 +6,7 @@ words = [
     "biquaternions",
     "cdots",
     "circumsphere",
+    "coxeter",
     "dyn",
     "egui",
     "frenkel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,11 +184,6 @@ default.extend-words = { ratatui = "ratatui" }
 # https://docs.rs/about/metadata
 rustdoc-args = [ "--html-in-header", "katex.html" ]
 
-# TODO: Test compiler flags on Linux
-# [profile.release]
-# lto = true
-# codegen-units = 1
-
 # Optimize for size in wasm builds
 [profile.release-wasm]
 opt-level = 'z'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,11 @@ default.extend-words = { ratatui = "ratatui" }
 # https://docs.rs/about/metadata
 rustdoc-args = [ "--html-in-header", "katex.html" ]
 
+# TODO: Test compiler flags on Linux
+# [profile.release]
+# lto = true
+# codegen-units = 1
+
 # Optimize for size in wasm builds
 [profile.release-wasm]
 opt-level = 'z'

--- a/benchmarks/src/mc/ellipsoid.rs
+++ b/benchmarks/src/mc/ellipsoid.rs
@@ -30,7 +30,7 @@ use hoomd_microstate::{
     property::OrientedPoint,
 };
 use hoomd_simulation::{Simulation, macrostate::Isothermal};
-use hoomd_spatial::{PointUpdate, PointsNearBall, WithSearchRadius};
+use hoomd_spatial::{IndexFromPosition, PointUpdate, PointsNearBall, WithSearchRadius};
 use hoomd_vector::{Cartesian, Versor};
 
 use crate::{Effort, place::place_single_site_orientable_bodies};
@@ -99,11 +99,16 @@ impl<X> Effort for EllipsoidSim<X> {
 
 impl<X> Simulation for EllipsoidSim<X>
 where
-    X: PointsNearBall<Cartesian<3>, SiteKey> + PointUpdate<Cartesian<3>, SiteKey> + Sync,
+    X: PointsNearBall<Cartesian<3>, SiteKey> + PointUpdate<Cartesian<3>, SiteKey> + Sync +
+    IndexFromPosition<Cartesian<3>>,
     Periodic<Hypercuboid<3>>: GenerateGhosts<OrientedPoint<Cartesian<3>, Versor>>,
 {
     #[inline]
     fn advance(&mut self) -> anyhow::Result<()> {
+        if self.microstate.step().is_multiple_of(300) {
+            self.microstate.sort();
+        }
+
         if self.parallel {
             self.translate_count += self.parallel_translate_sweep.apply(
                 &mut self.microstate,
@@ -167,7 +172,8 @@ where
         + WithSearchRadius
         + Clone
         + for<'a> Deserialize<'a>
-        + Serialize + Sync,
+        + Serialize + Sync
+        + IndexFromPosition<Cartesian<3>>,
     Periodic<Hypercuboid<3>>: GenerateGhosts<OrientedPoint<Cartesian<3>, Versor>>,
 {
     /// Construct a new hard octahedra simulation
@@ -191,6 +197,7 @@ where
                     .with_context(|| format!("Could not read {cache_filename}"))?;
                 // The cache may have been generated with a different value of parallel.
                 result.parallel = parallel;
+                result.microstate.sort();
                 return Ok(result);
             }
             Err(error) => match error.kind() {
@@ -223,12 +230,13 @@ where
         };
         let overlap_penalty_hamiltonian = PairwiseCutoff(approximate_shape_overlap);
 
-        let microstate = place_single_site_orientable_bodies(
+        let mut microstate = place_single_site_orientable_bodies(
             n,
             number_density,
             hamiltonian.maximum_interaction_range(),
             &overlap_penalty_hamiltonian,
         )?;
+        microstate.sort();
 
         translate_sweep.tune_default(&microstate, &hamiltonian, &Isothermal { temperature: 1.0 });
         *parallel_translate_sweep

--- a/benchmarks/src/mc/ellipsoid.rs
+++ b/benchmarks/src/mc/ellipsoid.rs
@@ -108,7 +108,7 @@ where
     #[inline]
     fn advance(&mut self) -> anyhow::Result<()> {
         if self.microstate.step().is_multiple_of(300) {
-            self.microstate.sort();
+            self.microstate.sort_sites();
         }
 
         if self.parallel {
@@ -200,7 +200,7 @@ where
                     .with_context(|| format!("Could not read {cache_filename}"))?;
                 // The cache may have been generated with a different value of parallel.
                 result.parallel = parallel;
-                result.microstate.sort();
+                result.microstate.sort_sites();
                 return Ok(result);
             }
             Err(error) => match error.kind() {
@@ -239,7 +239,7 @@ where
             hamiltonian.maximum_interaction_range(),
             &overlap_penalty_hamiltonian,
         )?;
-        microstate.sort();
+        microstate.sort_sites();
 
         translate_sweep.tune_default(&microstate, &hamiltonian, &Isothermal { temperature: 1.0 });
         *parallel_translate_sweep

--- a/benchmarks/src/mc/ellipsoid.rs
+++ b/benchmarks/src/mc/ellipsoid.rs
@@ -167,7 +167,7 @@ where
         + WithSearchRadius
         + Clone
         + for<'a> Deserialize<'a>
-        + Serialize,
+        + Serialize + Sync,
     Periodic<Hypercuboid<3>>: GenerateGhosts<OrientedPoint<Cartesian<3>, Versor>>,
 {
     /// Construct a new hard octahedra simulation

--- a/benchmarks/src/mc/ellipsoid.rs
+++ b/benchmarks/src/mc/ellipsoid.rs
@@ -99,8 +99,10 @@ impl<X> Effort for EllipsoidSim<X> {
 
 impl<X> Simulation for EllipsoidSim<X>
 where
-    X: PointsNearBall<Cartesian<3>, SiteKey> + PointUpdate<Cartesian<3>, SiteKey> + Sync +
-    IndexFromPosition<Cartesian<3>>,
+    X: PointsNearBall<Cartesian<3>, SiteKey>
+        + PointUpdate<Cartesian<3>, SiteKey>
+        + Sync
+        + IndexFromPosition<Cartesian<3>>,
     Periodic<Hypercuboid<3>>: GenerateGhosts<OrientedPoint<Cartesian<3>, Versor>>,
 {
     #[inline]
@@ -172,7 +174,8 @@ where
         + WithSearchRadius
         + Clone
         + for<'a> Deserialize<'a>
-        + Serialize + Sync
+        + Serialize
+        + Sync
         + IndexFromPosition<Cartesian<3>>,
     Periodic<Hypercuboid<3>>: GenerateGhosts<OrientedPoint<Cartesian<3>, Versor>>,
 {

--- a/benchmarks/src/mc/hard_sphere.rs
+++ b/benchmarks/src/mc/hard_sphere.rs
@@ -26,7 +26,7 @@ use hoomd_microstate::{
     property::Point,
 };
 use hoomd_simulation::{Simulation, macrostate::Isothermal};
-use hoomd_spatial::{PointUpdate, PointsNearBall, WithSearchRadius};
+use hoomd_spatial::{IndexFromPosition, PointUpdate, PointsNearBall, WithSearchRadius};
 use hoomd_vector::Cartesian;
 use log::debug;
 use serde::{Deserialize, Serialize};
@@ -77,11 +77,16 @@ impl<const D: usize, X> Effort for HardSphereSim<D, X> {
 
 impl<const D: usize, X> Simulation for HardSphereSim<D, X>
 where
-    X: PointsNearBall<Cartesian<D>, SiteKey> + PointUpdate<Cartesian<D>, SiteKey> + Sync,
+    X: PointsNearBall<Cartesian<D>, SiteKey> + PointUpdate<Cartesian<D>, SiteKey> + Sync+
+    IndexFromPosition<Cartesian<D>>,
     Periodic<Hypercuboid<D>>: GenerateGhosts<Point<Cartesian<D>>>,
 {
     #[inline]
     fn advance(&mut self) -> anyhow::Result<()> {
+        if self.microstate.step().is_multiple_of(300) {
+            self.microstate.sort();
+        }
+
         if self.parallel {
             self.count += self.parallel_translate_sweep.apply(
                 &mut self.microstate,
@@ -130,7 +135,8 @@ where
         + WithSearchRadius
         + Clone
         + for<'a> Deserialize<'a>
-        + Serialize,
+        + Serialize + Sync
+        + IndexFromPosition<Cartesian<D>>,
     Periodic<Hypercuboid<D>>: GenerateGhosts<Point<Cartesian<D>>>,
 {
     /// Construct a new hard sphere simulation
@@ -153,6 +159,7 @@ where
                     .with_context(|| format!("Could not read {cache_filename}"))?;
                 // The cache may have been generated with a different value of parallel.
                 result.parallel = parallel;
+                result.microstate.sort();
                 return Ok(result);
             }
             Err(error) => match error.kind() {
@@ -180,12 +187,13 @@ where
 
         let overlap_penalty_hamiltonian = PairwiseCutoff(overlap_penalty);
 
-        let microstate = place_single_site_point_bodies(
+        let mut microstate = place_single_site_point_bodies(
             n,
             number_density,
             hamiltonian.0.maximum_interaction_range(),
             &overlap_penalty_hamiltonian,
         )?;
+        microstate.sort();
 
         translate_sweep.tune_default(&microstate, &hamiltonian, &Isothermal { temperature: 1.0 });
         *parallel_translate_sweep

--- a/benchmarks/src/mc/hard_sphere.rs
+++ b/benchmarks/src/mc/hard_sphere.rs
@@ -77,8 +77,10 @@ impl<const D: usize, X> Effort for HardSphereSim<D, X> {
 
 impl<const D: usize, X> Simulation for HardSphereSim<D, X>
 where
-    X: PointsNearBall<Cartesian<D>, SiteKey> + PointUpdate<Cartesian<D>, SiteKey> + Sync+
-    IndexFromPosition<Cartesian<D>>,
+    X: PointsNearBall<Cartesian<D>, SiteKey>
+        + PointUpdate<Cartesian<D>, SiteKey>
+        + Sync
+        + IndexFromPosition<Cartesian<D>>,
     Periodic<Hypercuboid<D>>: GenerateGhosts<Point<Cartesian<D>>>,
 {
     #[inline]
@@ -135,7 +137,8 @@ where
         + WithSearchRadius
         + Clone
         + for<'a> Deserialize<'a>
-        + Serialize + Sync
+        + Serialize
+        + Sync
         + IndexFromPosition<Cartesian<D>>,
     Periodic<Hypercuboid<D>>: GenerateGhosts<Point<Cartesian<D>>>,
 {

--- a/benchmarks/src/mc/hard_sphere.rs
+++ b/benchmarks/src/mc/hard_sphere.rs
@@ -86,7 +86,7 @@ where
     #[inline]
     fn advance(&mut self) -> anyhow::Result<()> {
         if self.microstate.step().is_multiple_of(300) {
-            self.microstate.sort();
+            self.microstate.sort_sites();
         }
 
         if self.parallel {
@@ -162,7 +162,7 @@ where
                     .with_context(|| format!("Could not read {cache_filename}"))?;
                 // The cache may have been generated with a different value of parallel.
                 result.parallel = parallel;
-                result.microstate.sort();
+                result.microstate.sort_sites();
                 return Ok(result);
             }
             Err(error) => match error.kind() {
@@ -196,7 +196,7 @@ where
             hamiltonian.0.maximum_interaction_range(),
             &overlap_penalty_hamiltonian,
         )?;
-        microstate.sort();
+        microstate.sort_sites();
 
         translate_sweep.tune_default(&microstate, &hamiltonian, &Isothermal { temperature: 1.0 });
         *parallel_translate_sweep

--- a/benchmarks/src/mc/lennard_jones.rs
+++ b/benchmarks/src/mc/lennard_jones.rs
@@ -86,7 +86,7 @@ where
     #[inline]
     fn advance(&mut self) -> anyhow::Result<()> {
         if self.microstate.step().is_multiple_of(300) {
-            self.microstate.sort();
+            self.microstate.sort_sites();
         }
 
         if self.parallel {
@@ -165,7 +165,7 @@ where
                     .with_context(|| format!("Could not read {cache_filename}"))?;
                 // The cache may have been generated with a different value of parallel.
                 result.parallel = parallel;
-                result.microstate.sort();
+                result.microstate.sort_sites();
                 return Ok(result);
             }
             Err(error) => match error.kind() {
@@ -205,7 +205,7 @@ where
             hamiltonian.maximum_interaction_range(),
             &insert_hamiltonian,
         )?;
-        microstate.sort();
+        microstate.sort_sites();
 
         translate_sweep.tune_default(&microstate, &hamiltonian, &macrostate);
         *parallel_translate_sweep

--- a/benchmarks/src/mc/lennard_jones.rs
+++ b/benchmarks/src/mc/lennard_jones.rs
@@ -26,7 +26,7 @@ use hoomd_microstate::{
     property::Point,
 };
 use hoomd_simulation::{Simulation, macrostate::Isothermal};
-use hoomd_spatial::{PointUpdate, PointsNearBall, WithSearchRadius};
+use hoomd_spatial::{IndexFromPosition, PointUpdate, PointsNearBall, WithSearchRadius};
 use hoomd_vector::Cartesian;
 use log::debug;
 use serde::{Deserialize, Serialize};
@@ -77,11 +77,16 @@ impl<const D: usize, X> Effort for LennardJones<D, X> {
 
 impl<const D: usize, X> Simulation for LennardJones<D, X>
 where
-    X: PointsNearBall<Cartesian<D>, SiteKey> + PointUpdate<Cartesian<D>, SiteKey> + Sync,
+    X: PointsNearBall<Cartesian<D>, SiteKey> + PointUpdate<Cartesian<D>, SiteKey> + Sync+
+    IndexFromPosition<Cartesian<D>>,
     Periodic<Hypercuboid<D>>: GenerateGhosts<Point<Cartesian<D>>>,
 {
     #[inline]
     fn advance(&mut self) -> anyhow::Result<()> {
+        if self.microstate.step().is_multiple_of(300) {
+            self.microstate.sort();
+        }
+
         if self.parallel {
             self.count += self.parallel_translate_sweep.apply(
                 &mut self.microstate,
@@ -131,7 +136,8 @@ where
         + WithSearchRadius
         + Clone
         + for<'a> Deserialize<'a>
-        + Serialize,
+        + Serialize + Sync
+        + IndexFromPosition<Cartesian<D>>,
     Periodic<Hypercuboid<D>>: GenerateGhosts<Point<Cartesian<D>>>,
 {
     /// Construct a new Lennard Jones simulation
@@ -156,6 +162,7 @@ where
                     .with_context(|| format!("Could not read {cache_filename}"))?;
                 // The cache may have been generated with a different value of parallel.
                 result.parallel = parallel;
+                result.microstate.sort();
                 return Ok(result);
             }
             Err(error) => match error.kind() {
@@ -189,12 +196,13 @@ where
 
         let insert_hamiltonian = PairwiseCutoff(overlap_penalty);
 
-        let microstate = place_single_site_point_bodies(
+        let mut microstate = place_single_site_point_bodies(
             n,
             number_density,
             hamiltonian.maximum_interaction_range(),
             &insert_hamiltonian,
         )?;
+        microstate.sort();
 
         translate_sweep.tune_default(&microstate, &hamiltonian, &macrostate);
         *parallel_translate_sweep

--- a/benchmarks/src/mc/lennard_jones.rs
+++ b/benchmarks/src/mc/lennard_jones.rs
@@ -77,8 +77,10 @@ impl<const D: usize, X> Effort for LennardJones<D, X> {
 
 impl<const D: usize, X> Simulation for LennardJones<D, X>
 where
-    X: PointsNearBall<Cartesian<D>, SiteKey> + PointUpdate<Cartesian<D>, SiteKey> + Sync+
-    IndexFromPosition<Cartesian<D>>,
+    X: PointsNearBall<Cartesian<D>, SiteKey>
+        + PointUpdate<Cartesian<D>, SiteKey>
+        + Sync
+        + IndexFromPosition<Cartesian<D>>,
     Periodic<Hypercuboid<D>>: GenerateGhosts<Point<Cartesian<D>>>,
 {
     #[inline]
@@ -136,7 +138,8 @@ where
         + WithSearchRadius
         + Clone
         + for<'a> Deserialize<'a>
-        + Serialize + Sync
+        + Serialize
+        + Sync
         + IndexFromPosition<Cartesian<D>>,
     Periodic<Hypercuboid<D>>: GenerateGhosts<Point<Cartesian<D>>>,
 {

--- a/benchmarks/src/mc/octahedron.rs
+++ b/benchmarks/src/mc/octahedron.rs
@@ -104,9 +104,9 @@ where
 {
     #[inline]
     fn advance(&mut self) -> anyhow::Result<()> {
-        // if self.microstate.step().is_multiple_of(300) {
-        //     self.microstate.sort();
-        // }
+        if self.microstate.step().is_multiple_of(300) {
+            self.microstate.sort();
+        }
 
         if self.parallel {
             self.translate_count += self.parallel_translate_sweep.apply(
@@ -196,6 +196,7 @@ where
                     .with_context(|| format!("Could not read {cache_filename}"))?;
                 // The cache may have been generated with a different value of parallel.
                 result.parallel = parallel;
+                result.microstate.sort();
                 return Ok(result);
             }
             Err(error) => match error.kind() {
@@ -236,12 +237,13 @@ where
         };
         let overlap_penalty_hamiltonian = PairwiseCutoff(approximate_shape_overlap);
 
-        let microstate = place_single_site_orientable_bodies(
+        let mut microstate = place_single_site_orientable_bodies(
             n,
             number_density,
             hamiltonian.maximum_interaction_range(),
             &overlap_penalty_hamiltonian,
         )?;
+        microstate.sort();
 
         translate_sweep.tune_default(&microstate, &hamiltonian, &Isothermal { temperature: 1.0 });
         *parallel_translate_sweep

--- a/benchmarks/src/mc/octahedron.rs
+++ b/benchmarks/src/mc/octahedron.rs
@@ -108,7 +108,7 @@ where
     #[inline]
     fn advance(&mut self) -> anyhow::Result<()> {
         if self.microstate.step().is_multiple_of(300) {
-            self.microstate.sort();
+            self.microstate.sort_sites();
         }
 
         if self.parallel {
@@ -200,7 +200,7 @@ where
                     .with_context(|| format!("Could not read {cache_filename}"))?;
                 // The cache may have been generated with a different value of parallel.
                 result.parallel = parallel;
-                result.microstate.sort();
+                result.microstate.sort_sites();
                 return Ok(result);
             }
             Err(error) => match error.kind() {
@@ -247,7 +247,7 @@ where
             hamiltonian.maximum_interaction_range(),
             &overlap_penalty_hamiltonian,
         )?;
-        microstate.sort();
+        microstate.sort_sites();
 
         translate_sweep.tune_default(&microstate, &hamiltonian, &Isothermal { temperature: 1.0 });
         *parallel_translate_sweep

--- a/benchmarks/src/mc/octahedron.rs
+++ b/benchmarks/src/mc/octahedron.rs
@@ -99,7 +99,10 @@ impl<X> Effort for Octahedron<X> {
 
 impl<X> Simulation for Octahedron<X>
 where
-    X: PointsNearBall<Cartesian<3>, SiteKey> + PointUpdate<Cartesian<3>, SiteKey> + Sync + IndexFromPosition<Cartesian<3>>,
+    X: PointsNearBall<Cartesian<3>, SiteKey>
+        + PointUpdate<Cartesian<3>, SiteKey>
+        + Sync
+        + IndexFromPosition<Cartesian<3>>,
     Periodic<Hypercuboid<3>>: GenerateGhosts<OrientedPoint<Cartesian<3>, Versor>>,
 {
     #[inline]
@@ -171,7 +174,8 @@ where
         + WithSearchRadius
         + Clone
         + for<'a> Deserialize<'a>
-        + Serialize + Sync
+        + Serialize
+        + Sync
         + IndexFromPosition<Cartesian<3>>,
     Periodic<Hypercuboid<3>>: GenerateGhosts<OrientedPoint<Cartesian<3>, Versor>>,
 {

--- a/benchmarks/src/mc/octahedron.rs
+++ b/benchmarks/src/mc/octahedron.rs
@@ -167,7 +167,7 @@ where
         + WithSearchRadius
         + Clone
         + for<'a> Deserialize<'a>
-        + Serialize,
+        + Serialize + Sync,
     Periodic<Hypercuboid<3>>: GenerateGhosts<OrientedPoint<Cartesian<3>, Versor>>,
 {
     /// Construct a new hard octahedra simulation

--- a/benchmarks/src/mc/octahedron.rs
+++ b/benchmarks/src/mc/octahedron.rs
@@ -30,7 +30,7 @@ use hoomd_microstate::{
     property::OrientedPoint,
 };
 use hoomd_simulation::{Simulation, macrostate::Isothermal};
-use hoomd_spatial::{PointUpdate, PointsNearBall, WithSearchRadius};
+use hoomd_spatial::{IndexFromPosition, PointUpdate, PointsNearBall, WithSearchRadius};
 use hoomd_vector::{Cartesian, Versor};
 
 use crate::{Effort, place::place_single_site_orientable_bodies};
@@ -99,11 +99,15 @@ impl<X> Effort for Octahedron<X> {
 
 impl<X> Simulation for Octahedron<X>
 where
-    X: PointsNearBall<Cartesian<3>, SiteKey> + PointUpdate<Cartesian<3>, SiteKey> + Sync,
+    X: PointsNearBall<Cartesian<3>, SiteKey> + PointUpdate<Cartesian<3>, SiteKey> + Sync + IndexFromPosition<Cartesian<3>>,
     Periodic<Hypercuboid<3>>: GenerateGhosts<OrientedPoint<Cartesian<3>, Versor>>,
 {
     #[inline]
     fn advance(&mut self) -> anyhow::Result<()> {
+        // if self.microstate.step().is_multiple_of(300) {
+        //     self.microstate.sort();
+        // }
+
         if self.parallel {
             self.translate_count += self.parallel_translate_sweep.apply(
                 &mut self.microstate,
@@ -167,7 +171,8 @@ where
         + WithSearchRadius
         + Clone
         + for<'a> Deserialize<'a>
-        + Serialize + Sync,
+        + Serialize + Sync
+        + IndexFromPosition<Cartesian<3>>,
     Periodic<Hypercuboid<3>>: GenerateGhosts<OrientedPoint<Cartesian<3>, Versor>>,
 {
     /// Construct a new hard octahedra simulation

--- a/benchmarks/src/mc/regular_polygon.rs
+++ b/benchmarks/src/mc/regular_polygon.rs
@@ -108,7 +108,7 @@ where
     #[inline]
     fn advance(&mut self) -> anyhow::Result<()> {
         if self.microstate.step().is_multiple_of(300) {
-            self.microstate.sort();
+            self.microstate.sort_sites();
         }
 
         if self.parallel {
@@ -201,7 +201,7 @@ where
                     .with_context(|| format!("Could not read {cache_filename}"))?;
                 // The cache may have been generated with a different value of parallel.
                 result.parallel = parallel;
-                result.microstate.sort();
+                result.microstate.sort_sites();
                 return Ok(result);
             }
             Err(error) => match error.kind() {
@@ -241,7 +241,7 @@ where
             hamiltonian.maximum_interaction_range(),
             &overlap_penalty_hamiltonian,
         )?;
-        microstate.sort();
+        microstate.sort_sites();
 
         translate_sweep.tune_default(&microstate, &hamiltonian, &Isothermal { temperature: 1.0 });
         *parallel_translate_sweep

--- a/benchmarks/src/mc/regular_polygon.rs
+++ b/benchmarks/src/mc/regular_polygon.rs
@@ -99,9 +99,11 @@ impl<X> Effort for RegularPolygon<X> {
 
 impl<X> Simulation for RegularPolygon<X>
 where
-    X: PointsNearBall<Cartesian<2>, SiteKey> + PointUpdate<Cartesian<2>, SiteKey> + Sync +
-    IndexFromPosition<Cartesian<2>>,
-    Periodic<Hypercuboid<2>>: GenerateGhosts<OrientedPoint<Cartesian<2>, Angle>>
+    X: PointsNearBall<Cartesian<2>, SiteKey>
+        + PointUpdate<Cartesian<2>, SiteKey>
+        + Sync
+        + IndexFromPosition<Cartesian<2>>,
+    Periodic<Hypercuboid<2>>: GenerateGhosts<OrientedPoint<Cartesian<2>, Angle>>,
 {
     #[inline]
     fn advance(&mut self) -> anyhow::Result<()> {
@@ -173,7 +175,8 @@ where
         + WithSearchRadius
         + Clone
         + for<'a> Deserialize<'a>
-        + Serialize + Sync
+        + Serialize
+        + Sync
         + IndexFromPosition<Cartesian<2>>,
     Periodic<Hypercuboid<2>>: GenerateGhosts<OrientedPoint<Cartesian<2>, Angle>>,
 {

--- a/benchmarks/src/mc/regular_polygon.rs
+++ b/benchmarks/src/mc/regular_polygon.rs
@@ -28,7 +28,7 @@ use hoomd_microstate::{
     property::OrientedPoint,
 };
 use hoomd_simulation::{Simulation, macrostate::Isothermal};
-use hoomd_spatial::{PointUpdate, PointsNearBall, WithSearchRadius};
+use hoomd_spatial::{IndexFromPosition, PointUpdate, PointsNearBall, WithSearchRadius};
 use hoomd_vector::{Angle, Cartesian};
 use log::debug;
 use serde::{Deserialize, Serialize};
@@ -99,11 +99,16 @@ impl<X> Effort for RegularPolygon<X> {
 
 impl<X> Simulation for RegularPolygon<X>
 where
-    X: PointsNearBall<Cartesian<2>, SiteKey> + PointUpdate<Cartesian<2>, SiteKey> + Sync,
-    Periodic<Hypercuboid<2>>: GenerateGhosts<OrientedPoint<Cartesian<2>, Angle>>,
+    X: PointsNearBall<Cartesian<2>, SiteKey> + PointUpdate<Cartesian<2>, SiteKey> + Sync +
+    IndexFromPosition<Cartesian<2>>,
+    Periodic<Hypercuboid<2>>: GenerateGhosts<OrientedPoint<Cartesian<2>, Angle>>
 {
     #[inline]
     fn advance(&mut self) -> anyhow::Result<()> {
+        // if self.microstate.step().is_multiple_of(300) {
+        //     self.microstate.sort();
+        // }
+
         if self.parallel {
             self.translate_count += self.parallel_translate_sweep.apply(
                 &mut self.microstate,

--- a/benchmarks/src/mc/regular_polygon.rs
+++ b/benchmarks/src/mc/regular_polygon.rs
@@ -105,9 +105,9 @@ where
 {
     #[inline]
     fn advance(&mut self) -> anyhow::Result<()> {
-        // if self.microstate.step().is_multiple_of(300) {
-        //     self.microstate.sort();
-        // }
+        if self.microstate.step().is_multiple_of(300) {
+            self.microstate.sort();
+        }
 
         if self.parallel {
             self.translate_count += self.parallel_translate_sweep.apply(
@@ -173,7 +173,8 @@ where
         + WithSearchRadius
         + Clone
         + for<'a> Deserialize<'a>
-        + Serialize + Sync,
+        + Serialize + Sync
+        + IndexFromPosition<Cartesian<2>>,
     Periodic<Hypercuboid<2>>: GenerateGhosts<OrientedPoint<Cartesian<2>, Angle>>,
 {
     /// Construct a new polygon simulation
@@ -197,6 +198,7 @@ where
                     .with_context(|| format!("Could not read {cache_filename}"))?;
                 // The cache may have been generated with a different value of parallel.
                 result.parallel = parallel;
+                result.microstate.sort();
                 return Ok(result);
             }
             Err(error) => match error.kind() {
@@ -230,12 +232,13 @@ where
         };
         let overlap_penalty_hamiltonian = PairwiseCutoff(approximate_shape_overlap);
 
-        let microstate = place_single_site_orientable_bodies(
+        let mut microstate = place_single_site_orientable_bodies(
             n,
             number_density,
             hamiltonian.maximum_interaction_range(),
             &overlap_penalty_hamiltonian,
         )?;
+        microstate.sort();
 
         translate_sweep.tune_default(&microstate, &hamiltonian, &Isothermal { temperature: 1.0 });
         *parallel_translate_sweep

--- a/benchmarks/src/mc/regular_polygon.rs
+++ b/benchmarks/src/mc/regular_polygon.rs
@@ -168,7 +168,7 @@ where
         + WithSearchRadius
         + Clone
         + for<'a> Deserialize<'a>
-        + Serialize,
+        + Serialize + Sync,
     Periodic<Hypercuboid<2>>: GenerateGhosts<OrientedPoint<Cartesian<2>, Angle>>,
 {
     /// Construct a new polygon simulation

--- a/benchmarks/src/place.rs
+++ b/benchmarks/src/place.rs
@@ -141,7 +141,7 @@ where
         + DeltaEnergyOne<B, S, X, Periodic<Hypercuboid<D>>>
         + TotalEnergy<Microstate<B, S, X, Periodic<Hypercuboid<D>>>> + MaximumInteractionRange + Sync,
 {
-    let initial_number_density = 0.7 * number_density;
+    let initial_number_density = 0.5 * number_density;
     let initial_box_length = (n as f64 / initial_number_density).powf(1.0 / (D as f64));
     let final_box_volume = n as f64 / number_density;
     let macrostate = Isothermal { temperature: 1.0 };
@@ -175,7 +175,7 @@ where
     let mut quick_compress = QuickCompress::with_target_volume(final_box_volume.try_into()?);
 
     while !quick_compress.is_complete() {
-        if microstate.step().is_multiple_of(20) {
+        if microstate.step().is_multiple_of(10) {
             if quick_insert.is_complete() {
                 quick_compress.apply(&mut microstate, insert_hamiltonian, |_| true);
             } else {

--- a/benchmarks/src/place.rs
+++ b/benchmarks/src/place.rs
@@ -8,9 +8,9 @@ use log::{debug, trace};
 use rand::distr::Distribution;
 
 use hoomd_geometry::{Volume, shape::Hypercuboid};
-use hoomd_interaction::{DeltaEnergyInsert, DeltaEnergyOne, TotalEnergy};
+use hoomd_interaction::{DeltaEnergyInsert, DeltaEnergyOne, MaximumInteractionRange, TotalEnergy};
 use hoomd_mc::{
-    LocalTrial, QuickCompress, QuickInsert, Rotate, Sweep, Translate, Trial, UniformIn,
+    LocalTrial, ParallelSweep, QuickCompress, QuickInsert, Rotate, Sweep, Translate, Trial, UniformIn
 };
 use hoomd_microstate::{
     Body, Microstate, SiteKey, Transform,
@@ -128,18 +128,18 @@ where
         + Position<Position = Cartesian<D>>
         + Orientation<Rotation = R>
         + Transform<S>
-        + Copy,
-    S: Default + Position<Position = Cartesian<D>> + Copy,
+        + Copy + Send + Sync,
+    S: Default + Position<Position = Cartesian<D>> + Copy + Send + Sync,
     UniformIn<S, Periodic<Hypercuboid<D>>>: Distribution<Body<B, S>>,
     Periodic<Hypercuboid<D>>: GenerateGhosts<S> + Volume,
-    Rotate<R>: LocalTrial<B> + Clone,
+    Rotate<R>: LocalTrial<B> + Clone + Sync,
     X: PointsNearBall<Cartesian<D>, SiteKey>
         + PointUpdate<Cartesian<D>, SiteKey>
         + WithSearchRadius
-        + Clone,
+        + Clone + Sync,
     H: DeltaEnergyInsert<B, S, X, Periodic<Hypercuboid<D>>>
         + DeltaEnergyOne<B, S, X, Periodic<Hypercuboid<D>>>
-        + TotalEnergy<Microstate<B, S, X, Periodic<Hypercuboid<D>>>>,
+        + TotalEnergy<Microstate<B, S, X, Periodic<Hypercuboid<D>>>> + MaximumInteractionRange + Sync,
 {
     let initial_number_density = 0.7 * number_density;
     let initial_box_length = (n as f64 / initial_number_density).powf(1.0 / (D as f64));
@@ -160,10 +160,12 @@ where
         .try_build()?;
 
     let translate = Translate::with_maximum_distance(0.03.try_into()?);
-    let mut translate_sweep = Sweep(translate);
+    let mut translate_sweep = ParallelSweep::new(insert_hamiltonian.maximum_interaction_range().try_into()?,
+        translate);
 
     let rotate = Rotate::with_maximum_rotation(0.1.try_into()?);
-    let mut rotate_sweep = Sweep(rotate.clone());
+    let mut rotate_sweep = ParallelSweep::new(insert_hamiltonian.maximum_interaction_range().try_into()?,
+        rotate);
 
     let distribution = UniformIn {
         boundary: microstate.boundary().clone(),

--- a/benchmarks/src/place.rs
+++ b/benchmarks/src/place.rs
@@ -10,7 +10,8 @@ use rand::distr::Distribution;
 use hoomd_geometry::{Volume, shape::Hypercuboid};
 use hoomd_interaction::{DeltaEnergyInsert, DeltaEnergyOne, MaximumInteractionRange, TotalEnergy};
 use hoomd_mc::{
-    LocalTrial, ParallelSweep, QuickCompress, QuickInsert, Rotate, Sweep, Translate, Trial, UniformIn
+    LocalTrial, ParallelSweep, QuickCompress, QuickInsert, Rotate, Sweep, Translate, Trial,
+    UniformIn,
 };
 use hoomd_microstate::{
     Body, Microstate, SiteKey, Transform,
@@ -128,7 +129,9 @@ where
         + Position<Position = Cartesian<D>>
         + Orientation<Rotation = R>
         + Transform<S>
-        + Copy + Send + Sync,
+        + Copy
+        + Send
+        + Sync,
     S: Default + Position<Position = Cartesian<D>> + Copy + Send + Sync,
     UniformIn<S, Periodic<Hypercuboid<D>>>: Distribution<Body<B, S>>,
     Periodic<Hypercuboid<D>>: GenerateGhosts<S> + Volume,
@@ -136,10 +139,13 @@ where
     X: PointsNearBall<Cartesian<D>, SiteKey>
         + PointUpdate<Cartesian<D>, SiteKey>
         + WithSearchRadius
-        + Clone + Sync,
+        + Clone
+        + Sync,
     H: DeltaEnergyInsert<B, S, X, Periodic<Hypercuboid<D>>>
         + DeltaEnergyOne<B, S, X, Periodic<Hypercuboid<D>>>
-        + TotalEnergy<Microstate<B, S, X, Periodic<Hypercuboid<D>>>> + MaximumInteractionRange + Sync,
+        + TotalEnergy<Microstate<B, S, X, Periodic<Hypercuboid<D>>>>
+        + MaximumInteractionRange
+        + Sync,
 {
     let initial_number_density = 0.5 * number_density;
     let initial_box_length = (n as f64 / initial_number_density).powf(1.0 / (D as f64));
@@ -160,12 +166,16 @@ where
         .try_build()?;
 
     let translate = Translate::with_maximum_distance(0.03.try_into()?);
-    let mut translate_sweep = ParallelSweep::new(insert_hamiltonian.maximum_interaction_range().try_into()?,
-        translate);
+    let mut translate_sweep = ParallelSweep::new(
+        insert_hamiltonian.maximum_interaction_range().try_into()?,
+        translate,
+    );
 
     let rotate = Rotate::with_maximum_rotation(0.1.try_into()?);
-    let mut rotate_sweep = ParallelSweep::new(insert_hamiltonian.maximum_interaction_range().try_into()?,
-        rotate);
+    let mut rotate_sweep = ParallelSweep::new(
+        insert_hamiltonian.maximum_interaction_range().try_into()?,
+        rotate,
+    );
 
     let distribution = UniformIn {
         boundary: microstate.boundary().clone(),

--- a/benchmarks/src/place.rs
+++ b/benchmarks/src/place.rs
@@ -76,10 +76,12 @@ where
     let mut quick_compress = QuickCompress::with_target_volume(final_box_volume.try_into()?);
 
     while !quick_compress.is_complete() {
-        if quick_insert.is_complete() {
-            quick_compress.apply(&mut microstate, overlap_penalty_hamiltonian, |_| true);
-        } else {
-            quick_insert.apply(&mut microstate, overlap_penalty_hamiltonian);
+        if microstate.step().is_multiple_of(20) {
+            if quick_insert.is_complete() {
+                quick_compress.apply(&mut microstate, overlap_penalty_hamiltonian, |_| true);
+            } else {
+                quick_insert.apply(&mut microstate, overlap_penalty_hamiltonian);
+            }
         }
 
         translate_sweep.apply(&mut microstate, overlap_penalty_hamiltonian, &macrostate);
@@ -157,7 +159,7 @@ where
         .boundary(boundary)
         .try_build()?;
 
-    let translate = Translate::with_maximum_distance(0.1.try_into()?);
+    let translate = Translate::with_maximum_distance(0.03.try_into()?);
     let mut translate_sweep = Sweep(translate);
 
     let rotate = Rotate::with_maximum_rotation(0.1.try_into()?);
@@ -171,10 +173,12 @@ where
     let mut quick_compress = QuickCompress::with_target_volume(final_box_volume.try_into()?);
 
     while !quick_compress.is_complete() {
-        if quick_insert.is_complete() {
-            quick_compress.apply(&mut microstate, insert_hamiltonian, |_| true);
-        } else {
-            quick_insert.apply(&mut microstate, insert_hamiltonian);
+        if microstate.step().is_multiple_of(20) {
+            if quick_insert.is_complete() {
+                quick_compress.apply(&mut microstate, insert_hamiltonian, |_| true);
+            } else {
+                quick_insert.apply(&mut microstate, insert_hamiltonian);
+            }
         }
 
         translate_sweep.apply(&mut microstate, insert_hamiltonian, &macrostate);

--- a/doc/src/mc-tutorial/hard-tetrahedron-self-assembly.md
+++ b/doc/src/mc-tutorial/hard-tetrahedron-self-assembly.md
@@ -78,6 +78,10 @@ Wrap it in the `Convex` newtype for use with the `HardShape` Hamiltonian:
 ```rust,ignore
 {{#rustdoc_include ../../../examples/mc-tutorial/hard-tetrahedron-self-assembly.rs:hamiltonian}}
 ```
+[Coxeter] is one of many tools you can use to construct the vertices of a
+convex polyhedron.
+
+[Coxeter]: https://coxeter.readthedocs.io
 
 ## Initialization and Simulation
 
@@ -141,6 +145,13 @@ or use [modifier templates].
 
 Render with Tachyon, and you should see something like:
 ![Hard tetrahedron self-assembly rendered with Ovito](hard-tetrahedron-self-assembly.png)
+
+> [!TIP]
+> Use [Coxeter], [Blender], [OnShape], or any modeling tool you prefer to
+> create `.obj` files that best represent your model's sites.
+
+[Blender]: https://www.blender.org
+[OnShape]: https://www.onshape.com
 
 ## Conclusion
 

--- a/doc/src/mc-tutorial/hard-tetrahedron-self-assembly.md
+++ b/doc/src/mc-tutorial/hard-tetrahedron-self-assembly.md
@@ -95,7 +95,7 @@ To run the simulation, construct the `HardTetrahedronSelfAssembly` simulation mo
 Then call `advance()` many times and write the sites to a GSD file periodically so that
 you can inspect the results of the simulation:
 ```rust,ignore
-{{#rustdoc_include ../../../examples/mc-tutorial/hard-ellipse-self-assembly.rs:main}}
+{{#rustdoc_include ../../../examples/mc-tutorial/hard-tetrahedron-self-assembly.rs:main}}
 ```
 
 See [Applying Interactions](applying-interactions.md) for a step-by-step explanation

--- a/hoomd-interaction/src/univariate/overlap_penalty.rs
+++ b/hoomd-interaction/src/univariate/overlap_penalty.rs
@@ -56,7 +56,7 @@ impl Default for OverlapPenalty {
     /// The default values are tuned for use with `QuickInsert` and `QuickCompress`
     /// applied to systems of spherical particles with diameter approximately 1.
     ///
-    /// * $`k = 1000`$
+    /// * $`k = 10,000`$
     /// * $`d_\mathrm{max} = 0.2`$
     /// * $`\varepsilon_\mathrm{shoulder} = 100`$
     ///
@@ -73,7 +73,7 @@ impl Default for OverlapPenalty {
     #[inline]
     fn default() -> Self {
         Self {
-            k: 1000.0,
+            k: 10_000.0,
             maximum_allowed_overlap: 0.2,
             epsilon_shoulder: 100.0,
         }

--- a/hoomd-mc/src/hypercuboid.rs
+++ b/hoomd-mc/src/hypercuboid.rs
@@ -77,7 +77,7 @@ impl<const N: usize> Default for HypercuboidCheckerboard<N> {
             space_width: [1.0; N],
             shape: [2; N],
             periodic: [false; N],
-            space_indices_by_color: Vec::new(),
+            space_indices_by_color: Self::construct_space_indices_by_color([2; N]),
         }
     }
 }
@@ -334,7 +334,7 @@ impl<const N: usize> HypercuboidCheckerboard<N> {
             }),
         };
 
-        if shape != self.shape {
+        if shape != self.shape || self.space_indices_by_color.is_empty() {
             self.space_indices_by_color = Self::construct_space_indices_by_color(shape);
             self.shape = shape;
         }
@@ -522,7 +522,37 @@ mod tests {
     }
 
     #[test]
-    fn test_construct_space_indices_by_color_3d() {
+    fn test_construct_space_indices_by_color_3d_222() {
+        let space_indices_by_color =
+            HypercuboidCheckerboard::<3>::construct_space_indices_by_color([2, 2, 2]);
+
+        assert!(space_indices_by_color.len() == 8);
+        assert!(space_indices_by_color[0].len() == 1);
+        check!(space_indices_by_color[0][0] == 0);
+
+        assert!(space_indices_by_color[1].len() == 1);
+        check!(space_indices_by_color[1][0] == 1);
+
+        assert!(space_indices_by_color[2].len() == 1);
+        check!(space_indices_by_color[2][0] == 2);
+
+        assert!(space_indices_by_color[3].len() == 1);
+        check!(space_indices_by_color[3][0] == 3);
+
+        assert!(space_indices_by_color[4].len() == 1);
+        check!(space_indices_by_color[4][0] == 4);
+
+        assert!(space_indices_by_color[5].len() == 1);
+        check!(space_indices_by_color[5][0] == 5);
+
+        assert!(space_indices_by_color[6].len() == 1);
+        check!(space_indices_by_color[6][0] == 6);
+
+        assert!(space_indices_by_color[7].len() == 1);
+        check!(space_indices_by_color[7][0] == 7);
+    }
+    #[test]
+    fn test_construct_space_indices_by_color_3d_general() {
         let space_indices_by_color =
             HypercuboidCheckerboard::<3>::construct_space_indices_by_color([2, 6, 4]);
 

--- a/hoomd-mc/src/parallel_sweep.rs
+++ b/hoomd-mc/src/parallel_sweep.rs
@@ -91,6 +91,7 @@ pub struct ParallelSweep<L, K, B, S> {
     checkerboard: K,
 
     /// Cached storage of the body indices assigned to each space.
+    #[serde(skip)]
     spaces: Vec<Vec<usize>>,
 
     /// Cached storage of the body trial moves in each space.
@@ -389,7 +390,7 @@ where
         let kt = macrostate.temperature();
 
         self.update_checkerboard(microstate);
-
+    
         let mut count = Self::Count::default();
 
         while count.total() < microstate.bodies().len() as u64 {

--- a/hoomd-mc/src/parallel_sweep.rs
+++ b/hoomd-mc/src/parallel_sweep.rs
@@ -390,7 +390,7 @@ where
         let kt = macrostate.temperature();
 
         self.update_checkerboard(microstate);
-    
+
         let mut count = Self::Count::default();
 
         while count.total() < microstate.bodies().len() as u64 {

--- a/hoomd-mc/src/quick_compress.rs
+++ b/hoomd-mc/src/quick_compress.rs
@@ -139,9 +139,9 @@ impl<C> QuickCompress<C> {
     pub fn with_target_volume(target_volume: PositiveReal) -> Self {
         Self {
             target_volume,
-            maximum_energy_per_site: 25.0,
+            maximum_energy_per_site: 1000.0,
             state: State::default(),
-            maximum_delta: 0.01
+            maximum_delta: 0.05
                 .try_into()
                 .expect("hard-coded constant should be in the open unit interval"),
         }

--- a/hoomd-microstate/src/lib.rs
+++ b/hoomd-microstate/src/lib.rs
@@ -235,7 +235,7 @@ use property::Point;
 /// # Ok(())
 /// # }
 /// ```
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Site<S> {
     /// Every site in a [`Microstate`] has a unique value in `site_tag`.
     pub site_tag: usize,

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -1423,16 +1423,26 @@ where
 impl<P, B, S, X, C, L> Microstate<B, S, X, C>
 where
     S: Position<Position = P>,
-    X: IndexFromPosition<P, L = L>,
+    X: IndexFromPosition<P, Location = L>,
     L: Ord,
     Site<S>: Copy,
 {
+    /// Sort the sites spatially.
+    ///
+    /// `sort_sites` reorders the sites in memory based on their spatial location.
+    /// `PairwiseCutoff` interactions compute in less them when the sites are sorted
+    /// because the interacting sites are more likely to be nearby in memory.
+    ///
+    /// CPUs have large caches. Typical simulations start to see benefits from sorting
+    /// when there are more than 100,000 sites. `sort` is a quick operation, so there
+    /// is no harm in sorting the microstate every few hundred steps regardless of the
+    /// system size.
     #[inline]
-    pub fn sort(&mut self) {
+    pub fn sort_sites(&mut self) {
         let mut sort_order = (0..self.sites.len()).collect::<Vec<_>>();
         sort_order.sort_by_key(|&i| {
             self.spatial_data
-                .index_from_position(self.sites.items[i].properties.position())
+                .location_from_position(self.sites.items[i].properties.position())
         });
 
         let mut new_sites_items = Vec::new();
@@ -1449,9 +1459,9 @@ where
             self.sites.indices[*tag] = Some(index);
         }
 
-        mem::replace(&mut self.sites.items, new_sites_items);
-        mem::replace(&mut self.sites.tags, new_sites_tags);
-        mem::replace(&mut self.sites_ghosts, new_sites_ghosts);
+        let _ = mem::replace(&mut self.sites.items, new_sites_items);
+        let _ = mem::replace(&mut self.sites.tags, new_sites_tags);
+        let _ = mem::replace(&mut self.sites_ghosts, new_sites_ghosts);
     }
 }
 

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -218,6 +218,9 @@ pub struct Microstate<B, S = B, X = AllPairs<SiteKey>, C = Open> {
 
     /// Spatial data structure.
     spatial_data: X,
+
+    /// Temporary buffer for wrapped site properties
+    wrapped_site_properties: Vec<S>,
 }
 
 impl<B, S> Default for Microstate<B, S, AllPairs<SiteKey>, Open> {
@@ -265,6 +268,7 @@ impl<B, S> Microstate<B, S, AllPairs<SiteKey>, Open> {
             sites_ghosts: Vec::new(),
             boundary: Open,
             spatial_data: AllPairs::default(),
+            wrapped_site_properties: Vec::new(),
         }
     }
 
@@ -568,14 +572,13 @@ where
     /// Given a site in the boundary, update that site's ghosts to be consistent
     /// with that site's properties. This may require adding or removing ghosts.
     fn update_site_ghosts(
-        sites: &VecWithTags<Site<S>>,
+        site: &Site<S>,
         site_index: usize,
         boundary: &C,
         sites_ghosts: &mut [ArrayVec<usize, MAX_GHOSTS>],
         ghosts: &mut VecWithTags<Site<S>>,
         spatial_data: &mut X,
     ) {
-        let site = &sites.items[site_index];
         let new_ghosts = boundary.generate_ghosts(&site.properties);
         let ghost_tags = &mut sites_ghosts[site_index];
 
@@ -621,7 +624,7 @@ where
             let site_index = self.sites.indices[*site_tag]
                 .expect("bodies_sites and site_indices should be consistent");
             Self::update_site_ghosts(
-                &self.sites,
+                &self.sites.items[site_index],
                 site_index,
                 &self.boundary,
                 &mut self.sites_ghosts,
@@ -911,28 +914,31 @@ where
         // to be a performance bottleneck, we could alternately implement a
         // staging Vec (would require allocation/deallocation per update or a
         // reusable scratch storage).
+        self.wrapped_site_properties.clear();
         for s in &body.item.sites {
-            self.boundary
+            let wrapped = self.boundary
                 .wrap(new_body_properties.transform(s))
                 .map_err(|e| Error::UpdateBody(body.tag, e))?;
+            self.wrapped_site_properties.push(wrapped);
         }
 
         body.item.properties = new_body_properties;
 
         // Update site properties
-        for (i, site_tag) in self.bodies_sites[body_index].iter().enumerate() {
+        for ((i, site_tag), site_properties) in self.bodies_sites[body_index].iter().enumerate().zip(self.wrapped_site_properties.drain(..)) {
             let site_index = self.sites.indices[*site_tag]
                 .expect("bodies_sites and site_indices should be consistent");
-            let site_properties = self
-                .boundary
-                .wrap(body.item.properties.transform(&body.item.sites[i]))
-                .expect("sites should be validated as wrappable prior to this loop");
             self.spatial_data
                 .insert(SiteKey::Primary(*site_tag), *site_properties.position());
             self.sites.items[site_index].properties = site_properties;
-        }
 
-        self.update_body_site_ghosts(body_index);
+            Self::update_site_ghosts(&self.sites.items[site_index],
+                site_index,
+                &self.boundary,
+                &mut self.sites_ghosts,
+                &mut self.ghosts,
+                &mut self.spatial_data);
+        }
 
         Ok(())
     }
@@ -1669,6 +1675,7 @@ impl<B, S, X, C> MicrostateBuilder<B, S, X, C> {
             ghosts: VecWithTags::new(),
             sites_ghosts: Vec::new(),
             spatial_data: self.spatial_data,
+            wrapped_site_properties: Vec::new(),
         };
 
         microstate.spatial_data.clear();

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -928,12 +928,14 @@ where
                 .insert(SiteKey::Primary(*site_tag), *site_properties.position());
             self.sites.items[site_index].properties = site_properties;
 
-            Self::update_site_ghosts(&self.sites.items[site_index],
+            Self::update_site_ghosts(
+                &self.sites.items[site_index],
                 site_index,
                 &self.boundary,
                 &mut self.sites_ghosts,
                 &mut self.ghosts,
-                &mut self.spatial_data);
+                &mut self.spatial_data,
+            );
         }
 
         Ok(())
@@ -1428,19 +1430,22 @@ where
     #[inline]
     pub fn sort(&mut self) {
         let mut sort_order = (0..self.sites.len()).collect::<Vec<_>>();
-        sort_order.sort_by_key(|&i| self.spatial_data.index_from_position(self.sites.items[i].properties.position()));
+        sort_order.sort_by_key(|&i| {
+            self.spatial_data
+                .index_from_position(self.sites.items[i].properties.position())
+        });
 
         let mut new_sites_items = Vec::new();
         let mut new_sites_tags = Vec::new();
         let mut new_sites_ghosts = Vec::new();
-        
+
         for index in sort_order {
             new_sites_items.push(self.sites.items[index]);
             new_sites_tags.push(self.sites.tags[index]);
             new_sites_ghosts.push(self.sites_ghosts[index].clone());
         }
 
-        for (index,tag) in new_sites_tags.iter().enumerate() {
+        for (index, tag) in new_sites_tags.iter().enumerate() {
             self.sites.indices[*tag] = Some(index);
         }
 

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -5,7 +5,7 @@
 
 use arrayvec::ArrayVec;
 use serde::{Deserialize, Serialize};
-use std::{cmp::Reverse, collections::BinaryHeap, fmt};
+use std::{cmp::Reverse, collections::BinaryHeap, fmt, mem};
 
 use crate::{
     Body, Error, Site, Transform,
@@ -15,7 +15,7 @@ use crate::{
 
 use hoomd_geometry::MapPoint;
 use hoomd_rand::Counter;
-use hoomd_spatial::{AllPairs, PointUpdate, PointsNearBall};
+use hoomd_spatial::{AllPairs, IndexFromPosition, PointUpdate, PointsNearBall};
 
 /// Either a primary site index or a ghost site index.
 #[derive(Clone, Copy, Eq, Hash, PartialEq, Serialize, Deserialize)]
@@ -121,7 +121,6 @@ impl<T> VecWithTags<T> {
     }
 
     /// Number of items stored.
-    #[cfg(test)]
     fn len(&self) -> usize {
         self.items.len()
     }
@@ -1416,6 +1415,38 @@ where
         }
 
         Ok(new_microstate)
+    }
+}
+
+impl<P, B, S, X, C, L> Microstate<B, S, X, C>
+where
+    S: Position<Position = P>,
+    X: IndexFromPosition<P, L = L>,
+    L: Ord,
+    Site<S>: Copy,
+{
+    #[inline]
+    pub fn sort(&mut self) {
+        let mut sort_order = (0..self.sites.len()).collect::<Vec<_>>();
+        sort_order.sort_by_key(|&i| self.spatial_data.index_from_position(self.sites.items[i].properties.position()));
+
+        let mut new_sites_items = Vec::new();
+        let mut new_sites_tags = Vec::new();
+        let mut new_sites_ghosts = Vec::new();
+        
+        for index in sort_order {
+            new_sites_items.push(self.sites.items[index]);
+            new_sites_tags.push(self.sites.tags[index]);
+            new_sites_ghosts.push(self.sites_ghosts[index].clone());
+        }
+
+        for (index,tag) in new_sites_tags.iter().enumerate() {
+            self.sites.indices[*tag] = Some(index);
+        }
+
+        mem::replace(&mut self.sites.items, new_sites_items);
+        mem::replace(&mut self.sites.tags, new_sites_tags);
+        mem::replace(&mut self.sites_ghosts, new_sites_ghosts);
     }
 }
 

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -218,9 +218,6 @@ pub struct Microstate<B, S = B, X = AllPairs<SiteKey>, C = Open> {
 
     /// Spatial data structure.
     spatial_data: X,
-
-    /// Temporary buffer for wrapped site properties
-    wrapped_site_properties: Vec<S>,
 }
 
 impl<B, S> Default for Microstate<B, S, AllPairs<SiteKey>, Open> {
@@ -268,7 +265,6 @@ impl<B, S> Microstate<B, S, AllPairs<SiteKey>, Open> {
             sites_ghosts: Vec::new(),
             boundary: Open,
             spatial_data: AllPairs::default(),
-            wrapped_site_properties: Vec::new(),
         }
     }
 
@@ -910,24 +906,25 @@ where
 
         // An unknown site in the body might not wrap into the boundary.
         // Check that they do first before starting to modify internal data
-        // structures. This wraps every site twice on update. Should that prove
-        // to be a performance bottleneck, we could alternately implement a
-        // staging Vec (would require allocation/deallocation per update or a
-        // reusable scratch storage).
-        self.wrapped_site_properties.clear();
+        // structures. This wraps every site twice on update. Testing
+        // shows that caching/reusing the results of the first wrap
+        // does not change performance at all.
         for s in &body.item.sites {
-            let wrapped = self.boundary
+            self.boundary
                 .wrap(new_body_properties.transform(s))
                 .map_err(|e| Error::UpdateBody(body.tag, e))?;
-            self.wrapped_site_properties.push(wrapped);
         }
 
         body.item.properties = new_body_properties;
 
         // Update site properties
-        for ((i, site_tag), site_properties) in self.bodies_sites[body_index].iter().enumerate().zip(self.wrapped_site_properties.drain(..)) {
+        for (i, site_tag) in self.bodies_sites[body_index].iter().enumerate() {
             let site_index = self.sites.indices[*site_tag]
                 .expect("bodies_sites and site_indices should be consistent");
+            let site_properties = self
+                .boundary
+                .wrap(body.item.properties.transform(&body.item.sites[i]))
+                .expect("sites should be validated as wrappable prior to this loop");
             self.spatial_data
                 .insert(SiteKey::Primary(*site_tag), *site_properties.position());
             self.sites.items[site_index].properties = site_properties;
@@ -1675,7 +1672,6 @@ impl<B, S, X, C> MicrostateBuilder<B, S, X, C> {
             ghosts: VecWithTags::new(),
             sites_ghosts: Vec::new(),
             spatial_data: self.spatial_data,
-            wrapped_site_properties: Vec::new(),
         };
 
         microstate.spatial_data.clear();

--- a/hoomd-spatial/src/lib.rs
+++ b/hoomd-spatial/src/lib.rs
@@ -170,7 +170,13 @@ pub trait WithSearchRadius {
 ///
 /// This is used by `Microstate` to sort for cache coherency.
 pub trait IndexFromPosition<P> {
-    type L: Ord;
+    /// Orderable type based on the site's position.
+    type Location: Ord;
 
-    fn index_from_position(&self, position: &P) -> Self::L;
+    /// Determine the location of a site based on its position.
+    ///
+    /// Many positions can map to the same location. The ideal
+    /// mapping will place points close together in physical space
+    /// close together in the ordering.
+    fn location_from_position(&self, position: &P) -> Self::Location;
 }

--- a/hoomd-spatial/src/lib.rs
+++ b/hoomd-spatial/src/lib.rs
@@ -165,3 +165,12 @@ pub trait WithSearchRadius {
     /// Construct a spatial data structure that can search *at least* as far as the given radius.
     fn with_search_radius(radius: PositiveReal) -> Self;
 }
+
+/// Locate the index of a given point.
+///
+/// This is used by `Microstate` to sort for cache coherency.
+pub trait IndexFromPosition<P> {
+    type L: Ord;
+
+    fn index_from_position(&self, position: &P) -> Self::L;
+}

--- a/hoomd-spatial/src/vec_cell.rs
+++ b/hoomd-spatial/src/vec_cell.rs
@@ -24,7 +24,7 @@ use hoomd_vector::Cartesian;
 
 use super::{PointUpdate, PointsNearBall, WithSearchRadius};
 
-use crate::hash_cell::CellIndex;
+use crate::{IndexFromPosition, hash_cell::CellIndex};
 
 /// Bucket sort points into cubes with [`Vec`]-backed storage
 ///
@@ -774,6 +774,18 @@ where
             self.cell_width.get() * self.stencils.len() as f64
         )?;
         write!(f, "- Largest cell length: {largest_cell_size}")
+    }
+}
+
+impl<K, const D: usize> IndexFromPosition<Cartesian<D>> for VecCell<K, D>
+where
+    K: Eq + Hash,
+{
+    type L = [i64; D];
+
+    #[inline]
+    fn index_from_position(&self, position: &Cartesian<D>) -> Self::L {
+        self.cell_index_from_position(position)
     }
 }
 

--- a/hoomd-spatial/src/vec_cell.rs
+++ b/hoomd-spatial/src/vec_cell.rs
@@ -781,10 +781,10 @@ impl<K, const D: usize> IndexFromPosition<Cartesian<D>> for VecCell<K, D>
 where
     K: Eq + Hash,
 {
-    type L = [i64; D];
+    type Location = [i64; D];
 
     #[inline]
-    fn index_from_position(&self, position: &Cartesian<D>) -> Self::L {
+    fn location_from_position(&self, position: &Cartesian<D>) -> Self::Location {
         self.cell_index_from_position(position)
     }
 }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
* Reduce the number of steps that QuickCompress requires.
* Add spatial sorting

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Compare hoomd-rs and HOOMD-blue performance across a wide range of system sizes and numbers of threads.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Executed all the benchmarks on Anvil.

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**hoomd-rs Contributor Agreement**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/credits.md`) in the pull request source branch.
