### PR TITLE
Implement Graham scan for 2D convex hulls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3667,6 +3667,7 @@ version = "1.0.2"
 dependencies = [
  "anyhow",
  "approxim",
+ "arrayvec",
  "assert2",
  "divan",
  "hoomd-linear-algebra",

--- a/hoomd-geometry/Cargo.toml
+++ b/hoomd-geometry/Cargo.toml
@@ -22,6 +22,7 @@ serde_with.workspace = true
 thiserror.workspace = true
 robust.workspace = true
 
+arrayvec.workspace = true
 hoomd-manifold.workspace = true
 hoomd-vector.workspace = true
 hoomd-linear-algebra.workspace = true

--- a/hoomd-geometry/Cargo.toml
+++ b/hoomd-geometry/Cargo.toml
@@ -40,3 +40,7 @@ rstest.workspace = true
 [[bench]]
 name = "overlaps"
 harness = false
+
+[[bench]]
+name = "hull"
+harness = false

--- a/hoomd-geometry/benches/hull.rs
+++ b/hoomd-geometry/benches/hull.rs
@@ -11,7 +11,7 @@
 //! Benchmark 2D convex hull (Graham scan)
 
 use divan::{self, Bencher, black_box, counter::ItemsCount};
-use hoomd_geometry::construct_convex_hull_2d;
+use hoomd_geometry::shape::ConvexSurfaceMesh2d;
 use hoomd_vector::Cartesian;
 use rand::{RngExt, SeedableRng, rngs::StdRng};
 
@@ -62,7 +62,7 @@ mod random {
         bencher
             .counter(ItemsCount::from(N as u32))
             .with_inputs(|| create_random_points(N, &mut rng))
-            .bench_local_values(|mut pts| black_box(construct_convex_hull_2d(&mut pts)));
+            .bench_local_values(|pts| black_box(ConvexSurfaceMesh2d::construct_convex_hull(pts)));
     }
 }
 
@@ -75,7 +75,7 @@ mod boundaries {
         bencher
             .counter(ItemsCount::from(N as u32))
             .with_inputs(|| create_circle_points(N))
-            .bench_local_values(|mut pts| black_box(construct_convex_hull_2d(&mut pts)));
+            .bench_local_values(|pts| black_box(ConvexSurfaceMesh2d::construct_convex_hull(pts)));
     }
 
     #[divan::bench(consts = NUM_POINTS)]
@@ -83,6 +83,6 @@ mod boundaries {
         bencher
             .counter(ItemsCount::from(N as u32))
             .with_inputs(|| create_square_boundary(N / 4 + 1))
-            .bench_local_values(|mut pts| black_box(construct_convex_hull_2d(&mut pts)));
+            .bench_local_values(|pts| black_box(ConvexSurfaceMesh2d::construct_convex_hull(pts)));
     }
 }

--- a/hoomd-geometry/benches/hull.rs
+++ b/hoomd-geometry/benches/hull.rs
@@ -11,7 +11,7 @@
 //! Benchmark 2D convex hull (Graham scan)
 
 use divan::{self, Bencher, black_box, counter::ItemsCount};
-use hoomd_geometry::hull_2d_grahamscan;
+use hoomd_geometry::construct_convex_hull_2d;
 use hoomd_vector::Cartesian;
 use rand::{RngExt, SeedableRng, rngs::StdRng};
 
@@ -62,7 +62,7 @@ mod random {
         bencher
             .counter(ItemsCount::from(N as u32))
             .with_inputs(|| create_random_points(N, &mut rng))
-            .bench_local_values(|mut pts| black_box(hull_2d_grahamscan(&mut pts)));
+            .bench_local_values(|mut pts| black_box(construct_convex_hull_2d(&mut pts)));
     }
 }
 
@@ -75,7 +75,7 @@ mod boundaries {
         bencher
             .counter(ItemsCount::from(N as u32))
             .with_inputs(|| create_circle_points(N))
-            .bench_local_values(|mut pts| black_box(hull_2d_grahamscan(&mut pts)));
+            .bench_local_values(|mut pts| black_box(construct_convex_hull_2d(&mut pts)));
     }
 
     #[divan::bench(consts = NUM_POINTS)]
@@ -83,6 +83,6 @@ mod boundaries {
         bencher
             .counter(ItemsCount::from(N as u32))
             .with_inputs(|| create_square_boundary(N / 4 + 1))
-            .bench_local_values(|mut pts| black_box(hull_2d_grahamscan(&mut pts)));
+            .bench_local_values(|mut pts| black_box(construct_convex_hull_2d(&mut pts)));
     }
 }

--- a/hoomd-geometry/benches/hull.rs
+++ b/hoomd-geometry/benches/hull.rs
@@ -6,6 +6,7 @@
     reason = "benches don't need public documentation"
 )]
 #![expect(clippy::wildcard_imports, reason = "simplifies code")]
+#![expect(clippy::cast_possible_truncation, reason = "N is small")]
 
 //! Benchmark 2D convex hull (Graham scan)
 

--- a/hoomd-geometry/benches/hull.rs
+++ b/hoomd-geometry/benches/hull.rs
@@ -61,7 +61,7 @@ mod random {
         bencher
             .counter(ItemsCount::from(N as u32))
             .with_inputs(|| create_random_points(N, &mut rng))
-            .bench_local_values(|pts| black_box(hull_2d_grahamscan(pts)));
+            .bench_local_values(|mut pts| black_box(hull_2d_grahamscan(&mut pts)));
     }
 }
 
@@ -74,7 +74,7 @@ mod boundaries {
         bencher
             .counter(ItemsCount::from(N as u32))
             .with_inputs(|| create_circle_points(N))
-            .bench_local_values(|pts| black_box(hull_2d_grahamscan(pts)));
+            .bench_local_values(|mut pts| black_box(hull_2d_grahamscan(&mut pts)));
     }
 
     #[divan::bench(consts = NUM_POINTS)]
@@ -82,6 +82,6 @@ mod boundaries {
         bencher
             .counter(ItemsCount::from(N as u32))
             .with_inputs(|| create_square_boundary(N / 4 + 1))
-            .bench_local_values(|pts| black_box(hull_2d_grahamscan(pts)));
+            .bench_local_values(|mut pts| black_box(hull_2d_grahamscan(&mut pts)));
     }
 }

--- a/hoomd-geometry/benches/hull.rs
+++ b/hoomd-geometry/benches/hull.rs
@@ -19,7 +19,7 @@ fn main() {
     divan::main();
 }
 
-const NUM_POINTS: &[usize] = &[10, 100, 1_000, 10_000];
+const NUM_POINTS: &[usize] = &[10, 100, 1_000];
 
 /// Create random points in the unit square
 fn create_random_points(n: usize, rng: &mut StdRng) -> Vec<Cartesian<2>> {

--- a/hoomd-geometry/benches/hull.rs
+++ b/hoomd-geometry/benches/hull.rs
@@ -61,7 +61,7 @@ mod random {
         bencher
             .counter(ItemsCount::from(N as u32))
             .with_inputs(|| create_random_points(N, &mut rng))
-            .bench_local_values(|mut pts| black_box(hull_2d_grahamscan(&mut pts)));
+            .bench_local_values(|pts| black_box(hull_2d_grahamscan(pts)));
     }
 }
 
@@ -74,7 +74,7 @@ mod boundaries {
         bencher
             .counter(ItemsCount::from(N as u32))
             .with_inputs(|| create_circle_points(N))
-            .bench_local_values(|mut pts| black_box(hull_2d_grahamscan(&mut pts)));
+            .bench_local_values(|pts| black_box(hull_2d_grahamscan(pts)));
     }
 
     #[divan::bench(consts = NUM_POINTS)]
@@ -82,6 +82,6 @@ mod boundaries {
         bencher
             .counter(ItemsCount::from(N as u32))
             .with_inputs(|| create_square_boundary(N / 4 + 1))
-            .bench_local_values(|mut pts| black_box(hull_2d_grahamscan(&mut pts)));
+            .bench_local_values(|pts| black_box(hull_2d_grahamscan(pts)));
     }
 }

--- a/hoomd-geometry/benches/hull.rs
+++ b/hoomd-geometry/benches/hull.rs
@@ -1,0 +1,87 @@
+// Copyright (c) 2024-2026 The Regents of the University of Michigan.
+// Part of hoomd-rs, released under the BSD 3-Clause License.
+
+#![expect(
+    clippy::missing_docs_in_private_items,
+    reason = "benches don't need public documentation"
+)]
+#![expect(clippy::wildcard_imports, reason = "simplifies code")]
+
+//! Benchmark 2D convex hull (Graham scan)
+
+use divan::{self, Bencher, black_box, counter::ItemsCount};
+use hoomd_geometry::hull_2d_grahamscan;
+use hoomd_vector::Cartesian;
+use rand::{RngExt, SeedableRng, rngs::StdRng};
+
+fn main() {
+    divan::main();
+}
+
+const NUM_POINTS: &[usize] = &[10, 100, 1_000, 10_000];
+
+/// Create random points in the unit square
+fn create_random_points(n: usize, rng: &mut StdRng) -> Vec<Cartesian<2>> {
+    (0..n)
+        .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
+        .collect()
+}
+
+/// Create points uniformly distributed on a circle
+fn create_circle_points(n: usize) -> Vec<Cartesian<2>> {
+    (0..n)
+        .map(|i| {
+            let angle = 2.0 * std::f64::consts::PI * i as f64 / n as f64;
+            Cartesian::from([angle.cos(), angle.sin()])
+        })
+        .collect()
+}
+
+/// Create points densely on a square boundary
+fn create_square_boundary(n_per_edge: usize) -> Vec<Cartesian<2>> {
+    let mut pts = Vec::with_capacity(4 * n_per_edge);
+    for i in 0..n_per_edge {
+        let t = i as f64 / (n_per_edge - 1) as f64;
+        pts.push(Cartesian::from([t, 0.0])); // bottom
+        pts.push(Cartesian::from([1.0, t])); // right
+        pts.push(Cartesian::from([t, 1.0])); // top
+        pts.push(Cartesian::from([0.0, t])); // left
+    }
+    pts
+}
+
+#[divan::bench_group]
+mod random {
+    use super::*;
+
+    #[divan::bench(consts = NUM_POINTS)]
+    fn unit_square<const N: usize>(bencher: Bencher) {
+        let mut rng = StdRng::seed_from_u64(42);
+
+        bencher
+            .counter(ItemsCount::from(N as u32))
+            .with_inputs(|| create_random_points(N, &mut rng))
+            .bench_local_values(|mut pts| black_box(hull_2d_grahamscan(&mut pts)));
+    }
+}
+
+#[divan::bench_group]
+mod boundaries {
+    use super::*;
+
+    #[divan::bench(consts = NUM_POINTS)]
+    fn circle_boundary<const N: usize>(bencher: Bencher) {
+        bencher
+            .counter(ItemsCount::from(N as u32))
+            .with_inputs(|| create_circle_points(N))
+            .bench_local_values(|mut pts| black_box(hull_2d_grahamscan(&mut pts)));
+    }
+
+    #[divan::bench(consts = NUM_POINTS)]
+    fn square_boundary<const N: usize>(bencher: Bencher) {
+        bencher
+            .counter(ItemsCount::from(N as u32))
+            .with_inputs(|| create_square_boundary(N / 4 + 1))
+            .bench_local_values(|mut pts| black_box(hull_2d_grahamscan(&mut pts)));
+    }
+}

--- a/hoomd-geometry/benches/overlaps.rs
+++ b/hoomd-geometry/benches/overlaps.rs
@@ -24,7 +24,7 @@ use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
 #[inline(never)]
 fn asm_collide3d() {
     let mut rng = StdRng::seed_from_u64(1);
-    let (p0, p1) = create_dipyramid_pair::<4, 6, _>(&mut rng, 10.0);
+    let (p0, p1) = create_dipyramid_pair::<6, _>(&mut rng, 10.0);
     let (t, r) = create_offset_3d(&mut rng);
     collide3d(&p0, &p1, &t, &r);
 }
@@ -90,14 +90,14 @@ fn create_simplex_pair<R: Rng>(rng: &mut R) -> (Simplex3, Simplex3) {
         ]),
     )
 }
-/// Create a pair of N-dipyramids with random half-heights between 0 and `h_max`
-fn create_dipyramid_pair<const N: usize, const MAX: usize, R: Rng>(
+/// Create a pair of dipyramids with N total vertices (N-2 base + 2 apex).
+fn create_dipyramid_pair<const N: usize, R: Rng>(
     rng: &mut R,
     h_max: f64,
-) -> (ConvexPolytope<3, MAX>, ConvexPolytope<3, MAX>) {
-    let base = ConvexPolytope::<2, N>::regular(N);
+) -> (ConvexPolytope<3, N>, ConvexPolytope<3, N>) {
+    let base = ConvexPolytope::<2, N>::regular(N - 2);
     (
-        ConvexPolytope::<3, MAX>::with_vertices(
+        ConvexPolytope::<3, N>::with_vertices(
             base.vertices()
                 .iter()
                 .map(|x| Cartesian::from([x[0], x[1], 0.0]))
@@ -107,7 +107,7 @@ fn create_dipyramid_pair<const N: usize, const MAX: usize, R: Rng>(
                 ]),
         )
         .unwrap(),
-        ConvexPolytope::<3, MAX>::with_vertices(
+        ConvexPolytope::<3, N>::with_vertices(
             base.vertices()
                 .iter()
                 .map(|x| Cartesian::from([x[0], x[1], 0.0]))
@@ -164,6 +164,7 @@ fn create_offset_3d<R: Rng>(rng: &mut R) -> (Cartesian<3>, Versor) {
 
 const DIMENSIONS: &[usize] = &[2, 3, 4];
 const NUM_VERTICES: &[usize] = &[3, 4, 8, 16, 50];
+const DIPYRAMID_VERTICES: &[usize] = &[5, 6, 10, 18, 52];
 
 #[divan::bench_group]
 mod sphere {
@@ -285,7 +286,7 @@ mod polytopes {
             .bench_local_values(|((p0, p1), (t, r))| black_box(collide2d(&p0, &p1, &t, &r)));
     }
 
-    #[divan::bench(consts = NUM_VERTICES)]
+    #[divan::bench(consts = DIPYRAMID_VERTICES)]
     fn dipyramid_3d<const N: usize>(bencher: Bencher) {
         let mut rng = StdRng::seed_from_u64(1);
 
@@ -293,7 +294,7 @@ mod polytopes {
             .counter(ItemsCount::from(1_u32))
             .with_inputs(|| {
                 (
-                    shapes_to_convex(create_dipyramid_pair::<N, 52, _>(&mut rng, 10.0)),
+                    shapes_to_convex(create_dipyramid_pair::<N, _>(&mut rng, 10.0)),
                     create_offset_3d(&mut rng),
                 )
             })

--- a/hoomd-geometry/benches/overlaps.rs
+++ b/hoomd-geometry/benches/overlaps.rs
@@ -5,7 +5,6 @@
     clippy::missing_docs_in_private_items,
     reason = "benches don't need public documentation"
 )]
-#![expect(clippy::unwrap_used, reason = "benches can use unwrap where needed")]
 #![expect(clippy::wildcard_imports, reason = "simplifies code")]
 
 //! Benchmark overlaps
@@ -18,20 +17,10 @@ use hoomd_geometry::{
     },
     xenocollide::{collide2d, collide3d},
 };
-use hoomd_vector::{Angle, Cartesian, Versor};
+use hoomd_vector::{Angle, Cartesian, InnerProduct, Versor};
 use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
 
-#[inline(never)]
-fn asm_collide3d() {
-    let mut rng = StdRng::seed_from_u64(1);
-    let (p0, p1) = create_dipyramid_pair::<6, _>(&mut rng, 10.0);
-    let (t, r) = create_offset_3d(&mut rng);
-    collide3d(&p0, &p1, &t, &r);
-}
-
 fn main() {
-    asm_collide3d();
-
     divan::main();
 }
 
@@ -39,124 +28,33 @@ fn shapes_to_convex<S>(tup: (S, S)) -> (Convex<S>, Convex<S>) {
     (Convex(tup.0), Convex(tup.1))
 }
 
-fn create_sphere_pair<const N: usize, R: Rng>(rng: &mut R) -> (Hypersphere<N>, Hypersphere<N>) {
-    (
-        Hypersphere::<N> {
-            radius: rng
-                .random_range(0.0..10.0)
-                .try_into()
-                .expect("test value is a positive real"),
-        },
-        Hypersphere::<N> {
-            radius: rng
-                .random_range(0.0..10.0)
-                .try_into()
-                .expect("test value is a positive real"),
-        },
+fn create_dipyramid(n: usize) -> ConvexPolytope<3> {
+    let base = ConvexPolytope::<2>::regular(n);
+    ConvexPolytope::<3>::with_vertices(
+        base.vertices()
+            .iter()
+            .map(|x| Cartesian::from([x[0], x[1], 0.0]))
+            .chain([[0.0, 0.0, 0.5].into(), [0.0, 0.0, -0.5].into()]),
     )
+    .expect("constructed polytope should be valid")
 }
 
-fn create_cuboid_pair<const N: usize, R: Rng>(rng: &mut R) -> (Hypercuboid<N>, Hypercuboid<N>) {
-    (
-        Hypercuboid {
-            edge_lengths: (rng.random::<Cartesian<N>>() * 10.0).coordinates.map(|x| {
-                (x + 11.0)
-                    .try_into()
-                    .expect("test value is a positive real")
-            }),
-        },
-        Hypercuboid {
-            edge_lengths: (rng.random::<Cartesian<N>>() * 10.0).coordinates.map(|x| {
-                (x + 11.0)
-                    .try_into()
-                    .expect("test value is a positive real")
-            }),
-        },
-    )
-}
-fn create_simplex_pair<R: Rng>(rng: &mut R) -> (Simplex3, Simplex3) {
-    (
-        Simplex3::from([
-            rng.random::<Cartesian<3>>() * 10.0,
-            rng.random::<Cartesian<3>>() * 10.0,
-            rng.random::<Cartesian<3>>() * 10.0,
-            rng.random::<Cartesian<3>>() * 10.0,
-        ]),
-        Simplex3::from([
-            rng.random::<Cartesian<3>>() * 10.0,
-            rng.random::<Cartesian<3>>() * 10.0,
-            rng.random::<Cartesian<3>>() * 10.0,
-            rng.random::<Cartesian<3>>() * 10.0,
-        ]),
-    )
-}
-/// Create a pair of dipyramids with N total vertices (N-2 base + 2 apex).
-fn create_dipyramid_pair<const N: usize, R: Rng>(
-    rng: &mut R,
-    h_max: f64,
-) -> (ConvexPolytope<3, N>, ConvexPolytope<3, N>) {
-    let base = ConvexPolytope::<2, N>::regular(N - 2);
-    (
-        ConvexPolytope::<3, N>::with_vertices(
-            base.vertices()
-                .iter()
-                .map(|x| Cartesian::from([x[0], x[1], 0.0]))
-                .chain([
-                    [0.0, 0.0, rng.random_range(0.0..h_max)].into(),
-                    [0.0, 0.0, -rng.random_range(0.0..h_max)].into(),
-                ]),
-        )
-        .unwrap(),
-        ConvexPolytope::<3, N>::with_vertices(
-            base.vertices()
-                .iter()
-                .map(|x| Cartesian::from([x[0], x[1], 0.0]))
-                .chain([
-                    [0.0, 0.0, rng.random_range(0.0..h_max)].into(),
-                    [0.0, 0.0, -rng.random_range(0.0..h_max)].into(),
-                ]),
-        )
-        .unwrap(),
-    )
+fn sample_offset_angle<R: Rng>(rng: &mut R, r_min: f64, r_max: f64) -> (Cartesian<2>, Angle) {
+    (sample_offset(rng, r_min, r_max), rng.random())
 }
 
-fn create_polygon_pair<const N: usize>() -> (ConvexPolytope<2, N>, ConvexPolytope<2, N>) {
-    (
-        ConvexPolytope::<2, N>::regular(N),
-        ConvexPolytope::<2, N>::regular(N),
-    )
+fn sample_offset_versor<R: Rng>(rng: &mut R, r_min: f64, r_max: f64) -> (Cartesian<3>, Versor) {
+    (sample_offset(rng, r_min, r_max), rng.random())
 }
 
-fn create_ellipsoid_pair<const N: usize, R: Rng>(
-    rng: &mut R,
-) -> (Hyperellipsoid<N>, Hyperellipsoid<N>) {
-    (
-        Hyperellipsoid::with_semi_axes((rng.random::<Cartesian<N>>() * 10.0).coordinates.map(
-            |x| {
-                (x + 11.0)
-                    .try_into()
-                    .expect("test value is a positive real")
-            },
-        )),
-        Hyperellipsoid::with_semi_axes((rng.random::<Cartesian<N>>() * 10.0).coordinates.map(
-            |x| {
-                (x + 11.0)
-                    .try_into()
-                    .expect("test value is a positive real")
-            },
-        )),
-    )
-}
-
-fn create_offset_2d<R: Rng>(rng: &mut R) -> (Cartesian<2>, Angle) {
-    (
-        rng.random::<Cartesian<2>>() * 10.0,
-        Angle::from(rng.random_range((-2.0 * std::f64::consts::PI)..(2.0 * std::f64::consts::PI))),
-    )
-}
-
-fn create_offset<const N: usize, R: Rng>(rng: &mut R) -> Cartesian<N> {
-    rng.random::<Cartesian<N>>() * 10.0
+fn sample_offset<const N: usize, R: Rng>(rng: &mut R, r_min: f64, r_max: f64) -> Cartesian<N> {
+    loop {
+        let v = rng.random::<Cartesian<N>>() * r_max;
+        let v_norm = v.norm();
+        if v_norm >= r_min && v_norm < r_max {
+            break v;
+        }
+    }
 }
 fn create_offset_3d<R: Rng>(rng: &mut R) -> (Cartesian<3>, Versor) {
     (rng.random::<Cartesian<3>>() * 10.0, rng.random())
@@ -173,46 +71,40 @@ mod sphere {
     #[divan::bench(consts = DIMENSIONS)]
     fn fast_nd<const N: usize>(bencher: Bencher) {
         let mut rng = StdRng::seed_from_u64(1);
+        let shape = Hypersphere::<N> {
+            radius: 0.5.try_into().expect("hard-coded value is positive"),
+        };
 
         bencher
             .counter(ItemsCount::from(1_u32))
-            .with_inputs(|| {
-                (
-                    create_sphere_pair::<N, _>(&mut rng),
-                    create_offset::<N, _>(&mut rng),
-                )
-            })
-            .bench_local_values(|((s0, s1), t)| black_box(s0.intersects(&s1, &t)));
+            .with_inputs(|| sample_offset::<N, _>(&mut rng, 0.9, 1.0))
+            .bench_local_values(|t| black_box(shape.intersects(&shape, &t)));
     }
 
     #[divan::bench]
     fn xenocollide_2d(bencher: Bencher) {
         let mut rng = StdRng::seed_from_u64(1);
+        let shape = Convex(Hypersphere::<2> {
+            radius: 0.5.try_into().expect("hard-coded value is positive"),
+        });
 
         bencher
             .counter(ItemsCount::from(1_u32))
-            .with_inputs(|| {
-                (
-                    shapes_to_convex(create_sphere_pair::<2, _>(&mut rng)),
-                    create_offset_2d(&mut rng),
-                )
-            })
-            .bench_local_values(|((s0, s1), (t, r))| black_box(collide2d(&s0, &s1, &t, &r)));
+            .with_inputs(|| sample_offset_angle(&mut rng, 0.9, 1.0))
+            .bench_local_values(|(t, r)| black_box(collide2d(&shape, &shape, &t, &r)));
     }
 
     #[divan::bench(sample_size = 10_000)]
     fn xenocollide_3d(bencher: Bencher) {
         let mut rng = StdRng::seed_from_u64(1);
+        let shape = Convex(Hypersphere::<3> {
+            radius: 0.5.try_into().expect("hard-coded value is positive"),
+        });
 
         bencher
             .counter(ItemsCount::from(1_u32))
-            .with_inputs(|| {
-                (
-                    shapes_to_convex(create_sphere_pair::<3, _>(&mut rng)),
-                    create_offset_3d(&mut rng),
-                )
-            })
-            .bench_local_values(|((s0, s1), (t, r))| black_box(collide3d(&s0, &s1, &t, &r)));
+            .with_inputs(|| sample_offset_versor(&mut rng, 0.9, 1.0))
+            .bench_local_values(|(t, r)| black_box(collide3d(&shape, &shape, &t, &r)));
     }
 }
 
@@ -223,82 +115,67 @@ mod cuboid {
     #[divan::bench(consts = DIMENSIONS)]
     fn aligned_nd<const N: usize>(bencher: Bencher) {
         let mut rng = StdRng::seed_from_u64(1);
+        let shape = Hypercuboid::with_equal_edges(
+            0.5.try_into().expect("hard coded value should be positive"),
+        );
 
         bencher
             .counter(ItemsCount::from(1_u32))
-            .with_inputs(|| {
-                (
-                    create_cuboid_pair::<N, _>(&mut rng),
-                    create_offset::<N, _>(&mut rng),
-                )
-            })
-            .bench_local_values(|((s0, s1), t)| black_box(s0.intersects_aligned(&s1, &t)));
+            .with_inputs(|| sample_offset::<N, _>(&mut rng, 0.8, 1.5))
+            .bench_local_values(|t| black_box(shape.intersects_aligned(&shape, &t)));
     }
 
     #[divan::bench]
     fn xenocollide_2d(bencher: Bencher) {
         let mut rng = StdRng::seed_from_u64(1);
+        let shape = Convex(Hypercuboid::with_equal_edges(
+            0.5.try_into().expect("hard coded value should be positive"),
+        ));
 
         bencher
             .counter(ItemsCount::from(1_u32))
-            .with_inputs(|| {
-                (
-                    shapes_to_convex(create_cuboid_pair::<2, _>(&mut rng)),
-                    create_offset_2d(&mut rng),
-                )
-            })
-            .bench_local_values(|((c0, c1), (t, r))| black_box(c0.intersects_at(&c1, &t, &r)));
+            .with_inputs(|| sample_offset_angle(&mut rng, 0.8, 1.5))
+            .bench_local_values(|(t, r)| black_box(collide2d(&shape, &shape, &t, &r)));
     }
 
     #[divan::bench]
     fn xenocollide_3d(bencher: Bencher) {
         let mut rng = StdRng::seed_from_u64(1);
+        let shape = Convex(Hypercuboid::with_equal_edges(
+            0.5.try_into().expect("hard coded value should be positive"),
+        ));
 
         bencher
             .counter(ItemsCount::from(1_u32))
-            .with_inputs(|| {
-                (
-                    shapes_to_convex(create_cuboid_pair::<3, _>(&mut rng)),
-                    create_offset_3d(&mut rng),
-                )
-            })
-            .bench_local_values(|((c0, c1), (t, r))| black_box(c0.intersects_at(&c1, &t, &r)));
+            .with_inputs(|| sample_offset_versor(&mut rng, 0.8, 1.5))
+            .bench_local_values(|(t, r)| black_box(collide3d(&shape, &shape, &t, &r)));
     }
 }
 
 #[divan::bench_group()]
 mod polytopes {
-
     use super::*;
 
     #[divan::bench(consts = NUM_VERTICES)]
     fn polygon_2d<const N: usize>(bencher: Bencher) {
         let mut rng = StdRng::seed_from_u64(1);
+        let shape = Convex(ConvexPolytope::<2>::regular(N));
 
         bencher
             .counter(ItemsCount::from(1_u32))
-            .with_inputs(|| {
-                (
-                    shapes_to_convex(create_polygon_pair::<N>()),
-                    create_offset_2d(&mut rng),
-                )
-            })
-            .bench_local_values(|((p0, p1), (t, r))| black_box(collide2d(&p0, &p1, &t, &r)));
+            .with_inputs(|| sample_offset_angle(&mut rng, 0.9, 1.0))
+            .bench_local_values(|(t, r)| black_box(collide2d(&shape, &shape, &t, &r)));
     }
 
     #[divan::bench(consts = DIPYRAMID_VERTICES)]
     fn dipyramid_3d<const N: usize>(bencher: Bencher) {
         let mut rng = StdRng::seed_from_u64(1);
+        let shape = Convex(create_dipyramid(N));
 
         bencher
             .counter(ItemsCount::from(1_u32))
-            .with_inputs(|| {
-                (
-                    shapes_to_convex(create_dipyramid_pair::<N, _>(&mut rng, 10.0)),
-                    create_offset_3d(&mut rng),
-                )
-            })
-            .bench_local_values(|((p0, p1), (t, r))| black_box(collide3d(&p0, &p1, &t, &r)));
+            .with_inputs(|| create_offset_3d(&mut rng))
+            .bench_local_values(|(t, r)| black_box(collide3d(&shape, &shape, &t, &r)));
     }
 }
 
@@ -309,26 +186,33 @@ mod simplex {
     #[divan::bench]
     fn xenocollide_3d(bencher: Bencher) {
         let mut rng = StdRng::seed_from_u64(1);
+        let shape = Convex(Simplex3::from([
+            Cartesian::from([-0.5, -0.5, -0.5]),
+            [-0.5, -0.5, 0.5].into(),
+            [-0.5, 0.5, 0.5].into(),
+            [0.5, 0.5, 0.5].into(),
+        ]));
 
         bencher
             .counter(ItemsCount::from(1_u32))
-            .with_inputs(|| {
-                (
-                    shapes_to_convex(create_simplex_pair(&mut rng)),
-                    create_offset_3d(&mut rng),
-                )
-            })
-            .bench_local_values(|((t0, t1), (t, r))| black_box(collide3d(&t0, &t1, &t, &r)));
+            .with_inputs(|| sample_offset_versor(&mut rng, 0.8, 1.5))
+            .bench_local_values(|(t, r)| black_box(collide3d(&shape, &shape, &t, &r)));
     }
 
     #[divan::bench]
     fn fast_3d(bencher: Bencher) {
         let mut rng = StdRng::seed_from_u64(1);
+        let shape = Simplex3::from([
+            Cartesian::from([-0.5, -0.5, -0.5]),
+            [-0.5, -0.5, 0.5].into(),
+            [-0.5, 0.5, 0.5].into(),
+            [0.5, 0.5, 0.5].into(),
+        ]);
 
         bencher
             .counter(ItemsCount::from(1_u32))
-            .with_inputs(|| (create_simplex_pair(&mut rng), create_offset_3d(&mut rng)))
-            .bench_local_values(|((t0, t1), (t, r))| black_box(t0.intersects_at(&t1, &t, &r)));
+            .with_inputs(|| sample_offset_versor(&mut rng, 0.8, 1.5))
+            .bench_local_values(|(t, r)| black_box(shape.intersects_at(&shape, &t, &r)));
     }
 }
 
@@ -339,46 +223,48 @@ mod ellipsoid {
     #[divan::bench]
     fn xenocollide_2d(bencher: Bencher) {
         let mut rng = StdRng::seed_from_u64(1);
+        let shape = Convex(Hyperellipsoid::<2>::with_semi_axes([
+            0.5.try_into().expect("hard-coded value should be positive"),
+            0.25.try_into()
+                .expect("hard-coded value should be positive"),
+        ]));
 
         bencher
             .counter(ItemsCount::from(1_u32))
-            .with_inputs(|| {
-                (
-                    shapes_to_convex(create_ellipsoid_pair::<2, _>(&mut rng)),
-                    create_offset_2d(&mut rng),
-                )
-            })
-            .bench_local_values(|((t0, t1), (t, r))| black_box(collide2d(&t0, &t1, &t, &r)));
+            .with_inputs(|| sample_offset_angle(&mut rng, 0.4, 1.0))
+            .bench_local_values(|(t, r)| black_box(collide2d(&shape, &shape, &t, &r)));
     }
 
     #[divan::bench]
     fn fast_2d(bencher: Bencher) {
         let mut rng = StdRng::seed_from_u64(1);
+        let shape = Hyperellipsoid::<2>::with_semi_axes([
+            0.5.try_into().expect("hard-coded value should be positive"),
+            0.25.try_into()
+                .expect("hard-coded value should be positive"),
+        ]);
 
         bencher
             .counter(ItemsCount::from(1_u32))
-            .with_inputs(|| {
-                (
-                    create_ellipsoid_pair::<2, _>(&mut rng),
-                    create_offset_2d(&mut rng),
-                )
-            })
-            .bench_local_values(|((e0, e1), (t, r))| black_box(e0.intersects_at(&e1, &t, &r)));
+            .with_inputs(|| sample_offset_angle(&mut rng, 0.4, 1.0))
+            .bench_local_values(|(t, r)| black_box(shape.intersects_at(&shape, &t, &r)));
     }
 
     #[divan::bench]
     fn xenocollide_3d(bencher: Bencher) {
         let mut rng = StdRng::seed_from_u64(1);
+        let shape = Hyperellipsoid::<3>::with_semi_axes([
+            0.5.try_into().expect("hard-coded value should be positive"),
+            0.25.try_into()
+                .expect("hard-coded value should be positive"),
+            0.25.try_into()
+                .expect("hard-coded value should be positive"),
+        ]);
 
         bencher
             .counter(ItemsCount::from(1_u32))
-            .with_inputs(|| {
-                (
-                    shapes_to_convex(create_ellipsoid_pair::<3, _>(&mut rng)),
-                    create_offset_3d(&mut rng),
-                )
-            })
-            .bench_local_values(|((t0, t1), (t, r))| black_box(collide3d(&t0, &t1, &t, &r)));
+            .with_inputs(|| sample_offset_versor(&mut rng, 0.4, 1.0))
+            .bench_local_values(|(t, r)| black_box(collide3d(&shape, &shape, &t, &r)));
     }
 }
 

--- a/hoomd-geometry/benches/overlaps.rs
+++ b/hoomd-geometry/benches/overlaps.rs
@@ -160,7 +160,7 @@ fn create_offset_3d<R: Rng>(rng: &mut R) -> (Cartesian<3>, Versor) {
 }
 
 const DIMENSIONS: &[usize] = &[2, 3, 4];
-const NUM_VERTICES: &[usize] = &[3, 4, 8, 16, 64, 256];
+const NUM_VERTICES: &[usize] = &[3, 4, 8, 16, 50];
 
 #[divan::bench_group]
 mod sphere {

--- a/hoomd-geometry/benches/overlaps.rs
+++ b/hoomd-geometry/benches/overlaps.rs
@@ -24,7 +24,7 @@ use rand::{Rng, RngExt, SeedableRng, rngs::StdRng};
 #[inline(never)]
 fn asm_collide3d() {
     let mut rng = StdRng::seed_from_u64(1);
-    let (p0, p1) = create_dipyramid_pair::<4, _>(&mut rng, 10.0);
+    let (p0, p1) = create_dipyramid_pair::<4, 6, _>(&mut rng, 10.0);
     let (t, r) = create_offset_3d(&mut rng);
     collide3d(&p0, &p1, &t, &r);
 }
@@ -91,13 +91,13 @@ fn create_simplex_pair<R: Rng>(rng: &mut R) -> (Simplex3, Simplex3) {
     )
 }
 /// Create a pair of N-dipyramids with random half-heights between 0 and `h_max`
-fn create_dipyramid_pair<const N: usize, R: Rng>(
+fn create_dipyramid_pair<const N: usize, const MAX: usize, R: Rng>(
     rng: &mut R,
     h_max: f64,
-) -> (ConvexPolytope<3>, ConvexPolytope<3>) {
-    let base = ConvexPolytope::<2>::regular(N);
+) -> (ConvexPolytope<3, MAX>, ConvexPolytope<3, MAX>) {
+    let base = ConvexPolytope::<2, N>::regular(N);
     (
-        ConvexPolytope::<3>::with_vertices(
+        ConvexPolytope::<3, MAX>::with_vertices(
             base.vertices()
                 .iter()
                 .map(|x| Cartesian::from([x[0], x[1], 0.0]))
@@ -107,7 +107,7 @@ fn create_dipyramid_pair<const N: usize, R: Rng>(
                 ]),
         )
         .unwrap(),
-        ConvexPolytope::<3>::with_vertices(
+        ConvexPolytope::<3, MAX>::with_vertices(
             base.vertices()
                 .iter()
                 .map(|x| Cartesian::from([x[0], x[1], 0.0]))
@@ -120,8 +120,11 @@ fn create_dipyramid_pair<const N: usize, R: Rng>(
     )
 }
 
-fn create_polygon_pair<const N: usize>() -> (ConvexPolytope<2>, ConvexPolytope<2>) {
-    (ConvexPolytope::regular(N), ConvexPolytope::regular(N))
+fn create_polygon_pair<const N: usize>() -> (ConvexPolytope<2, N>, ConvexPolytope<2, N>) {
+    (
+        ConvexPolytope::<2, N>::regular(N),
+        ConvexPolytope::<2, N>::regular(N),
+    )
 }
 
 fn create_ellipsoid_pair<const N: usize, R: Rng>(
@@ -290,7 +293,7 @@ mod polytopes {
             .counter(ItemsCount::from(1_u32))
             .with_inputs(|| {
                 (
-                    shapes_to_convex(create_dipyramid_pair::<N, _>(&mut rng, 10.0)),
+                    shapes_to_convex(create_dipyramid_pair::<N, 52, _>(&mut rng, 10.0)),
                     create_offset_3d(&mut rng),
                 )
             })

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -308,13 +308,13 @@ mod tests {
             let mut vertices1: Vec<Cartesian<2>> = (0..30)
                 .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
                 .collect();
-            assert!(hull_2d_grahamscan(&mut vertices1));
+            hull_2d_grahamscan(&mut vertices1).unwrap();
 
             let mut rng = StdRng::seed_from_u64(123);
             let mut vertices2: Vec<Cartesian<2>> = (0..30)
                 .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
                 .collect();
-            assert!(hull_2d_grahamscan(&mut vertices2));
+            hull_2d_grahamscan(&mut vertices2).unwrap();
 
             assert_eq!(vertices1.len(), vertices2.len());
         }

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -174,20 +174,35 @@ mod tests {
         hull_2d_grahamscan(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 4);
 
-        let hull = [[0.0, 0.0].into(), [1.0, 0.0].into(), [1.0, 1.0].into(), [0.0, 1.0].into()];
+        let hull = [
+            [0.0, 0.0].into(),
+            [1.0, 0.0].into(),
+            [1.0, 1.0].into(),
+            [0.0, 1.0].into(),
+        ];
         itertools::assert_equal(&vertices, &hull);
     }
 
     #[rstest]
     fn test_square_corners_big() {
-        let mut vertices: Vec<Cartesian<2>> = vec![[101.0, 101.0], [101.0, 100.0], [100.0, 101.0], [100.0, 100.0]]
-            .into_iter()
-            .map(Cartesian::from)
-            .collect();
+        let mut vertices: Vec<Cartesian<2>> = vec![
+            [101.0, 101.0],
+            [101.0, 100.0],
+            [100.0, 101.0],
+            [100.0, 100.0],
+        ]
+        .into_iter()
+        .map(Cartesian::from)
+        .collect();
         hull_2d_grahamscan(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 4);
 
-        let hull = [[100.0, 100.0].into(), [101.0, 100.0].into(), [101.0, 101.0].into(), [100.0, 101.0].into()];
+        let hull = [
+            [100.0, 100.0].into(),
+            [101.0, 100.0].into(),
+            [101.0, 101.0].into(),
+            [100.0, 101.0].into(),
+        ];
         itertools::assert_equal(&vertices, &hull);
     }
 
@@ -209,7 +224,12 @@ mod tests {
         hull_2d_grahamscan(&mut vertices).unwrap();
         // Hull should have 4 corners (interior edge points excluded)
         assert_eq!(vertices.len(), 4);
-        let hull = [[0.0, 0.0].into(), [1.0, 0.0].into(), [1.0, 1.0].into(), [0.0, 1.0].into()];
+        let hull = [
+            [0.0, 0.0].into(),
+            [1.0, 0.0].into(),
+            [1.0, 1.0].into(),
+            [0.0, 1.0].into(),
+        ];
         itertools::assert_equal(&vertices, &hull);
     }
 
@@ -236,7 +256,12 @@ mod tests {
         hull_2d_grahamscan(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 4);
 
-        let hull = [[0.0, 0.0].into(), [1.0, 0.0].into(), [1.0, 1.0].into(), [0.0, 1.0].into()];
+        let hull = [
+            [0.0, 0.0].into(),
+            [1.0, 0.0].into(),
+            [1.0, 1.0].into(),
+            [0.0, 1.0].into(),
+        ];
         itertools::assert_equal(&vertices, &hull);
     }
 
@@ -350,7 +375,12 @@ mod tests {
         hull_2d_grahamscan(&mut vertices).unwrap();
         assert!(vertices.len() >= 3);
 
-        let hull = [[0.0, 0.0].into(), [1.0, 0.0].into(), [1.0, 1.0].into(), [0.0, 1.0].into()];
+        let hull = [
+            [0.0, 0.0].into(),
+            [1.0, 0.0].into(),
+            [1.0, 1.0].into(),
+            [0.0, 1.0].into(),
+        ];
         itertools::assert_equal(&vertices, &hull);
     }
 
@@ -443,7 +473,12 @@ mod tests {
         // Should only keep furthest point in each direction
         assert!(vertices.len() >= 3);
 
-        let hull = [[0.0, 0.0].into(), [1.0, 0.0].into(), [3.0, 3.0].into(), [0.0, 1.0].into()];
+        let hull = [
+            [0.0, 0.0].into(),
+            [1.0, 0.0].into(),
+            [3.0, 3.0].into(),
+            [0.0, 1.0].into(),
+        ];
         itertools::assert_equal(&vertices, &hull);
     }
 
@@ -508,7 +543,12 @@ mod tests {
         hull_2d_grahamscan(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 4);
 
-        let hull = [[-1.0, -1.0].into(), [1.0, -1.0].into(), [1.0, 1.0].into(), [-1.0, 1.0].into()];
+        let hull = [
+            [-1.0, -1.0].into(),
+            [1.0, -1.0].into(),
+            [1.0, 1.0].into(),
+            [-1.0, 1.0].into(),
+        ];
         itertools::assert_equal(&vertices, &hull);
     }
 
@@ -521,7 +561,12 @@ mod tests {
         hull_2d_grahamscan(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 4);
 
-        let hull = [[0.0, 0.0].into(), [1e6, 0.0].into(), [1e6, 1e6].into(), [0.0, 1e6].into()];
+        let hull = [
+            [0.0, 0.0].into(),
+            [1e6, 0.0].into(),
+            [1e6, 1e6].into(),
+            [0.0, 1e6].into(),
+        ];
         itertools::assert_equal(&vertices, &hull);
     }
 }

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -1,0 +1,24 @@
+use crate::Error;
+use hoomd_vector::Cartesian;
+
+struct _SortKey {
+    angle: f64,
+    distance: f64,
+}
+
+/// Find the lowest, leftmost point from a slice of Cartesian vectors.
+fn _find_lowest_leftmost(vertices: &[Cartesian<2>]) -> (i32, Cartesian<2>) {
+    vertices.iter().enumerate().fold(
+        (-1, Cartesian::from([f64::INFINITY, f64::INFINITY])),
+        |(i, v), lowest_leftmost| (i, v),
+    )
+}
+
+/// Compute the convex hull of points in two dimensions using a Graham scan.
+/// # Errors
+///
+/// `[Error::PolytopeNotConvex]` when the provided vertices do not form a convex set.
+pub fn hull_2d_grahamscan<I>(vertices: Vec<Cartesian<2>>) -> Result<bool, Error> {
+    // vertices.sort_by(|a, b| {});
+    Ok(true)
+}

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -90,10 +90,12 @@ pub fn hull_2d_grahamscan(vertices: &mut Vec<Cartesian<2>>) -> bool {
         return true;
     }
 
-    // Now vertices[..2] is an edge on the hull
+    // Now vertices[..2] is an edge on the hull. Initialize counters for the hull length
+    // and number of vertices on the hull
     let mut n_vertices_on_hull = 2;
     let mut next_candidate = 2;
 
+    // Repeat until all interior points are gone
     while next_candidate < vertices.len() {
         let c = vertices[next_candidate];
         while n_vertices_on_hull >= 2 {

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -1,9 +1,7 @@
 // Copyright (c) 2024-2026 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-use crate::Error;
 use hoomd_vector::{Cartesian, InnerProduct};
-use itertools::Itertools;
 
 /// Find the lowest, leftmost point from a slice of Cartesian vectors.
 #[inline]
@@ -63,19 +61,19 @@ fn predicate_orient2d(edge: (Cartesian<2>, Cartesian<2>), test: Cartesian<2>) ->
 
 /// Compute the convex hull of points in two dimensions using a Graham scan.
 ///
-/// Takes ownership of the input vector and returns the hull vertices.
-/// The input is sorted and rearranged in-place, then truncated to the hull size.
+/// Mutates the input vector in-place, rearranging and truncating to contain
+/// only the hull vertices.
 ///
-/// # Errors
+/// # Returns
 ///
-/// `[Error::PolytopeNotConvex]` when the provided vertices do not form a convex set.
+/// `true` if the hull was computed, `false` if the input was empty.
 #[inline]
-pub fn hull_2d_grahamscan(mut vertices: Vec<Cartesian<2>>) -> Option<Vec<Cartesian<2>>> {
+pub fn hull_2d_grahamscan(vertices: &mut Vec<Cartesian<2>>) -> bool {
     if vertices.is_empty() {
-        return None;
+        return false;
     }
 
-    let (anchor_idx, anchor) = find_lowest_leftmost(&vertices);
+    let (anchor_idx, _) = find_lowest_leftmost(vertices);
 
     // Move the anchor to the front of the list of vertices, as it is always in the hull
     vertices.swap(0, anchor_idx);
@@ -89,7 +87,7 @@ pub fn hull_2d_grahamscan(mut vertices: Vec<Cartesian<2>>) -> Option<Vec<Cartesi
     });
 
     if vertices.len() < 3 {
-        return Some(vertices);
+        return true;
     }
 
     // Now vertices[..2] is an edge on the hull
@@ -116,7 +114,7 @@ pub fn hull_2d_grahamscan(mut vertices: Vec<Cartesian<2>>) -> Option<Vec<Cartesi
     }
 
     vertices.truncate(n_vertices_on_hull);
-    Some(vertices)
+    true
 }
 
 #[cfg(test)]
@@ -167,12 +165,12 @@ mod tests {
             .into_iter()
             .map(Cartesian::from)
             .collect();
-        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
-        assert_eq!(hull.len(), 4);
+        assert!(hull_2d_grahamscan(&mut vertices));
+        assert_eq!(vertices.len(), 4);
         // Check all corners are in hull
         let corners = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];
         for corner in corners {
-            assert!(hull_contains(&hull, corner, 1e-10));
+            assert!(hull_contains(&vertices, corner, 1e-10));
         }
     }
 
@@ -191,12 +189,12 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
+        assert!(hull_2d_grahamscan(&mut vertices));
         // Hull should have 4 corners (interior edge points excluded)
-        assert_eq!(hull.len(), 4);
+        assert_eq!(vertices.len(), 4);
         let corners = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];
         for corner in corners {
-            assert!(hull_contains(&hull, corner, 1e-10));
+            assert!(hull_contains(&vertices, corner, 1e-10));
         }
     }
 
@@ -220,8 +218,8 @@ mod tests {
             pts.push([0.0, i as f64 / 19.0]);
         }
         let mut vertices: Vec<Cartesian<2>> = pts.into_iter().map(Cartesian::from).collect();
-        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
-        assert_eq!(hull.len(), 4);
+        assert!(hull_2d_grahamscan(&mut vertices));
+        assert_eq!(vertices.len(), 4);
     }
 
     #[rstest]
@@ -233,9 +231,9 @@ mod tests {
                 Cartesian::from([angle.cos(), angle.sin()])
             })
             .collect();
-        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
+        assert!(hull_2d_grahamscan(&mut vertices));
         // All points on circle should be in hull
-        assert_eq!(hull.len(), n);
+        assert_eq!(vertices.len(), n);
     }
 
     #[rstest]
@@ -249,9 +247,9 @@ mod tests {
             .collect();
         // Add interior points
         vertices.extend([[0.0, 0.0], [0.3, 0.3], [-0.2, 0.1], [0.1, -0.4]].map(Cartesian::from));
-        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
+        assert!(hull_2d_grahamscan(&mut vertices));
         // Only boundary points should be in hull
-        assert_eq!(hull.len(), n_boundary);
+        assert_eq!(vertices.len(), n_boundary);
     }
 
     #[rstest]
@@ -263,9 +261,9 @@ mod tests {
                 Cartesian::from([angle.cos(), angle.sin()])
             })
             .collect();
-        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
+        assert!(hull_2d_grahamscan(&mut vertices));
         // All points on partial arc should be in hull
-        assert_eq!(hull.len(), 10);
+        assert_eq!(vertices.len(), 10);
     }
 
     #[rstest]
@@ -275,11 +273,11 @@ mod tests {
             .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
             .collect();
         let mut vertices = original.clone();
-        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
+        assert!(hull_2d_grahamscan(&mut vertices));
         // Hull should have at least 3 points
-        assert!(hull.len() >= 3);
+        assert!(vertices.len() >= 3);
         // All hull points should be in original set
-        for h in &hull {
+        for h in &vertices {
             assert!(original.iter().any(|v| (*v - *h).norm() < 1e-10));
         }
     }
@@ -295,26 +293,26 @@ mod tests {
                 ])
             })
             .collect();
-        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
-        assert!(hull.len() >= 3);
+        assert!(hull_2d_grahamscan(&mut vertices));
+        assert!(vertices.len() >= 3);
     }
 
     #[rstest]
     fn test_random_deterministic_output() {
         for _ in 0..3 {
             let mut rng = StdRng::seed_from_u64(123);
-            let vertices1: Vec<Cartesian<2>> = (0..30)
+            let mut vertices1: Vec<Cartesian<2>> = (0..30)
                 .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
                 .collect();
-            let hull1 = hull_2d_grahamscan(vertices1).expect("hull should exist");
+            assert!(hull_2d_grahamscan(&mut vertices1));
 
             let mut rng = StdRng::seed_from_u64(123);
-            let vertices2: Vec<Cartesian<2>> = (0..30)
+            let mut vertices2: Vec<Cartesian<2>> = (0..30)
                 .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
                 .collect();
-            let hull2 = hull_2d_grahamscan(vertices2).expect("hull should exist");
+            assert!(hull_2d_grahamscan(&mut vertices2));
 
-            assert_eq!(hull1.len(), hull2.len());
+            assert_eq!(vertices1.len(), vertices2.len());
         }
     }
 
@@ -331,8 +329,8 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
-        assert!(hull.len() >= 3);
+        assert!(hull_2d_grahamscan(&mut vertices));
+        assert!(vertices.len() >= 3);
     }
 
     #[rstest]
@@ -350,9 +348,9 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
+        assert!(hull_2d_grahamscan(&mut vertices));
         // Should handle duplicates gracefully
-        assert!(hull.len() >= 3);
+        assert!(vertices.len() >= 3);
     }
 
     #[rstest]
@@ -367,9 +365,9 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
+        assert!(hull_2d_grahamscan(&mut vertices));
         // Should pick leftmost of bottom points and include apex
-        assert!(hull.len() >= 3);
+        assert!(vertices.len() >= 3);
     }
 
     #[rstest]
@@ -383,9 +381,9 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
+        assert!(hull_2d_grahamscan(&mut vertices));
         // [0, 0] should be the anchor point
-        assert!(hull_contains(&hull, [0.0, 0.0], 1e-10));
+        assert!(hull_contains(&vertices, [0.0, 0.0], 1e-10));
     }
 
     #[rstest]
@@ -393,9 +391,9 @@ mod tests {
         let mut pts: Vec<[f64; 2]> = (0..10).map(|i| [i as f64 * 2.0 / 9.0, 0.0]).collect();
         pts.push([1.0, 1.0]); // Apex
         let mut vertices: Vec<Cartesian<2>> = pts.into_iter().map(Cartesian::from).collect();
-        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
+        assert!(hull_2d_grahamscan(&mut vertices));
         // Leftmost [0,0] and rightmost [2,0] should be in hull with apex
-        assert!(hull.len() >= 3);
+        assert!(vertices.len() >= 3);
     }
 
     #[rstest]
@@ -411,9 +409,9 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
+        assert!(hull_2d_grahamscan(&mut vertices));
         // Should only keep furthest point in each direction
-        assert!(hull.len() >= 3);
+        assert!(vertices.len() >= 3);
     }
 
     #[rstest]
@@ -434,9 +432,9 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
+        assert!(hull_2d_grahamscan(&mut vertices));
         // Should keep only outermost points
-        assert!(hull.len() >= 3);
+        assert!(vertices.len() >= 3);
     }
 
     #[rstest]
@@ -449,9 +447,9 @@ mod tests {
                 vertices.push(Cartesian::from([r * angle.cos(), r * angle.sin()]));
             }
         }
-        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
+        assert!(hull_2d_grahamscan(&mut vertices));
         // Outer points should form the hull
-        assert!(hull.len() >= 8); // At least 8 outer points
+        assert!(vertices.len() >= 8); // At least 8 outer points
     }
 
     #[rstest]
@@ -460,8 +458,8 @@ mod tests {
             .into_iter()
             .map(Cartesian::from)
             .collect();
-        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
-        assert_eq!(hull.len(), 3);
+        assert!(hull_2d_grahamscan(&mut vertices));
+        assert_eq!(vertices.len(), 3);
     }
 
     #[rstest]
@@ -471,8 +469,8 @@ mod tests {
                 .into_iter()
                 .map(Cartesian::from)
                 .collect();
-        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
-        assert_eq!(hull.len(), 4);
+        assert!(hull_2d_grahamscan(&mut vertices));
+        assert_eq!(vertices.len(), 4);
     }
 
     #[rstest]
@@ -481,7 +479,7 @@ mod tests {
             .into_iter()
             .map(Cartesian::from)
             .collect();
-        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
-        assert_eq!(hull.len(), 4);
+        assert!(hull_2d_grahamscan(&mut vertices));
+        assert_eq!(vertices.len(), 4);
     }
 }

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -24,7 +24,7 @@ fn find_lowest_leftmost(vertices: &[Cartesian<2>]) -> (usize, Cartesian<2>) {
 
 /// Get the key for a lexographical sort of points with respect to an anchor.
 #[inline]
-fn get_graham_key(p: Cartesian<2>, anchor: Cartesian<2>) -> (f64, f64) {
+pub fn get_graham_key(p: Cartesian<2>, anchor: Cartesian<2>) -> (f64, f64) {
     let diff = p - anchor;
     (f64::atan2(diff[1], diff[0]), diff.dot(&diff))
 }
@@ -82,7 +82,7 @@ pub fn hull_2d_grahamscan(vertices: &mut [Cartesian<2>]) -> Option<Vec<Cartesian
         a0.total_cmp(&b0).then(a1.total_cmp(&b1))
     });
 
-    // TODO: no allocation
+    // TODO: no allocation - swap remove? Ideally move unwanted to end and then truncate
     let mut angle_order = vertices[1..].iter().copied().collect::<VecDeque<_>>();
 
     // The anchor and the first vertex in the sorted list are always on the hull

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -22,15 +22,7 @@ fn find_lowest_leftmost(vertices: &[Cartesian<2>]) -> (usize, Cartesian<2>) {
     )
 }
 
-#[derive(Debug, PartialEq, PartialOrd)]
-/// Helper struct for ordering points with respect to an anchor.
-struct SortKey {
-    /// The angle a point makes with another.
-    angle: f64,
-    /// The distance of the point from the reference.
-    distance: f64,
-}
-
+/// Get the key for a lexographical sort of points with respect to an anchor.
 #[inline]
 fn get_graham_key(p: Cartesian<2>, anchor: Cartesian<2>) -> (f64, f64) {
     let diff = p - anchor;

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -72,7 +72,7 @@ fn predicate_orient2d(edge: (Cartesian<2>, Cartesian<2>), test: Cartesian<2>) ->
 /// # Errors
 ///
 /// `[Error::PolytopeNotConvex]` when the provided vertices do not form a convex set.
-pub fn hull_2d_grahamscan<I>(vertices: &mut [Cartesian<2>]) -> Option<Vec<Cartesian<2>>> {
+pub fn hull_2d_grahamscan(vertices: &mut [Cartesian<2>]) -> Option<Vec<Cartesian<2>>> {
     // vertices.sort_by(|a, b| {});
     let (anchor_idx, anchor) = find_lowest_leftmost(&vertices[..]);
 
@@ -113,7 +113,14 @@ pub fn hull_2d_grahamscan<I>(vertices: &mut [Cartesian<2>]) -> Option<Vec<Cartes
 mod tests {
     use super::*;
     use approxim::assert_relative_eq;
+    use rand::{RngExt, SeedableRng, rngs::StdRng};
     use rstest::*;
+
+    // Helper to check if a point is approximately in the hull
+    fn hull_contains(hull: &[Cartesian<2>], point: [f64; 2], tol: f64) -> bool {
+        hull.iter()
+            .any(|h| (h[0] - point[0]).abs() < tol && (h[1] - point[1]).abs() < tol)
+    }
 
     #[rstest]
     #[case::single_point(vec![[1.0, 2.0]], 0)]
@@ -142,5 +149,328 @@ mod tests {
         let (idx, point) = find_lowest_leftmost(&vertices);
         assert_eq!(idx, 0);
         assert_relative_eq!(point, Cartesian::from(coords));
+    }
+
+    #[rstest]
+    fn test_square_corners() {
+        let mut vertices: Vec<Cartesian<2>> = vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]]
+            .into_iter()
+            .map(Cartesian::from)
+            .collect();
+        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        assert_eq!(hull.len(), 4);
+        // Check all corners are in hull
+        for v in &vertices {
+            assert!(hull.iter().any(|h| (*h - *v).norm() < 1e-10));
+        }
+    }
+
+    #[rstest]
+    fn test_square_with_edge_points() {
+        let mut vertices: Vec<Cartesian<2>> = vec![
+            [0.0, 0.0],
+            [0.5, 0.0],
+            [1.0, 0.0], // bottom edge
+            [1.0, 0.5],
+            [1.0, 1.0], // right edge
+            [0.5, 1.0],
+            [0.0, 1.0], // top edge
+            [0.0, 0.5], // left edge
+        ]
+        .into_iter()
+        .map(Cartesian::from)
+        .collect();
+        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        // Hull should have 4 corners (interior edge points excluded)
+        assert_eq!(hull.len(), 4);
+        let corners = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];
+        for corner in corners {
+            assert!(hull_contains(&hull, corner, 1e-10));
+        }
+    }
+
+    #[rstest]
+    fn test_square_dense_boundary() {
+        let mut pts: Vec<[f64; 2]> = Vec::new();
+        // Bottom edge
+        for i in 0..20 {
+            pts.push([i as f64 / 19.0, 0.0]);
+        }
+        // Right edge
+        for i in 0..20 {
+            pts.push([1.0, i as f64 / 19.0]);
+        }
+        // Top edge
+        for i in 0..20 {
+            pts.push([i as f64 / 19.0, 1.0]);
+        }
+        // Left edge
+        for i in 0..20 {
+            pts.push([0.0, i as f64 / 19.0]);
+        }
+        let mut vertices: Vec<Cartesian<2>> = pts.into_iter().map(Cartesian::from).collect();
+        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        assert_eq!(hull.len(), 4);
+    }
+
+    #[rstest]
+    fn test_circle_uniform() {
+        let n = 20;
+        let mut vertices: Vec<Cartesian<2>> = (0..n)
+            .map(|i| {
+                let angle = 2.0 * std::f64::consts::PI * i as f64 / n as f64;
+                Cartesian::from([angle.cos(), angle.sin()])
+            })
+            .collect();
+        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        // All points on circle should be in hull
+        assert_eq!(hull.len(), n);
+    }
+
+    #[rstest]
+    fn test_circle_with_interior_points() {
+        let n_boundary = 12;
+        let mut vertices: Vec<Cartesian<2>> = (0..n_boundary)
+            .map(|i| {
+                let angle = 2.0 * std::f64::consts::PI * i as f64 / n_boundary as f64;
+                Cartesian::from([angle.cos(), angle.sin()])
+            })
+            .collect();
+        // Add interior points
+        vertices.extend([[0.0, 0.0], [0.3, 0.3], [-0.2, 0.1], [0.1, -0.4]].map(Cartesian::from));
+        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        // Only boundary points should be in hull
+        assert_eq!(hull.len(), n_boundary);
+    }
+
+    #[rstest]
+    fn test_circle_partial_arc() {
+        let mut vertices: Vec<Cartesian<2>> = (0..10)
+            .map(|i| {
+                let angle =
+                    -std::f64::consts::FRAC_PI_4 + (std::f64::consts::FRAC_PI_2 * i as f64 / 9.0);
+                Cartesian::from([angle.cos(), angle.sin()])
+            })
+            .collect();
+        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        // All points on partial arc should be in hull
+        assert_eq!(hull.len(), 10);
+    }
+
+    #[rstest]
+    fn test_random_unit_square(#[values(0, 42, 64, 100_000)] seed: u64) {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let original: Vec<Cartesian<2>> = (0..50)
+            .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
+            .collect();
+        let mut vertices = original.clone();
+        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        // Hull should have at least 3 points
+        assert!(hull.len() >= 3);
+        // All hull points should be in original set
+        for h in &hull {
+            assert!(original.iter().any(|v| (*v - *h).norm() < 1e-10));
+        }
+    }
+
+    #[rstest]
+    fn test_random_gaussian() {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut vertices: Vec<Cartesian<2>> = (0..100)
+            .map(|_| {
+                Cartesian::from([
+                    rng.random::<f64>() * 2.0 - 1.0,
+                    rng.random::<f64>() * 2.0 - 1.0,
+                ])
+            })
+            .collect();
+        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        assert!(hull.len() >= 3);
+    }
+
+    #[rstest]
+    fn test_random_deterministic_output() {
+        for _ in 0..3 {
+            let mut rng = StdRng::seed_from_u64(123);
+            let mut vertices1: Vec<Cartesian<2>> = (0..30)
+                .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
+                .collect();
+            let hull1 = hull_2d_grahamscan(&mut vertices1).expect("hull should exist");
+
+            let mut rng = StdRng::seed_from_u64(123);
+            let mut vertices2: Vec<Cartesian<2>> = (0..30)
+                .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
+                .collect();
+            let hull2 = hull_2d_grahamscan(&mut vertices2).expect("hull should exist");
+
+            assert_eq!(hull1.len(), hull2.len());
+        }
+    }
+
+    #[rstest]
+    fn test_duplicate_lowest_points() {
+        let mut vertices: Vec<Cartesian<2>> = vec![
+            [0.0, 0.0],
+            [0.0, 0.0],
+            [0.0, 0.0], // Three duplicates of lowest
+            [1.0, 0.0],
+            [1.0, 1.0],
+            [0.0, 1.0],
+        ]
+        .into_iter()
+        .map(Cartesian::from)
+        .collect();
+        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        assert!(hull.len() >= 3);
+    }
+
+    #[rstest]
+    fn test_many_duplicates_few_unique() {
+        let mut vertices: Vec<Cartesian<2>> = vec![
+            [0.0, 0.0],
+            [0.0, 0.0],
+            [0.0, 0.0],
+            [2.0, 0.0],
+            [2.0, 0.0],
+            [1.0, 2.0],
+            [1.0, 2.0],
+            [1.0, 2.0],
+        ]
+        .into_iter()
+        .map(Cartesian::from)
+        .collect();
+        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        // Should handle duplicates gracefully
+        assert!(hull.len() >= 3);
+    }
+
+    #[rstest]
+    fn test_collinear_bottom_edge() {
+        let mut vertices: Vec<Cartesian<2>> = vec![
+            [0.0, 0.0],
+            [0.5, 0.0],
+            [1.0, 0.0],
+            [1.5, 0.0],  // All at y=0
+            [0.75, 1.0], // Apex
+        ]
+        .into_iter()
+        .map(Cartesian::from)
+        .collect();
+        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        // Should pick leftmost of bottom points and include apex
+        assert!(hull.len() >= 3);
+    }
+
+    #[rstest]
+    fn test_leftmost_selected() {
+        let mut vertices: Vec<Cartesian<2>> = vec![
+            [0.5, 0.0],
+            [1.0, 0.0],
+            [0.0, 0.0], // All y=0, but [0,0] is leftmost
+            [0.5, 1.0],
+        ]
+        .into_iter()
+        .map(Cartesian::from)
+        .collect();
+        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        // [0, 0] should be the anchor point
+        assert!(hull_contains(&hull, [0.0, 0.0], 1e-10));
+    }
+
+    #[rstest]
+    fn test_many_bottom_points() {
+        let mut pts: Vec<[f64; 2]> = (0..10).map(|i| [i as f64 * 2.0 / 9.0, 0.0]).collect();
+        pts.push([1.0, 1.0]); // Apex
+        let mut vertices: Vec<Cartesian<2>> = pts.into_iter().map(Cartesian::from).collect();
+        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        // Leftmost [0,0] and rightmost [2,0] should be in hull with apex
+        assert!(hull.len() >= 3);
+    }
+
+    #[rstest]
+    fn test_collinear_from_anchor() {
+        let mut vertices: Vec<Cartesian<2>> = vec![
+            [0.0, 0.0], // Anchor (lowest leftmost)
+            [1.0, 1.0],
+            [2.0, 2.0],
+            [3.0, 3.0], // Collinear at 45 degrees
+            [1.0, 0.0],
+            [0.0, 1.0], // Other corners
+        ]
+        .into_iter()
+        .map(Cartesian::from)
+        .collect();
+        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        // Should only keep furthest point in each direction
+        assert!(hull.len() >= 3);
+    }
+
+    #[rstest]
+    fn test_radial_collinear_multiple_directions() {
+        let mut vertices: Vec<Cartesian<2>> = vec![
+            [0.0, 0.0], // Anchor
+            [1.0, 0.0],
+            [2.0, 0.0],
+            [3.0, 0.0], // Along x-axis
+            [0.0, 1.0],
+            [0.0, 2.0],
+            [0.0, 3.0], // Along y-axis
+            [1.0, 1.0],
+            [2.0, 2.0], // Diagonal
+            [-1.0, 0.0],
+            [-2.0, 0.0], // Negative x-axis (but won't be picked due to anchor)
+        ]
+        .into_iter()
+        .map(Cartesian::from)
+        .collect();
+        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        // Should keep only outermost points
+        assert!(hull.len() >= 3);
+    }
+
+    #[rstest]
+    fn test_star_pattern() {
+        let mut vertices: Vec<Cartesian<2>> = vec![Cartesian::from([0.0, 0.0])]; // Anchor
+        // Create points along 8 rays
+        for i in 0..8 {
+            let angle = 2.0 * std::f64::consts::PI * i as f64 / 8.0;
+            for r in [0.5, 1.0, 1.5] {
+                vertices.push(Cartesian::from([r * angle.cos(), r * angle.sin()]));
+            }
+        }
+        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        // Outer points should form the hull
+        assert!(hull.len() >= 8); // At least 8 outer points
+    }
+
+    #[rstest]
+    fn test_minimum_triangle() {
+        let mut vertices: Vec<Cartesian<2>> = vec![[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]]
+            .into_iter()
+            .map(Cartesian::from)
+            .collect();
+        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        assert_eq!(hull.len(), 3);
+    }
+
+    #[rstest]
+    fn test_negative_coordinates() {
+        let mut vertices: Vec<Cartesian<2>> =
+            vec![[-1.0, -1.0], [1.0, -1.0], [1.0, 1.0], [-1.0, 1.0]]
+                .into_iter()
+                .map(Cartesian::from)
+                .collect();
+        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        assert_eq!(hull.len(), 4);
+    }
+
+    #[rstest]
+    fn test_large_coordinates() {
+        let mut vertices: Vec<Cartesian<2>> = vec![[0.0, 0.0], [1e6, 0.0], [1e6, 1e6], [0.0, 1e6]]
+            .into_iter()
+            .map(Cartesian::from)
+            .collect();
+        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        assert_eq!(hull.len(), 4);
     }
 }

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -1,12 +1,11 @@
-use crate::Error;
-use hoomd_vector::Cartesian;
+use std::collections::VecDeque;
 
-struct _SortKey {
-    angle: f64,
-    distance: f64,
-}
+use crate::Error;
+use hoomd_vector::{Cartesian, InnerProduct};
+use itertools::Itertools;
 
 /// Find the lowest, leftmost point from a slice of Cartesian vectors.
+#[inline]
 fn find_lowest_leftmost(vertices: &[Cartesian<2>]) -> (usize, Cartesian<2>) {
     vertices.iter().enumerate().fold(
         (usize::MAX, Cartesian::from([f64::INFINITY, f64::INFINITY])),
@@ -20,14 +19,52 @@ fn find_lowest_leftmost(vertices: &[Cartesian<2>]) -> (usize, Cartesian<2>) {
     )
 }
 
+#[derive(Debug, PartialEq, PartialOrd)]
+/// Helper struct for ordering points with respect to an anchor.
+struct SortKey {
+    /// The angle a point makes with another.
+    angle: f64,
+    /// The distance of the point from the reference.
+    distance: f64,
+}
+
+#[inline]
+fn get_graham_key(p: Cartesian<2>, anchor: Cartesian<2>) -> (f64, f64) {
+    let diff = p - anchor;
+    (f64::atan2(diff[1], diff[0]), diff.dot(&diff))
+}
+
 /// Compute the convex hull of points in two dimensions using a Graham scan.
 /// # Errors
 ///
 /// `[Error::PolytopeNotConvex]` when the provided vertices do not form a convex set.
-pub fn hull_2d_grahamscan<I>(vertices: Vec<Cartesian<2>>) -> Result<bool, Error> {
+pub fn hull_2d_grahamscan<I>(vertices: &mut [Cartesian<2>]) -> Option<bool> {
     // vertices.sort_by(|a, b| {});
     let (anchor_idx, anchor) = find_lowest_leftmost(&vertices[..]);
-    Ok(true)
+
+    // Move the anchor to the front of the list of vertices, as it is always in the hull
+    vertices.swap(0, anchor_idx);
+    let anchor = vertices[0];
+
+    // Sort the remainder of the slice in-place
+    vertices[1..].sort_unstable_by(|&a, &b| {
+        let (a0, a1) = get_graham_key(a, anchor);
+        let (b0, b1) = get_graham_key(b, anchor);
+        a0.total_cmp(&b0).then(a1.total_cmp(&b1))
+    });
+
+    // TODO: no allocation
+    let mut angle_order = vertices[1..].iter().copied().collect::<VecDeque<_>>();
+
+    // The anchor and the first vertex in the sorted list are always on the hull
+    let hull_vertices= vec![anchor, angle_order.pop_front()?];
+
+    while !angle_order.is_empty() {
+        let c = angle_order.pop_front()
+        
+    }
+    Some(true)
+
 }
 
 #[cfg(test)]

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -67,6 +67,7 @@ fn predicate_orient2d(edge: (Cartesian<2>, Cartesian<2>), test: Cartesian<2>) ->
 /// # Errors
 ///
 /// `[Error::PolytopeNotConvex]` when the provided vertices do not form a convex set.
+#[inline]
 pub fn hull_2d_grahamscan(vertices: &mut [Cartesian<2>]) -> Option<Vec<Cartesian<2>>> {
     // vertices.sort_by(|a, b| {});
     let (anchor_idx, anchor) = find_lowest_leftmost(&vertices[..]);

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -42,6 +42,7 @@ pub fn get_graham_key(p: Cartesian<2>, anchor: Cartesian<2>) -> (f64, f64) {
 /// only ensure consistent behavior for related inputs.
 ///
 /// **Source:** [Robust Arithmetic in Computational Geometry](https://observablehq.com/@mourner/non-robust-arithmetic-as-art)
+#[inline]
 fn predicate_orient2d((p, q): (Cartesian<2>, Cartesian<2>), test: Cartesian<2>) -> i64 {
     let orientation = (p[0] * q[1] - p[1] * q[0])
         + (q[0] * test[1] - q[1] * test[0])

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -1,8 +1,6 @@
 // Copyright (c) 2024-2026 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-use std::collections::VecDeque;
-
 use crate::Error;
 use hoomd_vector::{Cartesian, InnerProduct};
 use itertools::Itertools;
@@ -82,41 +80,38 @@ pub fn hull_2d_grahamscan(vertices: &mut [Cartesian<2>]) -> Option<Vec<Cartesian
         let (b0, b1) = get_graham_key(b, anchor);
         a0.total_cmp(&b0).then(a1.total_cmp(&b1))
     });
+    // Handle degenerate cases
+    if vertices.len() < 3 {
+        return if vertices.is_empty() {
+            None
+        } else {
+            Some(vertices.to_vec())
+        };
+    }
+
     // Now vertices[..2] is an edge on the hull
     let mut n_vertices_on_hull = 2;
-    let mut n_vertices_total = vertices.len();
+    let mut next_candidate = 2;
 
-    // TODO: no allocation - swap remove? Ideally move unwanted to end and then truncate
-    // let mut angle_order = vertices[1..].iter().copied().collect::<VecDeque<_>>();
-
-    // The anchor and the first vertex in the sorted list are always on the hull
-    // let mut hull_vertices = vec![anchor, angle_order.pop_front()?];
-    // while !angle_order.is_empty() {
-    while n_vertices_on_hull < n_vertices_total {
-        // let c = angle_order.pop_front()?;
-        let c = vertices[n_vertices_on_hull]; // Next point in the sort
-        // while hull_vertices.len() >= 2 {
-        while n_vertices_total >= 2 {
-            // Backtrack while hull_indices[-1] is inside hull
-            // let &[p, n] = hull_vertices.last_chunk::<2>()?;
+    while next_candidate < vertices.len() {
+        let c = vertices[next_candidate];
+        while n_vertices_on_hull >= 2 {
             let p = vertices[n_vertices_on_hull - 2];
             let n = vertices[n_vertices_on_hull - 1];
 
             if predicate_orient2d((p, n), c) <= 0 {
-                // hull_vertices.pop(); // point n is inside the hull, so we remove it
-                // vertices.swap_remove(n_vertices_on_hull - 1)
-                vertices.swap(n_vertices_on_hull - 1, vertices.len() - 1);
-                n_vertices_total -= 1;
+                // Point n is inside the hull, remove it by shrinking the hull
+                n_vertices_on_hull -= 1;
             } else {
-                // n_vertices_on_hull += 1;
                 break;
             }
         }
-        // hull_vertices.push(c);
-        println!("{n_vertices_on_hull}");
+        // Swap candidate into hull position
+        vertices.swap(next_candidate, n_vertices_on_hull);
         n_vertices_on_hull += 1;
+        next_candidate += 1;
     }
-    Some(vertices.to_vec())
+    Some(vertices[..n_vertices_on_hull].to_vec())
 }
 
 #[cfg(test)]

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2024-2026 The Regents of the University of Michigan.
+// Part of hoomd-rs, released under the BSD 3-Clause License.
+
 use std::collections::VecDeque;
 
 use crate::Error;

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2024-2026 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
+use std::cmp::Ordering;
+
 use crate::Error;
 use hoomd_vector::{Cartesian, InnerProduct};
 use itertools::Itertools;
@@ -40,19 +42,16 @@ pub fn get_graham_key(p: Cartesian<2>, anchor: Cartesian<2>) -> (f64, f64) {
 /// only ensure consistent behavior for related inputs.
 ///
 /// **Source:** [Robust Arithmetic in Computational Geometry](https://observablehq.com/@mourner/non-robust-arithmetic-as-art)
-fn predicate_orient2d(edge: (Cartesian<2>, Cartesian<2>), test: Cartesian<2>) -> i64 {
-    let (p, q) = edge;
+fn predicate_orient2d((p, q): (Cartesian<2>, Cartesian<2>), test: Cartesian<2>) -> i64 {
     let orientation = (p[0] * q[1] - p[1] * q[0])
         + (q[0] * test[1] - q[1] * test[0])
         + (test[0] * p[1] - test[1] * p[0]);
-    if orientation > 0.0 {
-        // clockwise
-        return 1;
-    } else if orientation < 0.0 {
-        // counterclockwise
-        return -1;
+
+    match orientation.total_cmp(&0.0) {
+        Ordering::Greater => 1,
+        Ordering::Less => -1,
+        Ordering::Equal => 0,
     }
-    0
 }
 
 /// Compute the convex hull of points in two dimensions using a Graham scan.

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -167,17 +167,28 @@ mod tests {
 
     #[rstest]
     fn test_square_corners() {
-        let mut vertices: Vec<Cartesian<2>> = vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]]
+        let mut vertices: Vec<Cartesian<2>> = vec![[1.0, 1.0], [1.0, 0.0], [0.0, 0.0], [0.0, 1.0]]
             .into_iter()
             .map(Cartesian::from)
             .collect();
         hull_2d_grahamscan(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 4);
-        // Check all corners are in hull
-        let corners = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];
-        for corner in corners {
-            assert!(hull_contains(&vertices, corner, 1e-10));
-        }
+
+        let hull = [[0.0, 0.0].into(), [1.0, 0.0].into(), [1.0, 1.0].into(), [0.0, 1.0].into()];
+        itertools::assert_equal(&vertices, &hull);
+    }
+
+    #[rstest]
+    fn test_square_corners_big() {
+        let mut vertices: Vec<Cartesian<2>> = vec![[101.0, 101.0], [101.0, 100.0], [100.0, 101.0], [100.0, 100.0]]
+            .into_iter()
+            .map(Cartesian::from)
+            .collect();
+        hull_2d_grahamscan(&mut vertices).unwrap();
+        assert_eq!(vertices.len(), 4);
+
+        let hull = [[100.0, 100.0].into(), [101.0, 100.0].into(), [101.0, 101.0].into(), [100.0, 101.0].into()];
+        itertools::assert_equal(&vertices, &hull);
     }
 
     #[rstest]
@@ -198,10 +209,8 @@ mod tests {
         hull_2d_grahamscan(&mut vertices).unwrap();
         // Hull should have 4 corners (interior edge points excluded)
         assert_eq!(vertices.len(), 4);
-        let corners = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];
-        for corner in corners {
-            assert!(hull_contains(&vertices, corner, 1e-10));
-        }
+        let hull = [[0.0, 0.0].into(), [1.0, 0.0].into(), [1.0, 1.0].into(), [0.0, 1.0].into()];
+        itertools::assert_equal(&vertices, &hull);
     }
 
     #[rstest]
@@ -226,6 +235,9 @@ mod tests {
         let mut vertices: Vec<Cartesian<2>> = pts.into_iter().map(Cartesian::from).collect();
         hull_2d_grahamscan(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 4);
+
+        let hull = [[0.0, 0.0].into(), [1.0, 0.0].into(), [1.0, 1.0].into(), [0.0, 1.0].into()];
+        itertools::assert_equal(&vertices, &hull);
     }
 
     #[rstest]
@@ -337,6 +349,9 @@ mod tests {
         .collect();
         hull_2d_grahamscan(&mut vertices).unwrap();
         assert!(vertices.len() >= 3);
+
+        let hull = [[0.0, 0.0].into(), [1.0, 0.0].into(), [1.0, 1.0].into(), [0.0, 1.0].into()];
+        itertools::assert_equal(&vertices, &hull);
     }
 
     #[rstest]
@@ -357,6 +372,9 @@ mod tests {
         hull_2d_grahamscan(&mut vertices).unwrap();
         // Should handle duplicates gracefully
         assert!(vertices.len() >= 3);
+
+        let hull = [[0.0, 0.0].into(), [2.0, 0.0].into(), [1.0, 2.0].into()];
+        itertools::assert_equal(&vertices, &hull);
     }
 
     #[rstest]
@@ -374,6 +392,9 @@ mod tests {
         hull_2d_grahamscan(&mut vertices).unwrap();
         // Should pick leftmost of bottom points and include apex
         assert!(vertices.len() >= 3);
+
+        let hull = [[0.0, 0.0].into(), [1.5, 0.0].into(), [0.75, 1.0].into()];
+        itertools::assert_equal(&vertices, &hull);
     }
 
     #[rstest]
@@ -390,6 +411,9 @@ mod tests {
         hull_2d_grahamscan(&mut vertices).unwrap();
         // [0, 0] should be the anchor point
         assert!(hull_contains(&vertices, [0.0, 0.0], 1e-10));
+
+        let hull = [[0.0, 0.0].into(), [1.0, 0.0].into(), [0.5, 1.0].into()];
+        itertools::assert_equal(&vertices, &hull);
     }
 
     #[rstest]
@@ -418,6 +442,9 @@ mod tests {
         hull_2d_grahamscan(&mut vertices).unwrap();
         // Should only keep furthest point in each direction
         assert!(vertices.len() >= 3);
+
+        let hull = [[0.0, 0.0].into(), [1.0, 0.0].into(), [3.0, 3.0].into(), [0.0, 1.0].into()];
+        itertools::assert_equal(&vertices, &hull);
     }
 
     #[rstest]
@@ -466,17 +493,23 @@ mod tests {
             .collect();
         hull_2d_grahamscan(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 3);
+
+        let hull = [[0.0, 0.0].into(), [1.0, 0.0].into(), [0.5, 1.0].into()];
+        itertools::assert_equal(&vertices, &hull);
     }
 
     #[rstest]
     fn test_negative_coordinates() {
         let mut vertices: Vec<Cartesian<2>> =
-            vec![[-1.0, -1.0], [1.0, -1.0], [1.0, 1.0], [-1.0, 1.0]]
+            vec![[1.0, 1.0], [1.0, -1.0], [-1.0, 1.0], [-1.0, -1.0]]
                 .into_iter()
                 .map(Cartesian::from)
                 .collect();
         hull_2d_grahamscan(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 4);
+
+        let hull = [[-1.0, -1.0].into(), [1.0, -1.0].into(), [1.0, 1.0].into(), [-1.0, 1.0].into()];
+        itertools::assert_equal(&vertices, &hull);
     }
 
     #[rstest]
@@ -487,5 +520,8 @@ mod tests {
             .collect();
         hull_2d_grahamscan(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 4);
+
+        let hull = [[0.0, 0.0].into(), [1e6, 0.0].into(), [1e6, 1e6].into(), [0.0, 1e6].into()];
+        itertools::assert_equal(&vertices, &hull);
     }
 }

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -7,11 +7,11 @@ struct _SortKey {
 }
 
 /// Find the lowest, leftmost point from a slice of Cartesian vectors.
-fn _find_lowest_leftmost(vertices: &[Cartesian<2>]) -> (usize, Cartesian<2>) {
+fn find_lowest_leftmost(vertices: &[Cartesian<2>]) -> (usize, Cartesian<2>) {
     vertices.iter().enumerate().fold(
         (usize::MAX, Cartesian::from([f64::INFINITY, f64::INFINITY])),
         |(i, p), (min_i, &min_p)| {
-            if p[1] < min_p[1] || (p[1] == min_p[0] && p[0] < min_p[0]) {
+            if p[1] < min_p[1] || (p[1] == min_p[1] && p[0] < min_p[0]) {
                 (i, p)
             } else {
                 (min_i, min_p)
@@ -27,4 +27,44 @@ fn _find_lowest_leftmost(vertices: &[Cartesian<2>]) -> (usize, Cartesian<2>) {
 pub fn hull_2d_grahamscan<I>(vertices: Vec<Cartesian<2>>) -> Result<bool, Error> {
     // vertices.sort_by(|a, b| {});
     Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approxim::assert_relative_eq;
+    use rstest::*;
+
+    #[rstest]
+    #[case::single_point(vec![[1.0, 2.0]], 0, [1.0, 2.0])]
+    #[case::two_points_first_lower(vec![[1.0, 1.0], [2.0, 3.0]], 0, [1.0, 1.0])]
+    #[case::two_points_second_lower(vec![[1.0, 3.0], [2.0, 1.0]], 1, [2.0, 1.0])]
+    #[case::same_y_leftmost_wins(vec![[3.0, 1.0], [1.0, 1.0], [2.0, 1.0]], 1, [1.0, 1.0])]
+    #[case::same_y_negative(vec![[0.0, -5.0], [-3.0, -5.0], [2.0, -5.0]], 1, [-3.0, -5.0])]
+    #[case::multiple_points(vec![[3.0, 5.0], [1.0, 1.0], [4.0, 2.0], [2.0, 3.0]], 1, [1.0, 1.0])]
+    #[case::negative_coords(vec![[0.0, 0.0], [-1.0, -1.0], [1.0, -1.0]], 1, [-1.0, -1.0])]
+    #[case::same_y_all_negative_x(vec![[5.0, 0.0], [-10.0, 0.0], [-5.0, 0.0]], 1, [-10.0, 0.0])]
+    #[case::lowest_is_only_point(vec![[100.0, -100.0]], 0, [100.0, -100.0])]
+    #[case::diagonal_tiebreak(vec![[5.0, 5.0], [4.0, 4.0], [3.0, 3.0], [2.0, 2.0], [1.0, 1.0]], 4, [1.0, 1.0])]
+    fn test_find_lowest_leftmost(
+        #[case] vertices: Vec<[f64; 2]>,
+        #[case] expected_idx: usize,
+        #[case] expected_point: [f64; 2],
+    ) {
+        let vertices: Vec<Cartesian<2>> = vertices.into_iter().map(Cartesian::from).collect();
+        let (idx, point) = find_lowest_leftmost(&vertices);
+        assert_eq!(idx, expected_idx);
+        assert_relative_eq!(point, Cartesian::from(expected_point));
+    }
+
+    #[rstest]
+    fn test_single_point_various_coords(
+        #[values([0.0, 0.0], [-1.0, -1.0], [100.0, -50.0], [f64::MIN_POSITIVE, f64::MIN_POSITIVE])]
+        coords: [f64; 2],
+    ) {
+        let vertices = vec![Cartesian::from(coords)];
+        let (idx, point) = find_lowest_leftmost(&vertices);
+        assert_eq!(idx, 0);
+        assert_relative_eq!(point, Cartesian::from(coords));
+    }
 }

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -26,6 +26,7 @@ fn find_lowest_leftmost(vertices: &[Cartesian<2>]) -> (usize, Cartesian<2>) {
 /// `[Error::PolytopeNotConvex]` when the provided vertices do not form a convex set.
 pub fn hull_2d_grahamscan<I>(vertices: Vec<Cartesian<2>>) -> Result<bool, Error> {
     // vertices.sort_by(|a, b| {});
+    let (anchor_idx, anchor) = find_lowest_leftmost(&vertices[..]);
     Ok(true)
 }
 
@@ -36,25 +37,21 @@ mod tests {
     use rstest::*;
 
     #[rstest]
-    #[case::single_point(vec![[1.0, 2.0]], 0, [1.0, 2.0])]
-    #[case::two_points_first_lower(vec![[1.0, 1.0], [2.0, 3.0]], 0, [1.0, 1.0])]
-    #[case::two_points_second_lower(vec![[1.0, 3.0], [2.0, 1.0]], 1, [2.0, 1.0])]
-    #[case::same_y_leftmost_wins(vec![[3.0, 1.0], [1.0, 1.0], [2.0, 1.0]], 1, [1.0, 1.0])]
-    #[case::same_y_negative(vec![[0.0, -5.0], [-3.0, -5.0], [2.0, -5.0]], 1, [-3.0, -5.0])]
-    #[case::multiple_points(vec![[3.0, 5.0], [1.0, 1.0], [4.0, 2.0], [2.0, 3.0]], 1, [1.0, 1.0])]
-    #[case::negative_coords(vec![[0.0, 0.0], [-1.0, -1.0], [1.0, -1.0]], 1, [-1.0, -1.0])]
-    #[case::same_y_all_negative_x(vec![[5.0, 0.0], [-10.0, 0.0], [-5.0, 0.0]], 1, [-10.0, 0.0])]
-    #[case::lowest_is_only_point(vec![[100.0, -100.0]], 0, [100.0, -100.0])]
-    #[case::diagonal_tiebreak(vec![[5.0, 5.0], [4.0, 4.0], [3.0, 3.0], [2.0, 2.0], [1.0, 1.0]], 4, [1.0, 1.0])]
-    fn test_find_lowest_leftmost(
-        #[case] vertices: Vec<[f64; 2]>,
-        #[case] expected_idx: usize,
-        #[case] expected_point: [f64; 2],
-    ) {
+    #[case::single_point(vec![[1.0, 2.0]], 0)]
+    #[case::two_points_first_lower(vec![[1.0, 1.0], [2.0, 3.0]], 0)]
+    #[case::two_points_second_lower(vec![[1.0, 3.0], [2.0, 1.0]], 1)]
+    #[case::same_y_leftmost_wins(vec![[3.0, 1.0], [1.0, 1.0], [2.0, 1.0]], 1)]
+    #[case::same_y_negative(vec![[0.0, -5.0], [-3.0, -5.0], [2.0, -5.0]], 1)]
+    #[case::multiple_points(vec![[3.0, 5.0], [1.0, 1.0], [4.0, 2.0], [2.0, 3.0]], 1)]
+    #[case::negative_coords(vec![[0.0, 0.0], [-1.0, -1.0], [1.0, -1.0]], 1)]
+    #[case::same_y_all_negative_x(vec![[5.0, 0.0], [-10.0, 0.0], [-5.0, 0.0]], 1)]
+    #[case::lowest_is_only_point(vec![[100.0, -100.0]], 0)]
+    #[case::diagonal_tiebreak(vec![[5.0, 5.0], [4.0, 4.0], [3.0, 3.0], [2.0, 2.0], [1.0, 1.0]], 4)]
+    fn test_find_lowest_leftmost(#[case] vertices: Vec<[f64; 2]>, #[case] expected_idx: usize) {
         let vertices: Vec<Cartesian<2>> = vertices.into_iter().map(Cartesian::from).collect();
         let (idx, point) = find_lowest_leftmost(&vertices);
         assert_eq!(idx, expected_idx);
-        assert_relative_eq!(point, Cartesian::from(expected_point));
+        assert_relative_eq!(point, vertices[expected_idx]);
     }
 
     #[rstest]

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2024-2026 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
+use crate::Error;
 use hoomd_vector::{Cartesian, InnerProduct};
 
 /// Find the lowest, leftmost point from a slice of Cartesian vectors.
@@ -68,9 +69,10 @@ fn predicate_orient2d(edge: (Cartesian<2>, Cartesian<2>), test: Cartesian<2>) ->
 ///
 /// `true` if the hull was computed, `false` if the input was empty.
 #[inline]
-pub fn hull_2d_grahamscan(vertices: &mut Vec<Cartesian<2>>) -> bool {
-    if vertices.is_empty() {
-        return false;
+pub fn hull_2d_grahamscan(vertices: &mut Vec<Cartesian<2>>) -> Result<(), Error> {
+    // No need to try and triangulate if the hull is degenerate
+    if vertices.len() < 3 {
+        return Err(Error::DegeneratePolytope);
     }
 
     let (anchor_idx, _) = find_lowest_leftmost(vertices);
@@ -85,11 +87,6 @@ pub fn hull_2d_grahamscan(vertices: &mut Vec<Cartesian<2>>) -> bool {
         let (b0, b1) = get_graham_key(b, anchor);
         a0.total_cmp(&b0).then(a1.total_cmp(&b1))
     });
-
-    // No need to try and triangulate if the hull is degenerate
-    if vertices.len() < 3 {
-        return true;
-    }
 
     // Now vertices[..2] is an edge on the hull. Initialize counters for the hull length
     // and number of vertices on the hull
@@ -117,7 +114,11 @@ pub fn hull_2d_grahamscan(vertices: &mut Vec<Cartesian<2>>) -> bool {
     }
 
     vertices.truncate(n_vertices_on_hull);
-    true
+    if vertices.len() >= 3 {
+        Ok(())
+    } else {
+        Err(Error::DegeneratePolytope)
+    }
 }
 
 #[cfg(test)]

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -62,13 +62,20 @@ fn predicate_orient2d(edge: (Cartesian<2>, Cartesian<2>), test: Cartesian<2>) ->
 }
 
 /// Compute the convex hull of points in two dimensions using a Graham scan.
+///
+/// Takes ownership of the input vector and returns the hull vertices.
+/// The input is sorted and rearranged in-place, then truncated to the hull size.
+///
 /// # Errors
 ///
 /// `[Error::PolytopeNotConvex]` when the provided vertices do not form a convex set.
 #[inline]
-pub fn hull_2d_grahamscan(vertices: &mut [Cartesian<2>]) -> Option<Vec<Cartesian<2>>> {
-    // vertices.sort_by(|a, b| {});
-    let (anchor_idx, anchor) = find_lowest_leftmost(&vertices[..]);
+pub fn hull_2d_grahamscan(mut vertices: Vec<Cartesian<2>>) -> Option<Vec<Cartesian<2>>> {
+    if vertices.is_empty() {
+        return None;
+    }
+
+    let (anchor_idx, anchor) = find_lowest_leftmost(&vertices);
 
     // Move the anchor to the front of the list of vertices, as it is always in the hull
     vertices.swap(0, anchor_idx);
@@ -80,13 +87,9 @@ pub fn hull_2d_grahamscan(vertices: &mut [Cartesian<2>]) -> Option<Vec<Cartesian
         let (b0, b1) = get_graham_key(b, anchor);
         a0.total_cmp(&b0).then(a1.total_cmp(&b1))
     });
-    // Handle degenerate cases
+
     if vertices.len() < 3 {
-        return if vertices.is_empty() {
-            None
-        } else {
-            Some(vertices.to_vec())
-        };
+        return Some(vertices);
     }
 
     // Now vertices[..2] is an edge on the hull
@@ -111,7 +114,9 @@ pub fn hull_2d_grahamscan(vertices: &mut [Cartesian<2>]) -> Option<Vec<Cartesian
         n_vertices_on_hull += 1;
         next_candidate += 1;
     }
-    Some(vertices[..n_vertices_on_hull].to_vec())
+
+    vertices.truncate(n_vertices_on_hull);
+    Some(vertices)
 }
 
 #[cfg(test)]
@@ -162,11 +167,12 @@ mod tests {
             .into_iter()
             .map(Cartesian::from)
             .collect();
-        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
         assert_eq!(hull.len(), 4);
         // Check all corners are in hull
-        for v in &vertices {
-            assert!(hull.iter().any(|h| (*h - *v).norm() < 1e-10));
+        let corners = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];
+        for corner in corners {
+            assert!(hull_contains(&hull, corner, 1e-10));
         }
     }
 
@@ -185,7 +191,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
         // Hull should have 4 corners (interior edge points excluded)
         assert_eq!(hull.len(), 4);
         let corners = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];
@@ -214,7 +220,7 @@ mod tests {
             pts.push([0.0, i as f64 / 19.0]);
         }
         let mut vertices: Vec<Cartesian<2>> = pts.into_iter().map(Cartesian::from).collect();
-        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
         assert_eq!(hull.len(), 4);
     }
 
@@ -227,7 +233,7 @@ mod tests {
                 Cartesian::from([angle.cos(), angle.sin()])
             })
             .collect();
-        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
         // All points on circle should be in hull
         assert_eq!(hull.len(), n);
     }
@@ -243,7 +249,7 @@ mod tests {
             .collect();
         // Add interior points
         vertices.extend([[0.0, 0.0], [0.3, 0.3], [-0.2, 0.1], [0.1, -0.4]].map(Cartesian::from));
-        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
         // Only boundary points should be in hull
         assert_eq!(hull.len(), n_boundary);
     }
@@ -257,7 +263,7 @@ mod tests {
                 Cartesian::from([angle.cos(), angle.sin()])
             })
             .collect();
-        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
         // All points on partial arc should be in hull
         assert_eq!(hull.len(), 10);
     }
@@ -269,7 +275,7 @@ mod tests {
             .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
             .collect();
         let mut vertices = original.clone();
-        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
         // Hull should have at least 3 points
         assert!(hull.len() >= 3);
         // All hull points should be in original set
@@ -289,7 +295,7 @@ mod tests {
                 ])
             })
             .collect();
-        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
         assert!(hull.len() >= 3);
     }
 
@@ -297,16 +303,16 @@ mod tests {
     fn test_random_deterministic_output() {
         for _ in 0..3 {
             let mut rng = StdRng::seed_from_u64(123);
-            let mut vertices1: Vec<Cartesian<2>> = (0..30)
+            let vertices1: Vec<Cartesian<2>> = (0..30)
                 .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
                 .collect();
-            let hull1 = hull_2d_grahamscan(&mut vertices1).expect("hull should exist");
+            let hull1 = hull_2d_grahamscan(vertices1).expect("hull should exist");
 
             let mut rng = StdRng::seed_from_u64(123);
-            let mut vertices2: Vec<Cartesian<2>> = (0..30)
+            let vertices2: Vec<Cartesian<2>> = (0..30)
                 .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
                 .collect();
-            let hull2 = hull_2d_grahamscan(&mut vertices2).expect("hull should exist");
+            let hull2 = hull_2d_grahamscan(vertices2).expect("hull should exist");
 
             assert_eq!(hull1.len(), hull2.len());
         }
@@ -325,7 +331,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
         assert!(hull.len() >= 3);
     }
 
@@ -344,7 +350,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
         // Should handle duplicates gracefully
         assert!(hull.len() >= 3);
     }
@@ -361,7 +367,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
         // Should pick leftmost of bottom points and include apex
         assert!(hull.len() >= 3);
     }
@@ -377,7 +383,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
         // [0, 0] should be the anchor point
         assert!(hull_contains(&hull, [0.0, 0.0], 1e-10));
     }
@@ -387,7 +393,7 @@ mod tests {
         let mut pts: Vec<[f64; 2]> = (0..10).map(|i| [i as f64 * 2.0 / 9.0, 0.0]).collect();
         pts.push([1.0, 1.0]); // Apex
         let mut vertices: Vec<Cartesian<2>> = pts.into_iter().map(Cartesian::from).collect();
-        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
         // Leftmost [0,0] and rightmost [2,0] should be in hull with apex
         assert!(hull.len() >= 3);
     }
@@ -405,7 +411,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
         // Should only keep furthest point in each direction
         assert!(hull.len() >= 3);
     }
@@ -428,7 +434,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
         // Should keep only outermost points
         assert!(hull.len() >= 3);
     }
@@ -443,7 +449,7 @@ mod tests {
                 vertices.push(Cartesian::from([r * angle.cos(), r * angle.sin()]));
             }
         }
-        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
         // Outer points should form the hull
         assert!(hull.len() >= 8); // At least 8 outer points
     }
@@ -454,7 +460,7 @@ mod tests {
             .into_iter()
             .map(Cartesian::from)
             .collect();
-        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
         assert_eq!(hull.len(), 3);
     }
 
@@ -465,7 +471,7 @@ mod tests {
                 .into_iter()
                 .map(Cartesian::from)
                 .collect();
-        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
         assert_eq!(hull.len(), 4);
     }
 
@@ -475,7 +481,7 @@ mod tests {
             .into_iter()
             .map(Cartesian::from)
             .collect();
-        let hull = hull_2d_grahamscan(&mut vertices).expect("hull should exist");
+        let hull = hull_2d_grahamscan(vertices).expect("hull should exist");
         assert_eq!(hull.len(), 4);
     }
 }

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -299,8 +299,8 @@ mod tests {
     fn test_circle_partial_arc() {
         let mut vertices: Vec<Cartesian<2>> = (0..10)
             .map(|i| {
-                let angle =
-                    -std::f64::consts::FRAC_PI_4 + (std::f64::consts::FRAC_PI_2 * f64::from(i) / 9.0);
+                let angle = -std::f64::consts::FRAC_PI_4
+                    + (std::f64::consts::FRAC_PI_2 * f64::from(i) / 9.0);
                 Cartesian::from([angle.cos(), angle.sin()])
             })
             .collect();

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -3,20 +3,15 @@
 
 use crate::Error;
 use hoomd_vector::{Cartesian, InnerProduct};
+use itertools::Itertools;
 
 /// Find the lowest, leftmost point from a slice of Cartesian vectors.
 #[inline]
-fn find_lowest_leftmost(vertices: &[Cartesian<2>]) -> Option<(usize, &Cartesian<2>)> {
-    vertices
-        .iter()
-        .enumerate()
-        .reduce(|(min_i, min_p), (curr_i, curr_p)| {
-            if curr_p[1] < min_p[1] || (curr_p[1] == min_p[1] && curr_p[0] < min_p[0]) {
-                (curr_i, curr_p)
-            } else {
-                (min_i, min_p)
-            }
-        })
+fn find_lowest_leftmost(vertices: &[Cartesian<2>]) -> Option<usize> {
+    vertices.iter().position_min_by(|a, b| {
+        // Compare y-coordinates, then x.
+        a[1].total_cmp(&b[1]).then(a[0].total_cmp(&b[0]))
+    })
 }
 
 /// Get the key for a lexographical sort of points with respect to an anchor.
@@ -67,7 +62,7 @@ fn predicate_orient2d(edge: (Cartesian<2>, Cartesian<2>), test: Cartesian<2>) ->
 ///
 /// # Returns
 ///
-/// `true` if the hull was computed, `false` if the input was empty.
+/// `()` if the hull was computed, [`Error`] if a hull could not be generated.
 ///
 /// # Errors
 ///
@@ -79,7 +74,7 @@ pub fn hull_2d_grahamscan(vertices: &mut Vec<Cartesian<2>>) -> Result<(), Error>
         return Err(Error::DegeneratePolytope);
     }
 
-    let (anchor_idx, _) = find_lowest_leftmost(vertices).ok_or(Error::DegeneratePolytope)?;
+    let anchor_idx = find_lowest_leftmost(vertices).ok_or(Error::DegeneratePolytope)?;
 
     // Move the anchor to the front of the list of vertices, as it is always in the hull
     vertices.swap(0, anchor_idx);
@@ -128,7 +123,6 @@ pub fn hull_2d_grahamscan(vertices: &mut Vec<Cartesian<2>>) -> Result<(), Error>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use approxim::assert_relative_eq;
     use rand::{RngExt, SeedableRng, rngs::StdRng};
     use rstest::*;
 
@@ -151,9 +145,14 @@ mod tests {
     #[case::diagonal_tiebreak(vec![[5.0, 5.0], [4.0, 4.0], [3.0, 3.0], [2.0, 2.0], [1.0, 1.0]], 4)]
     fn test_find_lowest_leftmost(#[case] vertices: Vec<[f64; 2]>, #[case] expected_idx: usize) {
         let vertices: Vec<Cartesian<2>> = vertices.into_iter().map(Cartesian::from).collect();
-        let (idx, point) = find_lowest_leftmost(&vertices);
+        let idx = find_lowest_leftmost(&vertices).expect("returned None for non-empty input");
         assert_eq!(idx, expected_idx);
-        assert_relative_eq!(point, vertices[expected_idx]);
+    }
+
+    #[rstest]
+    fn test_find_lowest_leftmost_empty() {
+        let vertices: Vec<Cartesian<2>> = vec![];
+        assert_eq!(find_lowest_leftmost(&vertices), None);
     }
 
     #[rstest]
@@ -162,9 +161,8 @@ mod tests {
         coords: [f64; 2],
     ) {
         let vertices = vec![Cartesian::from(coords)];
-        let (idx, point) = find_lowest_leftmost(&vertices);
+        let idx = find_lowest_leftmost(&vertices).expect("returned None for non-empty input");
         assert_eq!(idx, 0);
-        assert_relative_eq!(point, Cartesian::from(coords));
     }
 
     #[rstest]

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -68,7 +68,7 @@ fn predicate_orient2d((p, q): (Cartesian<2>, Cartesian<2>), test: Cartesian<2>) 
 ///
 /// Returns [`Error`] if the input vertices do not form a convex body with 3 or more points.
 #[inline]
-pub fn hull_2d_grahamscan(vertices: &mut Vec<Cartesian<2>>) -> Result<(), Error> {
+pub fn construct_convex_hull_2d(vertices: &mut Vec<Cartesian<2>>) -> Result<(), Error> {
     // No need to try and triangulate if the hull is degenerate
     if vertices.len() < 3 {
         return Err(Error::DegeneratePolytope);
@@ -171,7 +171,7 @@ mod tests {
             .into_iter()
             .map(Cartesian::from)
             .collect();
-        hull_2d_grahamscan(&mut vertices).unwrap();
+        construct_convex_hull_2d(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 4);
 
         let hull = [
@@ -194,7 +194,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        hull_2d_grahamscan(&mut vertices).unwrap();
+        construct_convex_hull_2d(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 4);
 
         let hull = [
@@ -221,7 +221,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        hull_2d_grahamscan(&mut vertices).unwrap();
+        construct_convex_hull_2d(&mut vertices).unwrap();
         // Hull should have 4 corners (interior edge points excluded)
         assert_eq!(vertices.len(), 4);
         let hull = [
@@ -253,7 +253,7 @@ mod tests {
             pts.push([0.0, f64::from(i) / 19.0]);
         }
         let mut vertices: Vec<Cartesian<2>> = pts.into_iter().map(Cartesian::from).collect();
-        hull_2d_grahamscan(&mut vertices).unwrap();
+        construct_convex_hull_2d(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 4);
 
         let hull = [
@@ -274,7 +274,7 @@ mod tests {
                 Cartesian::from([angle.cos(), angle.sin()])
             })
             .collect();
-        hull_2d_grahamscan(&mut vertices).unwrap();
+        construct_convex_hull_2d(&mut vertices).unwrap();
         // All points on circle should be in hull
         assert_eq!(vertices.len(), n);
     }
@@ -290,7 +290,7 @@ mod tests {
             .collect();
         // Add interior points
         vertices.extend([[0.0, 0.0], [0.3, 0.3], [-0.2, 0.1], [0.1, -0.4]].map(Cartesian::from));
-        hull_2d_grahamscan(&mut vertices).unwrap();
+        construct_convex_hull_2d(&mut vertices).unwrap();
         // Only boundary points should be in hull
         assert_eq!(vertices.len(), n_boundary);
     }
@@ -304,7 +304,7 @@ mod tests {
                 Cartesian::from([angle.cos(), angle.sin()])
             })
             .collect();
-        hull_2d_grahamscan(&mut vertices).unwrap();
+        construct_convex_hull_2d(&mut vertices).unwrap();
         // All points on partial arc should be in hull
         assert_eq!(vertices.len(), 10);
     }
@@ -316,7 +316,7 @@ mod tests {
             .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
             .collect();
         let mut vertices = original.clone();
-        hull_2d_grahamscan(&mut vertices).unwrap();
+        construct_convex_hull_2d(&mut vertices).unwrap();
         // Hull should have at least 3 points
         assert!(vertices.len() >= 3);
         // All hull points should be in original set
@@ -336,7 +336,7 @@ mod tests {
                 ])
             })
             .collect();
-        hull_2d_grahamscan(&mut vertices).unwrap();
+        construct_convex_hull_2d(&mut vertices).unwrap();
         assert!(vertices.len() >= 3);
     }
 
@@ -347,13 +347,13 @@ mod tests {
             let mut vertices1: Vec<Cartesian<2>> = (0..30)
                 .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
                 .collect();
-            hull_2d_grahamscan(&mut vertices1).unwrap();
+            construct_convex_hull_2d(&mut vertices1).unwrap();
 
             let mut rng = StdRng::seed_from_u64(123);
             let mut vertices2: Vec<Cartesian<2>> = (0..30)
                 .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
                 .collect();
-            hull_2d_grahamscan(&mut vertices2).unwrap();
+            construct_convex_hull_2d(&mut vertices2).unwrap();
 
             assert_eq!(vertices1.len(), vertices2.len());
         }
@@ -372,7 +372,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        hull_2d_grahamscan(&mut vertices).unwrap();
+        construct_convex_hull_2d(&mut vertices).unwrap();
         assert!(vertices.len() >= 3);
 
         let hull = [
@@ -399,7 +399,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        hull_2d_grahamscan(&mut vertices).unwrap();
+        construct_convex_hull_2d(&mut vertices).unwrap();
         // Should handle duplicates gracefully
         assert!(vertices.len() >= 3);
 
@@ -419,7 +419,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        hull_2d_grahamscan(&mut vertices).unwrap();
+        construct_convex_hull_2d(&mut vertices).unwrap();
         // Should pick leftmost of bottom points and include apex
         assert!(vertices.len() >= 3);
 
@@ -438,7 +438,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        hull_2d_grahamscan(&mut vertices).unwrap();
+        construct_convex_hull_2d(&mut vertices).unwrap();
         // [0, 0] should be the anchor point
         assert!(hull_contains(&vertices, [0.0, 0.0], 1e-10));
 
@@ -451,7 +451,7 @@ mod tests {
         let mut pts: Vec<[f64; 2]> = (0..10).map(|i| [f64::from(i) * 2.0 / 9.0, 0.0]).collect();
         pts.push([1.0, 1.0]); // Apex
         let mut vertices: Vec<Cartesian<2>> = pts.into_iter().map(Cartesian::from).collect();
-        hull_2d_grahamscan(&mut vertices).unwrap();
+        construct_convex_hull_2d(&mut vertices).unwrap();
         // Leftmost [0,0] and rightmost [2,0] should be in hull with apex
         assert!(vertices.len() >= 3);
     }
@@ -469,7 +469,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        hull_2d_grahamscan(&mut vertices).unwrap();
+        construct_convex_hull_2d(&mut vertices).unwrap();
         // Should only keep furthest point in each direction
         assert!(vertices.len() >= 3);
 
@@ -500,7 +500,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        hull_2d_grahamscan(&mut vertices).unwrap();
+        construct_convex_hull_2d(&mut vertices).unwrap();
         // Should keep only outermost points
         assert!(vertices.len() >= 3);
     }
@@ -515,7 +515,7 @@ mod tests {
                 vertices.push(Cartesian::from([r * angle.cos(), r * angle.sin()]));
             }
         }
-        hull_2d_grahamscan(&mut vertices).unwrap();
+        construct_convex_hull_2d(&mut vertices).unwrap();
         // Outer points should form the hull
         assert!(vertices.len() >= 8); // At least 8 outer points
     }
@@ -526,7 +526,7 @@ mod tests {
             .into_iter()
             .map(Cartesian::from)
             .collect();
-        hull_2d_grahamscan(&mut vertices).unwrap();
+        construct_convex_hull_2d(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 3);
 
         let hull = [[0.0, 0.0].into(), [1.0, 0.0].into(), [0.5, 1.0].into()];
@@ -540,7 +540,7 @@ mod tests {
                 .into_iter()
                 .map(Cartesian::from)
                 .collect();
-        hull_2d_grahamscan(&mut vertices).unwrap();
+        construct_convex_hull_2d(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 4);
 
         let hull = [
@@ -558,7 +558,7 @@ mod tests {
             .into_iter()
             .map(Cartesian::from)
             .collect();
-        hull_2d_grahamscan(&mut vertices).unwrap();
+        construct_convex_hull_2d(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 4);
 
         let hull = [

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -7,10 +7,16 @@ struct _SortKey {
 }
 
 /// Find the lowest, leftmost point from a slice of Cartesian vectors.
-fn _find_lowest_leftmost(vertices: &[Cartesian<2>]) -> (i32, Cartesian<2>) {
+fn _find_lowest_leftmost(vertices: &[Cartesian<2>]) -> (usize, Cartesian<2>) {
     vertices.iter().enumerate().fold(
-        (-1, Cartesian::from([f64::INFINITY, f64::INFINITY])),
-        |(i, v), lowest_leftmost| (i, v),
+        (usize::MAX, Cartesian::from([f64::INFINITY, f64::INFINITY])),
+        |(i, p), (min_i, &min_p)| {
+            if p[1] < min_p[1] || (p[1] == min_p[0] && p[0] < min_p[0]) {
+                (i, p)
+            } else {
+                (min_i, min_p)
+            }
+        },
     )
 }
 

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -33,6 +33,40 @@ fn get_graham_key(p: Cartesian<2>, anchor: Cartesian<2>) -> (f64, f64) {
     let diff = p - anchor;
     (f64::atan2(diff[1], diff[0]), diff.dot(&diff))
 }
+/// Determines whether a point `test` is to the left, right, or colinear with `edge`.
+///
+/// # Warning
+///
+/// This predicate is not robust: points very close to the line may be misclassified
+/// due to floating-point precision limits. For all practical inputs, this will not
+/// result in issues.
+///
+/// # Note
+///
+/// This formulation (often referred to as the shoelace formula) guarantees
+/// **cyclic invariance**, or the property that the orientation sign is identical
+/// for any ordering of the three points `(e0, e1, t)`, `(e1, t, e0)`, and
+/// `(t, e0, e1)`. As a result, the result is antisymmetric about the edge `e`
+/// such that `p == -p'` for any `p'` reflected over `e`.
+///
+/// These properties do *not* prevent misclassification of points near the line—they
+/// only ensure consistent behavior for related inputs.
+///
+/// **Source:** [Robust Arithmetic in Computational Geometry](https://observablehq.com/@mourner/non-robust-arithmetic-as-art)
+fn predicate_orient2d(edge: (Cartesian<2>, Cartesian<2>), test: Cartesian<2>) -> i64 {
+    let (p, q) = edge;
+    let orientation = (p[0] * q[1] - p[1] * q[0])
+        + (q[0] * test[1] - q[1] * test[0])
+        + (test[0] * p[1] - test[1] * p[0]);
+    if orientation > 0.0 {
+        // clockwise
+        return 1;
+    } else if orientation < 0.0 {
+        // counterclockwise
+        return -1;
+    }
+    0
+}
 
 /// Compute the convex hull of points in two dimensions using a Graham scan.
 /// # Errors
@@ -57,14 +91,22 @@ pub fn hull_2d_grahamscan<I>(vertices: &mut [Cartesian<2>]) -> Option<bool> {
     let mut angle_order = vertices[1..].iter().copied().collect::<VecDeque<_>>();
 
     // The anchor and the first vertex in the sorted list are always on the hull
-    let hull_vertices= vec![anchor, angle_order.pop_front()?];
-
+    let mut hull_vertices = vec![anchor, angle_order.pop_front()?];
     while !angle_order.is_empty() {
-        let c = angle_order.pop_front()
-        
+        let c = angle_order.pop_front()?;
+        while hull_vertices.len() >= 2 {
+            // Backtrack while hull_indices[-1] is inside hull
+            let &[p, n] = hull_vertices.last_chunk::<2>()?;
+
+            if predicate_orient2d((p, n), c) <= 0 {
+                hull_vertices.pop(); // point n is inside the hull, so we remove it
+            } else {
+                break;
+            }
+        }
+        hull_vertices.push(c);
     }
     Some(true)
-
 }
 
 #[cfg(test)]

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -82,27 +82,41 @@ pub fn hull_2d_grahamscan(vertices: &mut [Cartesian<2>]) -> Option<Vec<Cartesian
         let (b0, b1) = get_graham_key(b, anchor);
         a0.total_cmp(&b0).then(a1.total_cmp(&b1))
     });
+    // Now vertices[..2] is an edge on the hull
+    let mut n_vertices_on_hull = 2;
+    let mut n_vertices_total = vertices.len();
 
     // TODO: no allocation - swap remove? Ideally move unwanted to end and then truncate
-    let mut angle_order = vertices[1..].iter().copied().collect::<VecDeque<_>>();
+    // let mut angle_order = vertices[1..].iter().copied().collect::<VecDeque<_>>();
 
     // The anchor and the first vertex in the sorted list are always on the hull
-    let mut hull_vertices = vec![anchor, angle_order.pop_front()?];
-    while !angle_order.is_empty() {
-        let c = angle_order.pop_front()?;
-        while hull_vertices.len() >= 2 {
+    // let mut hull_vertices = vec![anchor, angle_order.pop_front()?];
+    // while !angle_order.is_empty() {
+    while n_vertices_on_hull < n_vertices_total {
+        // let c = angle_order.pop_front()?;
+        let c = vertices[n_vertices_on_hull]; // Next point in the sort
+        // while hull_vertices.len() >= 2 {
+        while n_vertices_total >= 2 {
             // Backtrack while hull_indices[-1] is inside hull
-            let &[p, n] = hull_vertices.last_chunk::<2>()?;
+            // let &[p, n] = hull_vertices.last_chunk::<2>()?;
+            let p = vertices[n_vertices_on_hull - 2];
+            let n = vertices[n_vertices_on_hull - 1];
 
             if predicate_orient2d((p, n), c) <= 0 {
-                hull_vertices.pop(); // point n is inside the hull, so we remove it
+                // hull_vertices.pop(); // point n is inside the hull, so we remove it
+                // vertices.swap_remove(n_vertices_on_hull - 1)
+                vertices.swap(n_vertices_on_hull - 1, vertices.len() - 1);
+                n_vertices_total -= 1;
             } else {
+                // n_vertices_on_hull += 1;
                 break;
             }
         }
-        hull_vertices.push(c);
+        // hull_vertices.push(c);
+        println!("{n_vertices_on_hull}");
+        n_vertices_on_hull += 1;
     }
-    Some(hull_vertices)
+    Some(vertices.to_vec())
 }
 
 #[cfg(test)]

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -6,17 +6,17 @@ use hoomd_vector::{Cartesian, InnerProduct};
 
 /// Find the lowest, leftmost point from a slice of Cartesian vectors.
 #[inline]
-fn find_lowest_leftmost(vertices: &[Cartesian<2>]) -> (usize, Cartesian<2>) {
-    vertices.iter().enumerate().fold(
-        (usize::MAX, Cartesian::from([f64::INFINITY, f64::INFINITY])),
-        |(i, p), (min_i, &min_p)| {
-            if p[1] < min_p[1] || (p[1] == min_p[1] && p[0] < min_p[0]) {
-                (i, p)
+fn find_lowest_leftmost(vertices: &[Cartesian<2>]) -> Option<(usize, &Cartesian<2>)> {
+    vertices
+        .iter()
+        .enumerate()
+        .reduce(|(min_i, min_p), (curr_i, curr_p)| {
+            if curr_p[1] < min_p[1] || (curr_p[1] == min_p[1] && curr_p[0] < min_p[0]) {
+                (curr_i, curr_p)
             } else {
                 (min_i, min_p)
             }
-        },
-    )
+        })
 }
 
 /// Get the key for a lexographical sort of points with respect to an anchor.
@@ -68,6 +68,10 @@ fn predicate_orient2d(edge: (Cartesian<2>, Cartesian<2>), test: Cartesian<2>) ->
 /// # Returns
 ///
 /// `true` if the hull was computed, `false` if the input was empty.
+///
+/// # Errors
+///
+/// Returns [`Error`] if the input vertices do not form a convex body with 3 or more points.
 #[inline]
 pub fn hull_2d_grahamscan(vertices: &mut Vec<Cartesian<2>>) -> Result<(), Error> {
     // No need to try and triangulate if the hull is degenerate
@@ -75,7 +79,7 @@ pub fn hull_2d_grahamscan(vertices: &mut Vec<Cartesian<2>>) -> Result<(), Error>
         return Err(Error::DegeneratePolytope);
     }
 
-    let (anchor_idx, _) = find_lowest_leftmost(vertices);
+    let (anchor_idx, _) = find_lowest_leftmost(vertices).ok_or(Error::DegeneratePolytope)?;
 
     // Move the anchor to the front of the list of vertices, as it is always in the hull
     vertices.swap(0, anchor_idx);

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -126,7 +126,7 @@ mod tests {
     use rand::{RngExt, SeedableRng, rngs::StdRng};
     use rstest::*;
 
-    // Helper to check if a point is approximately in the hull
+    /// Helper to check if a point is approximately in the hull
     fn hull_contains(hull: &[Cartesian<2>], point: [f64; 2], tol: f64) -> bool {
         hull.iter()
             .any(|h| (h[0] - point[0]).abs() < tol && (h[1] - point[1]).abs() < tol)
@@ -299,8 +299,8 @@ mod tests {
     fn test_circle_partial_arc() {
         let mut vertices: Vec<Cartesian<2>> = (0..10)
             .map(|i| {
-                let angle = -std::f64::consts::FRAC_PI_4
-                    + (std::f64::consts::FRAC_PI_2 * f64::from(i) / 9.0);
+                let angle =
+                    -std::f64::consts::FRAC_PI_4 + (std::f64::consts::FRAC_PI_2 * f64::from(i) / 9.0);
                 Cartesian::from([angle.cos(), angle.sin()])
             })
             .collect();

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -72,7 +72,7 @@ fn predicate_orient2d(edge: (Cartesian<2>, Cartesian<2>), test: Cartesian<2>) ->
 /// # Errors
 ///
 /// `[Error::PolytopeNotConvex]` when the provided vertices do not form a convex set.
-pub fn hull_2d_grahamscan<I>(vertices: &mut [Cartesian<2>]) -> Option<bool> {
+pub fn hull_2d_grahamscan<I>(vertices: &mut [Cartesian<2>]) -> Option<Vec<Cartesian<2>>> {
     // vertices.sort_by(|a, b| {});
     let (anchor_idx, anchor) = find_lowest_leftmost(&vertices[..]);
 
@@ -106,7 +106,7 @@ pub fn hull_2d_grahamscan<I>(vertices: &mut [Cartesian<2>]) -> Option<bool> {
         }
         hull_vertices.push(c);
     }
-    Some(true)
+    Some(hull_vertices)
 }
 
 #[cfg(test)]

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -86,6 +86,7 @@ pub fn hull_2d_grahamscan(vertices: &mut Vec<Cartesian<2>>) -> bool {
         a0.total_cmp(&b0).then(a1.total_cmp(&b1))
     });
 
+    // No need to try and triangulate if the hull is degenerate
     if vertices.len() < 3 {
         return true;
     }
@@ -109,7 +110,7 @@ pub fn hull_2d_grahamscan(vertices: &mut Vec<Cartesian<2>>) -> bool {
                 break;
             }
         }
-        // Swap candidate into hull position
+        // Swap the vertex c onto the end of the hull, extending it by one
         vertices.swap(next_candidate, n_vertices_on_hull);
         n_vertices_on_hull += 1;
         next_candidate += 1;

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -18,7 +18,7 @@ fn find_lowest_leftmost(vertices: &[Cartesian<2>]) -> Option<usize> {
 
 /// Get the key for a lexographical sort of points with respect to an anchor.
 #[inline]
-pub fn get_graham_key(p: Cartesian<2>, anchor: Cartesian<2>) -> (f64, f64) {
+fn get_graham_key(p: Cartesian<2>, anchor: Cartesian<2>) -> (f64, f64) {
     let diff = p - anchor;
     (f64::atan2(diff[1], diff[0]), diff.dot(&diff))
 }
@@ -233,7 +233,7 @@ mod tests {
         let n = 20;
         let mut vertices: Vec<Cartesian<2>> = (0..n)
             .map(|i| {
-                let angle = 2.0 * std::f64::consts::PI * f64::from(i) / n as f64;
+                let angle = 2.0 * std::f64::consts::PI * i as f64 / n as f64;
                 Cartesian::from([angle.cos(), angle.sin()])
             })
             .collect();
@@ -247,7 +247,7 @@ mod tests {
         let n_boundary = 12;
         let mut vertices: Vec<Cartesian<2>> = (0..n_boundary)
             .map(|i| {
-                let angle = 2.0 * std::f64::consts::PI * f64::from(i) / n_boundary as f64;
+                let angle = 2.0 * std::f64::consts::PI * i as f64 / n_boundary as f64;
                 Cartesian::from([angle.cos(), angle.sin()])
             })
             .collect();

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -209,19 +209,19 @@ mod tests {
         let mut pts: Vec<[f64; 2]> = Vec::new();
         // Bottom edge
         for i in 0..20 {
-            pts.push([i as f64 / 19.0, 0.0]);
+            pts.push([f64::from(i) / 19.0, 0.0]);
         }
         // Right edge
         for i in 0..20 {
-            pts.push([1.0, i as f64 / 19.0]);
+            pts.push([1.0, f64::from(i) / 19.0]);
         }
         // Top edge
         for i in 0..20 {
-            pts.push([i as f64 / 19.0, 1.0]);
+            pts.push([f64::from(i) / 19.0, 1.0]);
         }
         // Left edge
         for i in 0..20 {
-            pts.push([0.0, i as f64 / 19.0]);
+            pts.push([0.0, f64::from(i) / 19.0]);
         }
         let mut vertices: Vec<Cartesian<2>> = pts.into_iter().map(Cartesian::from).collect();
         hull_2d_grahamscan(&mut vertices).unwrap();
@@ -233,7 +233,7 @@ mod tests {
         let n = 20;
         let mut vertices: Vec<Cartesian<2>> = (0..n)
             .map(|i| {
-                let angle = 2.0 * std::f64::consts::PI * i as f64 / n as f64;
+                let angle = 2.0 * std::f64::consts::PI * f64::from(i) / n as f64;
                 Cartesian::from([angle.cos(), angle.sin()])
             })
             .collect();
@@ -247,7 +247,7 @@ mod tests {
         let n_boundary = 12;
         let mut vertices: Vec<Cartesian<2>> = (0..n_boundary)
             .map(|i| {
-                let angle = 2.0 * std::f64::consts::PI * i as f64 / n_boundary as f64;
+                let angle = 2.0 * std::f64::consts::PI * f64::from(i) / n_boundary as f64;
                 Cartesian::from([angle.cos(), angle.sin()])
             })
             .collect();
@@ -262,8 +262,8 @@ mod tests {
     fn test_circle_partial_arc() {
         let mut vertices: Vec<Cartesian<2>> = (0..10)
             .map(|i| {
-                let angle =
-                    -std::f64::consts::FRAC_PI_4 + (std::f64::consts::FRAC_PI_2 * i as f64 / 9.0);
+                let angle = -std::f64::consts::FRAC_PI_4
+                    + (std::f64::consts::FRAC_PI_2 * f64::from(i) / 9.0);
                 Cartesian::from([angle.cos(), angle.sin()])
             })
             .collect();
@@ -394,7 +394,7 @@ mod tests {
 
     #[rstest]
     fn test_many_bottom_points() {
-        let mut pts: Vec<[f64; 2]> = (0..10).map(|i| [i as f64 * 2.0 / 9.0, 0.0]).collect();
+        let mut pts: Vec<[f64; 2]> = (0..10).map(|i| [f64::from(i) * 2.0 / 9.0, 0.0]).collect();
         pts.push([1.0, 1.0]); // Apex
         let mut vertices: Vec<Cartesian<2>> = pts.into_iter().map(Cartesian::from).collect();
         hull_2d_grahamscan(&mut vertices).unwrap();
@@ -448,7 +448,7 @@ mod tests {
         let mut vertices: Vec<Cartesian<2>> = vec![Cartesian::from([0.0, 0.0])]; // Anchor
         // Create points along 8 rays
         for i in 0..8 {
-            let angle = 2.0 * std::f64::consts::PI * i as f64 / 8.0;
+            let angle = 2.0 * std::f64::consts::PI * f64::from(i) / 8.0;
             for r in [0.5, 1.0, 1.5] {
                 vertices.push(Cartesian::from([r * angle.cos(), r * angle.sin()]));
             }

--- a/hoomd-geometry/src/hull.rs
+++ b/hoomd-geometry/src/hull.rs
@@ -169,7 +169,7 @@ mod tests {
             .into_iter()
             .map(Cartesian::from)
             .collect();
-        assert!(hull_2d_grahamscan(&mut vertices));
+        hull_2d_grahamscan(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 4);
         // Check all corners are in hull
         let corners = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];
@@ -193,7 +193,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        assert!(hull_2d_grahamscan(&mut vertices));
+        hull_2d_grahamscan(&mut vertices).unwrap();
         // Hull should have 4 corners (interior edge points excluded)
         assert_eq!(vertices.len(), 4);
         let corners = [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];
@@ -222,7 +222,7 @@ mod tests {
             pts.push([0.0, i as f64 / 19.0]);
         }
         let mut vertices: Vec<Cartesian<2>> = pts.into_iter().map(Cartesian::from).collect();
-        assert!(hull_2d_grahamscan(&mut vertices));
+        hull_2d_grahamscan(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 4);
     }
 
@@ -235,7 +235,7 @@ mod tests {
                 Cartesian::from([angle.cos(), angle.sin()])
             })
             .collect();
-        assert!(hull_2d_grahamscan(&mut vertices));
+        hull_2d_grahamscan(&mut vertices).unwrap();
         // All points on circle should be in hull
         assert_eq!(vertices.len(), n);
     }
@@ -251,7 +251,7 @@ mod tests {
             .collect();
         // Add interior points
         vertices.extend([[0.0, 0.0], [0.3, 0.3], [-0.2, 0.1], [0.1, -0.4]].map(Cartesian::from));
-        assert!(hull_2d_grahamscan(&mut vertices));
+        hull_2d_grahamscan(&mut vertices).unwrap();
         // Only boundary points should be in hull
         assert_eq!(vertices.len(), n_boundary);
     }
@@ -265,7 +265,7 @@ mod tests {
                 Cartesian::from([angle.cos(), angle.sin()])
             })
             .collect();
-        assert!(hull_2d_grahamscan(&mut vertices));
+        hull_2d_grahamscan(&mut vertices).unwrap();
         // All points on partial arc should be in hull
         assert_eq!(vertices.len(), 10);
     }
@@ -277,7 +277,7 @@ mod tests {
             .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
             .collect();
         let mut vertices = original.clone();
-        assert!(hull_2d_grahamscan(&mut vertices));
+        hull_2d_grahamscan(&mut vertices).unwrap();
         // Hull should have at least 3 points
         assert!(vertices.len() >= 3);
         // All hull points should be in original set
@@ -297,7 +297,7 @@ mod tests {
                 ])
             })
             .collect();
-        assert!(hull_2d_grahamscan(&mut vertices));
+        hull_2d_grahamscan(&mut vertices).unwrap();
         assert!(vertices.len() >= 3);
     }
 
@@ -333,7 +333,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        assert!(hull_2d_grahamscan(&mut vertices));
+        hull_2d_grahamscan(&mut vertices).unwrap();
         assert!(vertices.len() >= 3);
     }
 
@@ -352,7 +352,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        assert!(hull_2d_grahamscan(&mut vertices));
+        hull_2d_grahamscan(&mut vertices).unwrap();
         // Should handle duplicates gracefully
         assert!(vertices.len() >= 3);
     }
@@ -369,7 +369,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        assert!(hull_2d_grahamscan(&mut vertices));
+        hull_2d_grahamscan(&mut vertices).unwrap();
         // Should pick leftmost of bottom points and include apex
         assert!(vertices.len() >= 3);
     }
@@ -385,7 +385,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        assert!(hull_2d_grahamscan(&mut vertices));
+        hull_2d_grahamscan(&mut vertices).unwrap();
         // [0, 0] should be the anchor point
         assert!(hull_contains(&vertices, [0.0, 0.0], 1e-10));
     }
@@ -395,7 +395,7 @@ mod tests {
         let mut pts: Vec<[f64; 2]> = (0..10).map(|i| [i as f64 * 2.0 / 9.0, 0.0]).collect();
         pts.push([1.0, 1.0]); // Apex
         let mut vertices: Vec<Cartesian<2>> = pts.into_iter().map(Cartesian::from).collect();
-        assert!(hull_2d_grahamscan(&mut vertices));
+        hull_2d_grahamscan(&mut vertices).unwrap();
         // Leftmost [0,0] and rightmost [2,0] should be in hull with apex
         assert!(vertices.len() >= 3);
     }
@@ -413,7 +413,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        assert!(hull_2d_grahamscan(&mut vertices));
+        hull_2d_grahamscan(&mut vertices).unwrap();
         // Should only keep furthest point in each direction
         assert!(vertices.len() >= 3);
     }
@@ -436,7 +436,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        assert!(hull_2d_grahamscan(&mut vertices));
+        hull_2d_grahamscan(&mut vertices).unwrap();
         // Should keep only outermost points
         assert!(vertices.len() >= 3);
     }
@@ -451,7 +451,7 @@ mod tests {
                 vertices.push(Cartesian::from([r * angle.cos(), r * angle.sin()]));
             }
         }
-        assert!(hull_2d_grahamscan(&mut vertices));
+        hull_2d_grahamscan(&mut vertices).unwrap();
         // Outer points should form the hull
         assert!(vertices.len() >= 8); // At least 8 outer points
     }
@@ -462,7 +462,7 @@ mod tests {
             .into_iter()
             .map(Cartesian::from)
             .collect();
-        assert!(hull_2d_grahamscan(&mut vertices));
+        hull_2d_grahamscan(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 3);
     }
 
@@ -473,7 +473,7 @@ mod tests {
                 .into_iter()
                 .map(Cartesian::from)
                 .collect();
-        assert!(hull_2d_grahamscan(&mut vertices));
+        hull_2d_grahamscan(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 4);
     }
 
@@ -483,7 +483,7 @@ mod tests {
             .into_iter()
             .map(Cartesian::from)
             .collect();
-        assert!(hull_2d_grahamscan(&mut vertices));
+        hull_2d_grahamscan(&mut vertices).unwrap();
         assert_eq!(vertices.len(), 4);
     }
 }

--- a/hoomd-geometry/src/lib.rs
+++ b/hoomd-geometry/src/lib.rs
@@ -454,7 +454,7 @@ pub use hull::hull_2d_grahamscan;
 #[derive(Error, PartialEq, Debug)]
 pub enum Error {
     /// Polytopes require at least one vertex.
-    #[error("a ConvexPolytope must have at least one vertex")]
+    #[error("a ConvexPolytope must have at least (N+1) vertices")]
     DegeneratePolytope,
 
     /// Convex Polytopes must be convex

--- a/hoomd-geometry/src/lib.rs
+++ b/hoomd-geometry/src/lib.rs
@@ -454,7 +454,7 @@ pub use hull::construct_convex_hull_2d;
 #[derive(Error, PartialEq, Debug)]
 pub enum Error {
     /// Polytopes require at least one vertex.
-    #[error("a ConvexPolytope must have at least (N+1) vertices")]
+    #[error("a ConvexPolytope must have at least one vertex")]
     DegeneratePolytope,
 
     /// The point is outside the shape.

--- a/hoomd-geometry/src/lib.rs
+++ b/hoomd-geometry/src/lib.rs
@@ -457,10 +457,6 @@ pub enum Error {
     #[error("a ConvexPolytope must have at least (N+1) vertices")]
     DegeneratePolytope,
 
-    /// Convex Polytopes must be convex
-    #[error("a ConvexPolytope must be convex")]
-    PolytopeNotConvex,
-
     /// The point is outside the shape.
     #[error("cannot map a point that is outside the shape")]
     PointOutsideShape,

--- a/hoomd-geometry/src/lib.rs
+++ b/hoomd-geometry/src/lib.rs
@@ -444,6 +444,8 @@ pub trait MapPoint<P> {
     /// `self`.
     fn map_point(&self, point: P, other: &Self) -> Result<P, Error>;
 }
+mod hull;
+pub(crate) use hull::hull_2d_grahamscan;
 
 /// Enumerate possible sources of error in fallible geometry methods.
 #[non_exhaustive]
@@ -452,6 +454,10 @@ pub enum Error {
     /// Polytopes require at least one vertex.
     #[error("a ConvexPolytope must have at least one vertex")]
     DegeneratePolytope,
+
+    /// Convex Polytopes must be convex
+    #[error("a ConvexPolytope must be convex")]
+    PolytopeNotConvex,
 
     /// The point is outside the shape.
     #[error("cannot map a point that is outside the shape")]

--- a/hoomd-geometry/src/lib.rs
+++ b/hoomd-geometry/src/lib.rs
@@ -444,6 +444,8 @@ pub trait MapPoint<P> {
     /// `self`.
     fn map_point(&self, point: P, other: &Self) -> Result<P, Error>;
 }
+
+/// TODO
 mod hull;
 pub use hull::hull_2d_grahamscan;
 

--- a/hoomd-geometry/src/lib.rs
+++ b/hoomd-geometry/src/lib.rs
@@ -445,10 +445,6 @@ pub trait MapPoint<P> {
     fn map_point(&self, point: P, other: &Self) -> Result<P, Error>;
 }
 
-/// TODO
-mod hull;
-pub use hull::construct_convex_hull_2d;
-
 /// Enumerate possible sources of error in fallible geometry methods.
 #[non_exhaustive]
 #[derive(Error, PartialEq, Debug)]

--- a/hoomd-geometry/src/lib.rs
+++ b/hoomd-geometry/src/lib.rs
@@ -460,4 +460,8 @@ pub enum Error {
     /// The point is outside the shape.
     #[error("cannot map a point that is outside the shape")]
     PointOutsideShape,
+
+    /// Too many vertices were provided.
+    #[error("too many vertices")]
+    TooManyVertices,
 }

--- a/hoomd-geometry/src/lib.rs
+++ b/hoomd-geometry/src/lib.rs
@@ -445,7 +445,7 @@ pub trait MapPoint<P> {
     fn map_point(&self, point: P, other: &Self) -> Result<P, Error>;
 }
 mod hull;
-pub(crate) use hull::hull_2d_grahamscan;
+pub use hull::hull_2d_grahamscan;
 
 /// Enumerate possible sources of error in fallible geometry methods.
 #[non_exhaustive]

--- a/hoomd-geometry/src/lib.rs
+++ b/hoomd-geometry/src/lib.rs
@@ -447,7 +447,7 @@ pub trait MapPoint<P> {
 
 /// TODO
 mod hull;
-pub use hull::hull_2d_grahamscan;
+pub use hull::construct_convex_hull_2d;
 
 /// Enumerate possible sources of error in fallible geometry methods.
 #[non_exhaustive]

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -116,7 +116,7 @@ impl ConvexPolytope<2> {
     ///
     /// Returns `[Error::DegeneratePolytope]` when the hull has fewer than 3 vertices.
     #[inline]
-    pub fn with_vertices_hull<I>(vertices: I) -> Result<ConvexPolytope<2>, Error>
+    pub fn convex_hull_from_vertices<I>(vertices: I) -> Result<ConvexPolytope<2>, Error>
     where
         I: IntoIterator<Item = Cartesian<2>>,
     {

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -197,18 +197,18 @@ impl<const N: usize, const MAX_VERTICES: usize> ConvexPolytope<N, MAX_VERTICES> 
     where
         I: IntoIterator<Item = Cartesian<N>>,
     {
-        let mut buf: ArrayVec<Cartesian<N>, MAX_VERTICES> = ArrayVec::new();
+        let mut array_vec: ArrayVec<Cartesian<N>, MAX_VERTICES> = ArrayVec::new();
         for v in vertices {
-            buf.try_push(v).map_err(|_| Error::TooManyVertices)?;
+            array_vec.try_push(v).map_err(|_| Error::TooManyVertices)?;
         }
 
-        if buf.len() < (N + 1) {
+        if array_vec.is_empty() {
             return Err(Error::DegeneratePolytope);
         }
 
         Ok(ConvexPolytope {
-            bounding_radius: Self::bounding_radius(&buf),
-            vertices: buf,
+            bounding_radius: Self::bounding_radius(&array_vec),
+            vertices: array_vec,
         })
     }
 

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -5,7 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{BoundingSphereRadius, Error, SupportMapping, hull_2d_grahamscan};
+use crate::{BoundingSphereRadius, Error, SupportMapping, construct_convex_hull_2d};
 use hoomd_utility::valid::PositiveReal;
 use hoomd_vector::{Cartesian, InnerProduct};
 
@@ -126,7 +126,7 @@ impl ConvexPolytope<2> {
             return Err(Error::DegeneratePolytope);
         }
 
-        hull_2d_grahamscan(&mut vertices)?;
+        construct_convex_hull_2d(&mut vertices)?;
 
         Ok(ConvexPolytope {
             bounding_radius: Self::bounding_radius(&vertices),

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -17,9 +17,9 @@ use hoomd_vector::{Cartesian, InnerProduct};
 /// hull is formed by [`SupportMapping`] during intersection tests of
 /// `Convex(ConvexPolytope)` with other `Convex(_)` types.
 ///
-/// The elements of [`vertices`] are *not necessarily* the vertices of the
-/// convex hull. They are exactly the points given at construction and might
-/// include duplicate, collinear, coplanar, and/or interior points.
+/// Every vertex in the convex hull is an elements of [`vertices`]. [`vertices`]
+/// may also include duplicate, collinear, coplanar, and/or interior points.
+/// They are exactly the points given at construction.
 ///
 /// [`vertices`]: Self::vertices
 ///

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -20,7 +20,7 @@ use hoomd_vector::{Cartesian, InnerProduct};
 /// use hoomd_geometry::{BoundingSphereRadius, shape::ConvexPolyhedron};
 ///
 /// # fn main() -> Result<(), hoomd_geometry::Error> {
-/// let tetrahedron = ConvexPolyhedron::with_vertices(vec![
+/// let tetrahedron = ConvexPolyhedron::with_vertices([
 ///     [1.0, 1.0, 1.0].into(),
 ///     [1.0, -1.0, -1.0].into(),
 ///     [-1.0, 1.0, -1.0].into(),
@@ -95,7 +95,7 @@ pub type ConvexPolygon = ConvexPolytope<2, 32>;
 /// ```
 /// use hoomd_geometry::shape::{ConvexPolyhedron, Simplex3};
 /// # fn main() -> Result<(), hoomd_geometry::Error> {
-/// let poly = ConvexPolyhedron::with_vertices(vec![
+/// let poly = ConvexPolyhedron::with_vertices([
 ///     [1.0, 1.0, 1.0].into(),
 ///     [1.0, -1.0, -1.0].into(),
 ///     [-1.0, 1.0, -1.0].into(),
@@ -146,7 +146,7 @@ impl<const N: usize, const MAX_VERTICES: usize> ConvexPolytope<N, MAX_VERTICES> 
     /// use hoomd_geometry::shape::ConvexPolytope;
     ///
     /// # fn main() -> Result<(), hoomd_geometry::Error> {
-    /// let equilateral_triangle = ConvexPolytope::<2>::with_vertices(vec![
+    /// let equilateral_triangle = ConvexPolytope::<2>::with_vertices([
     ///     [1.0, 0.0].into(),
     ///     [0.5, f64::sqrt(3.0) / 2.0].into(),
     ///     [-0.5, f64::sqrt(3.0) / 2.0].into(),
@@ -238,7 +238,7 @@ mod tests {
 
     #[fixture]
     fn simplex3() -> ConvexPolyhedron {
-        ConvexPolyhedron::with_vertices(vec![
+        ConvexPolyhedron::with_vertices([
             [1.0, 1.0, 1.0].into(),
             [1.0, -1.0, -1.0].into(),
             [-1.0, 1.0, -1.0].into(),
@@ -249,7 +249,7 @@ mod tests {
 
     #[fixture]
     fn equilateral_triangle() -> ConvexPolygon {
-        ConvexPolytope::with_vertices(vec![
+        ConvexPolytope::with_vertices([
             [1.0, 0.0].into(),
             [0.5, f64::sqrt(3.0) / 2.0].into(),
             [-0.5, f64::sqrt(3.0) / 2.0].into(),

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -10,7 +10,18 @@ use arrayvec::ArrayVec;
 use hoomd_utility::valid::PositiveReal;
 use hoomd_vector::{Cartesian, InnerProduct};
 
-/// A faceted solid defined by the convex hull of its vertices.
+/// A faceted solid defined by the convex hull of a set of points.
+///
+/// [`ConvexPolytope`] stores the given point set without any modification.
+/// Therefore, it can be constructed quickly. The *implicit* convex
+/// hull is formed by [`SupportMapping`] during intersection tests of
+/// `Convex(ConvexPolytope)` with other `Convex(_)` types.
+///
+/// The elements of [`vertices`] are *not necessarily* the vertices of the
+/// convex hull. They are exactly the points given at construction and might
+/// include duplicate, collinear, coplanar, and/or interior points.
+///
+/// [`vertices`]: Self::vertices
 ///
 /// # Examples
 ///

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -167,7 +167,7 @@ impl<const N: usize, const MAX_VERTICES: usize> ConvexPolytope<N, MAX_VERTICES> 
     /// ```
     /// # Errors
     ///
-    /// `[Error::DegeneratePolytope]` when no vertices are provided.
+    /// [`Error::DegeneratePolytope`] when no vertices are provided.
     #[inline]
     pub fn with_vertices<I>(vertices: I) -> Result<ConvexPolytope<N, MAX_VERTICES>, Error>
     where

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -136,10 +136,7 @@ impl<const MAX_VERTICES: usize> ConvexPolytope<2, MAX_VERTICES> {
             return Err(Error::TooManyVertices);
         }
 
-        let mut verts: ArrayVec<Cartesian<2>, MAX_VERTICES> = ArrayVec::new();
-        for v in buf {
-            verts.push(v);
-        }
+        let verts: ArrayVec<Cartesian<2>, MAX_VERTICES> = buf.into_iter().collect();
 
         Ok(ConvexPolytope {
             bounding_radius: Self::bounding_radius(&verts),
@@ -151,9 +148,9 @@ impl<const MAX_VERTICES: usize> ConvexPolytope<2, MAX_VERTICES> {
     ///
     /// # Example
     /// ```
-    /// use hoomd_geometry::shape::ConvexPolytope;
+    /// use hoomd_geometry::shape::ConvexPolygon;
     ///
-    /// let equilateral_triangle: ConvexPolytope<2> = ConvexPolytope::regular(3);
+    /// let equilateral_triangle = ConvexPolygon::regular(3);
     /// ```
     #[inline]
     #[must_use]
@@ -184,7 +181,7 @@ impl<const N: usize, const MAX_VERTICES: usize> ConvexPolytope<N, MAX_VERTICES> 
     /// use hoomd_geometry::shape::ConvexPolytope;
     ///
     /// # fn main() -> Result<(), hoomd_geometry::Error> {
-    /// let equilateral_triangle: ConvexPolytope<2> = ConvexPolytope::with_vertices(vec![
+    /// let equilateral_triangle = ConvexPolytope::<2>::with_vertices(vec![
     ///     [1.0, 0.0].into(),
     ///     [0.5, f64::sqrt(3.0) / 2.0].into(),
     ///     [-0.5, f64::sqrt(3.0) / 2.0].into(),

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -192,9 +192,6 @@ impl<const N: usize> ConvexPolytope<N> {
     {
         let vertices = vertices.into_iter().collect::<Vec<_>>();
 
-        if vertices.is_empty() {
-            return Err(Error::DegeneratePolytope);
-        }
         if vertices.len() < (N + 1) {
             return Err(Error::DegeneratePolytope);
         }

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -108,6 +108,35 @@ pub type ConvexPolygon = ConvexPolytope<2>;
 pub type ConvexPolyhedron = ConvexPolytope<3>;
 
 impl ConvexPolytope<2> {
+    /// Create a 2D convex polygon with the given vertices.
+    ///
+    /// The vertices are reduced to their convex hull using a Graham scan.
+    ///
+    /// # Errors
+    ///
+    /// Returns `[Error::DegeneratePolytope]` when the hull has fewer than 3 vertices.
+    #[inline]
+    pub fn with_vertices_hull<I>(vertices: I) -> Result<ConvexPolytope<2>, Error>
+    where
+        I: IntoIterator<Item = Cartesian<2>>,
+    {
+        let mut vertices: Vec<Cartesian<2>> = vertices.into_iter().collect();
+
+        if vertices.is_empty() {
+            return Err(Error::DegeneratePolytope);
+        }
+        if vertices.len() < 3 {
+            return Err(Error::DegeneratePolytope);
+        }
+
+        hull_2d_grahamscan(&mut vertices)?;
+
+        Ok(ConvexPolytope {
+            bounding_radius: Self::bounding_radius(&vertices),
+            vertices,
+        })
+    }
+
     /// Create a regular *n*-gon with *n* vertices and circumradius 0.5.
     ///
     /// # Example
@@ -168,9 +197,6 @@ impl<const N: usize> ConvexPolytope<N> {
         }
         if vertices.len() < (N + 1) {
             return Err(Error::DegeneratePolytope);
-        }
-        if N == 2 {
-            hull_2d_grahamscan(&mut vertices)?;
         }
 
         Ok(ConvexPolytope {

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -6,6 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{BoundingSphereRadius, Error, SupportMapping, construct_convex_hull_2d};
+use arrayvec::ArrayVec;
 use hoomd_utility::valid::PositiveReal;
 use hoomd_vector::{Cartesian, InnerProduct};
 
@@ -62,9 +63,9 @@ use hoomd_vector::{Cartesian, InnerProduct};
 /// # }
 /// ```
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct ConvexPolytope<const N: usize> {
+pub struct ConvexPolytope<const N: usize, const MAX_VERTICES: usize = 64> {
     /// The vertices of the shape.
-    vertices: Vec<Cartesian<N>>,
+    vertices: ArrayVec<Cartesian<N>, MAX_VERTICES>,
     /// The radius of a bounding sphere of the geometry.
     pub(crate) bounding_radius: PositiveReal,
 }
@@ -85,7 +86,7 @@ pub struct ConvexPolytope<const N: usize> {
 /// # Ok(())
 /// # }
 /// ```
-pub type ConvexPolygon = ConvexPolytope<2>;
+pub type ConvexPolygon = ConvexPolytope<2, 32>;
 
 /// A faceted convex body in three dimensions.
 ///
@@ -105,9 +106,9 @@ pub type ConvexPolygon = ConvexPolytope<2>;
 /// # Ok(())
 /// # }
 /// ```
-pub type ConvexPolyhedron = ConvexPolytope<3>;
+pub type ConvexPolyhedron = ConvexPolytope<3, 32>;
 
-impl ConvexPolytope<2> {
+impl<const MAX_VERTICES: usize> ConvexPolytope<2, MAX_VERTICES> {
     /// Create a 2D convex polygon with the given vertices.
     ///
     /// The vertices are reduced to their convex hull using a Graham scan.
@@ -115,22 +116,34 @@ impl ConvexPolytope<2> {
     /// # Errors
     ///
     /// Returns `[Error::DegeneratePolytope]` when the hull has fewer than 3 vertices.
+    /// Returns `[Error::TooManyVertices]` when more than `MAX_VERTICES` vertices are provided. If this is the case, increase `MAX_VERTICES` as needed.
     #[inline]
-    pub fn convex_hull_from_vertices<I>(vertices: I) -> Result<ConvexPolytope<2>, Error>
+    pub fn convex_hull_from_vertices<I>(
+        vertices: I,
+    ) -> Result<ConvexPolytope<2, MAX_VERTICES>, Error>
     where
         I: IntoIterator<Item = Cartesian<2>>,
     {
-        let mut vertices: Vec<Cartesian<2>> = vertices.into_iter().collect();
+        let mut buf: Vec<Cartesian<2>> = vertices.into_iter().collect();
 
-        if vertices.len() < 3 {
+        if buf.len() < 3 {
             return Err(Error::DegeneratePolytope);
         }
 
-        construct_convex_hull_2d(&mut vertices)?;
+        construct_convex_hull_2d(&mut buf)?;
+
+        if buf.len() > MAX_VERTICES {
+            return Err(Error::TooManyVertices);
+        }
+
+        let mut verts: ArrayVec<Cartesian<2>, MAX_VERTICES> = ArrayVec::new();
+        for v in buf {
+            verts.push(v);
+        }
 
         Ok(ConvexPolytope {
-            bounding_radius: Self::bounding_radius(&vertices),
-            vertices,
+            bounding_radius: Self::bounding_radius(&verts),
+            vertices: verts,
         })
     }
 
@@ -140,7 +153,7 @@ impl ConvexPolytope<2> {
     /// ```
     /// use hoomd_geometry::shape::ConvexPolytope;
     ///
-    /// let equilateral_triangle = ConvexPolytope::regular(3);
+    /// let equilateral_triangle: ConvexPolytope<2> = ConvexPolytope::regular(3);
     /// ```
     #[inline]
     #[must_use]
@@ -148,14 +161,14 @@ impl ConvexPolytope<2> {
         clippy::missing_panics_doc,
         reason = "panic will never occur on a hard-coded constant"
     )]
-    pub fn regular(n: usize) -> ConvexPolytope<2> {
+    pub fn regular(n: usize) -> ConvexPolytope<2, MAX_VERTICES> {
         ConvexPolytope {
             vertices: (0..n)
                 .map(|x| {
                     let theta = 2.0 * std::f64::consts::PI * (x as f64) / (n as f64);
                     Cartesian::from([0.5 * f64::cos(theta), 0.5 * f64::sin(theta)])
                 })
-                .collect::<Vec<_>>(),
+                .collect(),
             bounding_radius: 0.5
                 .try_into()
                 .expect("hard-coded constant should be positive"),
@@ -163,7 +176,7 @@ impl ConvexPolytope<2> {
     }
 }
 
-impl<const N: usize> ConvexPolytope<N> {
+impl<const N: usize, const MAX_VERTICES: usize> ConvexPolytope<N, MAX_VERTICES> {
     /// Create an `N`-polytope with the given vertices.
     ///
     /// # Example
@@ -171,7 +184,7 @@ impl<const N: usize> ConvexPolytope<N> {
     /// use hoomd_geometry::shape::ConvexPolytope;
     ///
     /// # fn main() -> Result<(), hoomd_geometry::Error> {
-    /// let equilateral_triangle = ConvexPolytope::with_vertices(vec![
+    /// let equilateral_triangle: ConvexPolytope<2> = ConvexPolytope::with_vertices(vec![
     ///     [1.0, 0.0].into(),
     ///     [0.5, f64::sqrt(3.0) / 2.0].into(),
     ///     [-0.5, f64::sqrt(3.0) / 2.0].into(),
@@ -183,19 +196,22 @@ impl<const N: usize> ConvexPolytope<N> {
     ///
     /// `[Error::DegeneratePolytope]` when no vertices are provided.
     #[inline]
-    pub fn with_vertices<I>(vertices: I) -> Result<ConvexPolytope<N>, Error>
+    pub fn with_vertices<I>(vertices: I) -> Result<ConvexPolytope<N, MAX_VERTICES>, Error>
     where
         I: IntoIterator<Item = Cartesian<N>>,
     {
-        let vertices = vertices.into_iter().collect::<Vec<_>>();
+        let mut buf: ArrayVec<Cartesian<N>, MAX_VERTICES> = ArrayVec::new();
+        for v in vertices {
+            buf.try_push(v).map_err(|_| Error::TooManyVertices)?;
+        }
 
-        if vertices.len() < (N + 1) {
+        if buf.len() < (N + 1) {
             return Err(Error::DegeneratePolytope);
         }
 
         Ok(ConvexPolytope {
-            bounding_radius: Self::bounding_radius(&vertices),
-            vertices,
+            bounding_radius: Self::bounding_radius(&buf),
+            vertices: buf,
         })
     }
 
@@ -218,7 +234,9 @@ impl<const N: usize> ConvexPolytope<N> {
     }
 }
 
-impl<const N: usize> SupportMapping<Cartesian<N>> for ConvexPolytope<N> {
+impl<const N: usize, const MAX_VERTICES: usize> SupportMapping<Cartesian<N>>
+    for ConvexPolytope<N, MAX_VERTICES>
+{
     #[inline]
     fn support_mapping(&self, n: &Cartesian<N>) -> Cartesian<N> {
         match N {
@@ -237,7 +255,9 @@ impl<const N: usize> SupportMapping<Cartesian<N>> for ConvexPolytope<N> {
     }
 }
 
-impl<const N: usize> BoundingSphereRadius for ConvexPolytope<N> {
+impl<const N: usize, const MAX_VERTICES: usize> BoundingSphereRadius
+    for ConvexPolytope<N, MAX_VERTICES>
+{
     #[inline]
     fn bounding_sphere_radius(&self) -> PositiveReal {
         self.bounding_radius
@@ -266,7 +286,7 @@ mod tests {
     }
 
     #[fixture]
-    fn equilateral_triangle() -> ConvexPolytope<2> {
+    fn equilateral_triangle() -> ConvexPolytope<2, 32> {
         ConvexPolytope::with_vertices(vec![
             [1.0, 0.0].into(),
             [0.5, f64::sqrt(3.0) / 2.0].into(),
@@ -285,9 +305,12 @@ mod tests {
     }
 
     #[rstest]
-    fn test_bounding_radius_regular_polygons(#[values(1, 3, 8, 64)] n: usize) {
+    fn test_bounding_radius_regular_polygons(#[values(1, 3, 8, 32)] n: usize) {
         assert_eq!(ConvexPolygon::regular(n).bounding_radius.get(), 0.5);
-        assert_eq!(ConvexPolytope::regular(n).bounding_radius.get(), 0.5);
+        assert_eq!(
+            ConvexPolytope::<2, 32>::regular(n).bounding_radius.get(),
+            0.5
+        );
     }
 
     #[test]

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -170,8 +170,7 @@ impl<const N: usize> ConvexPolytope<N> {
             return Err(Error::DegeneratePolytope);
         }
         if N == 2 {
-            //
-            hull_2d_grahamscan(&mut vertices[..]);
+            hull_2d_grahamscan(&mut vertices)?;
         }
 
         Ok(ConvexPolytope {

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -5,7 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{BoundingSphereRadius, Error, SupportMapping};
+use crate::{BoundingSphereRadius, Error, SupportMapping, hull_2d_grahamscan};
 use hoomd_utility::valid::PositiveReal;
 use hoomd_vector::{Cartesian, InnerProduct};
 
@@ -165,6 +165,13 @@ impl<const N: usize> ConvexPolytope<N> {
 
         if vertices.is_empty() {
             return Err(Error::DegeneratePolytope);
+        }
+        if vertices.len() < (N + 1) {
+            return Err(Error::DegeneratePolytope);
+        }
+        if N == 2 {
+            //
+            hull_2d_grahamscan(&mut vertices[..]);
         }
 
         Ok(ConvexPolytope {

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -5,7 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{BoundingSphereRadius, Error, SupportMapping, construct_convex_hull_2d};
+use crate::{BoundingSphereRadius, Error, SupportMapping};
 use arrayvec::ArrayVec;
 use hoomd_utility::valid::PositiveReal;
 use hoomd_vector::{Cartesian, InnerProduct};
@@ -67,7 +67,7 @@ pub struct ConvexPolytope<const N: usize, const MAX_VERTICES: usize = 64> {
     /// The vertices of the shape.
     vertices: ArrayVec<Cartesian<N>, MAX_VERTICES>,
     /// The radius of a bounding sphere of the geometry.
-    pub(crate) bounding_radius: PositiveReal,
+    bounding_radius: PositiveReal,
 }
 
 /// A faceted convex body in two dimensions.
@@ -109,41 +109,6 @@ pub type ConvexPolygon = ConvexPolytope<2, 32>;
 pub type ConvexPolyhedron = ConvexPolytope<3, 32>;
 
 impl<const MAX_VERTICES: usize> ConvexPolytope<2, MAX_VERTICES> {
-    /// Create a 2D convex polygon with the given vertices.
-    ///
-    /// The vertices are reduced to their convex hull using a Graham scan.
-    ///
-    /// # Errors
-    ///
-    /// Returns `[Error::DegeneratePolytope]` when the hull has fewer than 3 vertices.
-    /// Returns `[Error::TooManyVertices]` when more than `MAX_VERTICES` vertices are provided. If this is the case, increase `MAX_VERTICES` as needed.
-    #[inline]
-    pub fn convex_hull_from_vertices<I>(
-        vertices: I,
-    ) -> Result<ConvexPolytope<2, MAX_VERTICES>, Error>
-    where
-        I: IntoIterator<Item = Cartesian<2>>,
-    {
-        let mut buf: Vec<Cartesian<2>> = vertices.into_iter().collect();
-
-        if buf.len() < 3 {
-            return Err(Error::DegeneratePolytope);
-        }
-
-        construct_convex_hull_2d(&mut buf)?;
-
-        if buf.len() > MAX_VERTICES {
-            return Err(Error::TooManyVertices);
-        }
-
-        let verts: ArrayVec<Cartesian<2>, MAX_VERTICES> = buf.into_iter().collect();
-
-        Ok(ConvexPolytope {
-            bounding_radius: Self::bounding_radius(&verts),
-            vertices: verts,
-        })
-    }
-
     /// Create a regular *n*-gon with *n* vertices and circumradius 0.5.
     ///
     /// # Example
@@ -220,7 +185,7 @@ impl<const N: usize, const MAX_VERTICES: usize> ConvexPolytope<N, MAX_VERTICES> 
     }
 
     /// Compute the bounding radius.
-    fn bounding_radius(vertices: &[Cartesian<N>]) -> PositiveReal {
+    pub(crate) fn bounding_radius(vertices: &[Cartesian<N>]) -> PositiveReal {
         vertices
             .iter()
             .map(Cartesian::norm_squared)

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -122,9 +122,6 @@ impl ConvexPolytope<2> {
     {
         let mut vertices: Vec<Cartesian<2>> = vertices.into_iter().collect();
 
-        if vertices.is_empty() {
-            return Err(Error::DegeneratePolytope);
-        }
         if vertices.len() < 3 {
             return Err(Error::DegeneratePolytope);
         }

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -283,7 +283,7 @@ mod tests {
     }
 
     #[fixture]
-    fn equilateral_triangle() -> ConvexPolytope<2, 32> {
+    fn equilateral_triangle() -> ConvexPolygon {
         ConvexPolytope::with_vertices(vec![
             [1.0, 0.0].into(),
             [0.5, f64::sqrt(3.0) / 2.0].into(),

--- a/hoomd-geometry/src/shape/convex_surface_mesh_2d.rs
+++ b/hoomd-geometry/src/shape/convex_surface_mesh_2d.rs
@@ -1,13 +1,13 @@
 // Copyright (c) 2024-2026 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-//! N-Dimensional generalization of a convex polyhedron.
+//! Convex polygon represented by vertices and edges.
 
 use serde::{Deserialize, Serialize};
 
 use std::cmp::Ordering;
 
-use crate::{BoundingSphereRadius, Error, SupportMapping, shape::ConvexPolytope};
+use crate::{BoundingSphereRadius, Error, SupportMapping, Volume, shape::ConvexPolytope};
 use hoomd_utility::valid::PositiveReal;
 use hoomd_vector::{Cartesian, InnerProduct};
 use itertools::Itertools;
@@ -31,10 +31,9 @@ use itertools::Itertools;
 ///
 /// # Examples
 ///
-/// Construction and basic methods:
+/// Construction:
 /// ```
-/// use approxim::assert_relative_eq;
-/// use hoomd_geometry::{BoundingSphereRadius, shape::ConvexSurfaceMesh2d};
+/// use hoomd_geometry::shape::ConvexSurfaceMesh2d;
 ///
 /// # fn main() -> Result<(), hoomd_geometry::Error> {
 /// let triangle = ConvexSurfaceMesh2d::from_point_set([
@@ -42,10 +41,6 @@ use itertools::Itertools;
 ///     [-1.0, -1.0].into(),
 ///     [0.0, 1.0].into(),
 /// ])?;
-///
-/// let bounding_radius = triangle.bounding_sphere_radius();
-///
-/// assert_relative_eq!(bounding_radius.get(), 2.0_f64.sqrt());
 /// # Ok(())
 /// # }
 /// ```
@@ -145,7 +140,7 @@ impl ConvexSurfaceMesh2d {
     ///
     /// # Errors
     ///
-    /// * `[Error::DegeneratePolytope]` when there are fewer than 3 non-collinear points.
+    /// * [`Error::DegeneratePolytope`] when there are fewer than 3 non-collinear points.
     ///
     /// # Example
     /// ```
@@ -264,6 +259,56 @@ impl ConvexSurfaceMesh2d {
 }
 
 impl SupportMapping<Cartesian<2>> for ConvexSurfaceMesh2d {
+    /// Find the point on a shape that is the furthest in a given direction.
+    ///
+    /// TODO: that the inherent `IntersectsAt` implementation is faster.
+    ///
+    /// [`ConvexSurfaceMesh2d`] implements [`SupportMapping`] to enable
+    /// intersection tests between mixed convex types.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_geometry::{
+    ///     Convex, IntersectsAt,
+    ///     shape::{Circle, ConvexSurfaceMesh2d, Sphero},
+    /// };
+    /// use hoomd_vector::{Angle, Cartesian};
+    /// use std::f64::consts::PI;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let circle = Convex(Circle {
+    ///     radius: 0.5.try_into()?,
+    /// });
+    /// let rectangle = ConvexSurfaceMesh2d::from_point_set([
+    ///     [-1.5, -1.0].into(),
+    ///     [1.5, -1.0].into(),
+    ///     [-1.5, 1.0].into(),
+    ///     [1.5, 1.0].into()
+    /// ])?;
+    /// let rounded_rectangle = Convex(Sphero {
+    ///     shape: rectangle,
+    ///     rounding_radius: 0.5.try_into()?,
+    /// });
+    ///
+    /// assert!(rounded_rectangle.intersects_at(
+    ///     &circle,
+    ///     &[2.4, 0.0].into(),
+    ///     &Angle::default()
+    /// ));
+    /// assert!(!rounded_rectangle.intersects_at(
+    ///     &circle,
+    ///     &[0.0, 2.4].into(),
+    ///     &Angle::default()
+    /// ));
+    /// assert!(circle.intersects_at(
+    ///     &rounded_rectangle,
+    ///     &[0.0, 2.4].into(),
+    ///     &Angle::from(PI / 2.0)
+    /// ));
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn support_mapping(&self, n: &Cartesian<2>) -> Cartesian<2> {
         *self
@@ -279,9 +324,71 @@ impl SupportMapping<Cartesian<2>> for ConvexSurfaceMesh2d {
 }
 
 impl BoundingSphereRadius for ConvexSurfaceMesh2d {
+    /// Radius of a circle that bounds the shape.
+    ///
+    /// The circle has the same local origin as the shape `self`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use approxim::assert_relative_eq;
+    /// use hoomd_geometry::{BoundingSphereRadius, shape::ConvexSurfaceMesh2d};
+    ///
+    /// # fn main() -> Result<(), hoomd_geometry::Error> {
+    /// let triangle = ConvexSurfaceMesh2d::from_point_set([
+    ///     [1.0, -1.0].into(),
+    ///     [-1.0, -1.0].into(),
+    ///     [0.0, 1.0].into(),
+    /// ])?;
+    ///
+    /// let bounding_radius = triangle.bounding_sphere_radius();
+    ///
+    /// assert_relative_eq!(bounding_radius.get(), 2.0_f64.sqrt());
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     fn bounding_sphere_radius(&self) -> PositiveReal {
         self.bounding_radius
+    }
+}
+
+impl Volume for ConvexSurfaceMesh2d {
+    /// Compute the area of the convex polygon.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use approxim::assert_relative_eq;
+    /// use hoomd_geometry::{Volume, shape::ConvexSurfaceMesh2d};
+    ///
+    /// # fn main() -> Result<(), hoomd_geometry::Error> {
+    /// let triangle = ConvexSurfaceMesh2d::from_point_set([
+    ///     [-1.0, -1.0].into(),
+    ///     [1.0, -1.0].into(),
+    ///     [1.0, 1.0].into(),
+    /// ])?;
+    ///
+    /// let area = triangle.volume();
+    ///
+    /// assert_relative_eq!(area, 2.0);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    fn volume(&self) -> f64 {
+        // Compute the polygon area with the shoelace formula:
+        // https://mathworld.wolfram.com/PolygonArea.html
+        let mut volume = 0.0;
+
+        let mut previous = self.vertices.len() - 1;
+        for current in 0..self.vertices.len() {
+            volume += self.vertices[previous][0] * self.vertices[current][1] - self.vertices[current][0] * self.vertices[previous][1];
+
+            previous = current;
+        }
+
+        0.5 * volume
     }
 }
 

--- a/hoomd-geometry/src/shape/convex_surface_mesh_2d.rs
+++ b/hoomd-geometry/src/shape/convex_surface_mesh_2d.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use std::cmp::Ordering;
 
-use crate::{BoundingSphereRadius, Error, SupportMapping, Volume, shape::ConvexPolytope};
+use crate::{BoundingSphereRadius, Error, IsPointInside, SupportMapping, Volume, shape::ConvexPolytope};
 use hoomd_utility::valid::PositiveReal;
 use hoomd_vector::{Cartesian, InnerProduct};
 use itertools::Itertools;
@@ -24,7 +24,6 @@ use itertools::Itertools;
 /// In contrast, [`ConvexSurfaceMesh2d`] *explicitly* computes the convex hull
 /// on construction. After construction, the [`vertices`] of the shape include
 /// only the points on the convex hull in a counter-clockwise order.
-/// TODO: explicit edges?
 /// TODO: discuss native `IntersectsAt` on the `benchmark-reconciliation` branch.
 ///
 /// [`vertices`]: Self::vertices
@@ -389,6 +388,48 @@ impl Volume for ConvexSurfaceMesh2d {
         }
 
         0.5 * volume
+    }
+}
+
+impl IsPointInside<Cartesian<2>> for ConvexSurfaceMesh2d {
+    /// Check if a point is inside the convex polygon.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_geometry::{IsPointInside, shape::ConvexSurfaceMesh2d};
+    ///
+    /// # fn main() -> Result<(), hoomd_geometry::Error> {
+    /// let triangle = ConvexSurfaceMesh2d::from_point_set([
+    ///     [1.0, -1.0].into(),
+    ///     [-1.0, -1.0].into(),
+    ///     [0.0, 1.0].into(),
+    /// ])?;
+    ///
+    /// assert!(triangle.is_point_inside(&[0.0, 0.0].into()));
+    /// assert!(triangle.is_point_inside(&[-0.9, -0.9].into()));
+    /// assert!(!triangle.is_point_inside(&[-1.5, 2.0].into()));
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    fn is_point_inside(&self, point: &Cartesian<2>) -> bool {
+        let mut previous = self.vertices.len() - 1;
+        for current in 0..self.vertices.len() {
+            let a = self.vertices[current];
+            let b = self.vertices[previous];
+            let edge = a - b;
+            let n = -edge.perpendicular();
+
+            let v = *point - a;
+            if v.dot(&n) > 0.0 {
+                return false;
+            }
+
+            previous = current;
+        }
+                
+        true
     }
 }
 

--- a/hoomd-geometry/src/shape/convex_surface_mesh_2d.rs
+++ b/hoomd-geometry/src/shape/convex_surface_mesh_2d.rs
@@ -3,16 +3,16 @@
 
 //! Convex polygon represented by vertices and edges.
 
-use serde::{Deserialize, Serialize};
-
 use std::cmp::Ordering;
+
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     BoundingSphereRadius, Error, IsPointInside, SupportMapping, Volume, shape::ConvexPolytope,
 };
 use hoomd_utility::valid::PositiveReal;
 use hoomd_vector::{Cartesian, InnerProduct};
-use itertools::Itertools;
 
 /// The vertices and edges that make up a convex polygon.
 ///

--- a/hoomd-geometry/src/shape/convex_surface_mesh_2d.rs
+++ b/hoomd-geometry/src/shape/convex_surface_mesh_2d.rs
@@ -14,7 +14,7 @@ use itertools::Itertools;
 
 /// The vertices and edges that make up a convex polygon.
 ///
-/// [`ConvexPolygon`] and [`ConvexSurfaceMesh2d`] can both represent
+/// [`ConvexPolytope::<2>`] and [`ConvexSurfaceMesh2d`] can both represent
 /// 2d convex polygons. The first is defined *implicitly* as the convex hull
 /// of a set of points. It stores the given point set without any modification,
 /// and can therefore be constructed quickly. The *implicit* convex hull is
@@ -182,6 +182,8 @@ impl ConvexSurfaceMesh2d {
     /// # Errors
     ///
     /// Returns [`Error`] if the input vertices do not form a convex body with 3 or more points.
+    ///
+    /// [`Error`]: enum@Error
     ///
     /// # Example
     /// ```

--- a/hoomd-geometry/src/shape/convex_surface_mesh_2d.rs
+++ b/hoomd-geometry/src/shape/convex_surface_mesh_2d.rs
@@ -1,11 +1,91 @@
 // Copyright (c) 2024-2026 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
+//! N-Dimensional generalization of a convex polyhedron.
+
+use serde::{Deserialize, Serialize};
+
 use std::cmp::Ordering;
 
-use crate::Error;
+use crate::{BoundingSphereRadius, Error, SupportMapping, shape::ConvexPolytope};
+use hoomd_utility::valid::PositiveReal;
 use hoomd_vector::{Cartesian, InnerProduct};
 use itertools::Itertools;
+
+/// The vertices and edges that make up a convex polygon.
+///
+/// [`ConvexPolygon`] and [`ConvexSurfaceMesh2d`] can both represent
+/// 2d convex polygons. The first is defined *implicitly* as the convex hull
+/// of a set of points. It stores the given point set without any modification,
+/// and can therefore be constructed quickly. The *implicit* convex hull is
+/// formed by [`SupportMapping`] during intersection tests of
+/// `Convex(ConvexPolygon)` with other `Convex(_)` types.
+///
+/// In contrast, [`ConvexSurfaceMesh2d`] *explicitly* computes the convex hull
+/// on construction. After construction, the [`vertices`] of the shape include
+/// only the points on the convex hull in a counter-clockwise order.
+/// TODO: explicit edges?
+/// TODO: discuss native `IntersectsAt` on the `benchmark-reconciliation` branch.
+///
+/// [`vertices`]: Self::vertices
+///
+/// # Examples
+///
+/// Construction and basic methods:
+/// ```
+/// use approxim::assert_relative_eq;
+/// use hoomd_geometry::{BoundingSphereRadius, shape::ConvexSurfaceMesh2d};
+///
+/// # fn main() -> Result<(), hoomd_geometry::Error> {
+/// let triangle = ConvexSurfaceMesh2d::from_point_set([
+///     [1.0, -1.0].into(),
+///     [-1.0, -1.0].into(),
+///     [0.0, 1.0].into(),
+/// ])?;
+///
+/// let bounding_radius = triangle.bounding_sphere_radius();
+///
+/// assert_relative_eq!(bounding_radius.get(), 2.0_f64.sqrt());
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Intersection tests:
+/// ```
+/// use hoomd_geometry::{Convex, IntersectsAt, shape::ConvexSurfaceMesh2d};
+/// use hoomd_vector::{Angle, Cartesian};
+/// use std::f64::consts::PI;
+///
+/// # fn main() -> Result<(), hoomd_geometry::Error> {
+/// let rectangle = ConvexSurfaceMesh2d::from_point_set([
+///     [-2.0, -1.0].into(),
+///     [2.0, -1.0].into(),
+///     [2.0, 1.0].into(),
+///     [-2.0, 1.0].into(),
+/// ])?;
+/// let rectangle = Convex(rectangle);
+///
+/// assert!(!rectangle.intersects_at(
+///     &rectangle,
+///     &[0.0, 2.1].into(),
+///     &Angle::default()
+/// ));
+/// assert!(rectangle.intersects_at(
+///     &rectangle,
+///     &[0.0, 2.1].into(),
+///     &Angle::from(PI / 2.0)
+/// ));
+/// # Ok(())
+/// # }
+/// ```
+/// TODO: demonstrate the native `IntersectsAt` on the `benchmark-reconciliation` branch.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ConvexSurfaceMesh2d {
+    /// The vertices of the polygon in counter-clockwise order.
+    vertices: Vec<Cartesian<2>>,
+    /// The radius of a bounding sphere of the geometry.
+    bounding_radius: PositiveReal,
+}
 
 /// Find the lowest, leftmost point from a slice of Cartesian vectors.
 #[inline]
@@ -16,13 +96,14 @@ fn find_lowest_leftmost(vertices: &[Cartesian<2>]) -> Option<usize> {
     })
 }
 
-/// Get the key for a lexographical sort of points with respect to an anchor.
+/// Get the key for a lexicographic order of points with respect to an anchor.
 #[inline]
 fn get_graham_key(p: Cartesian<2>, anchor: Cartesian<2>) -> (f64, f64) {
     let diff = p - anchor;
     (f64::atan2(diff[1], diff[0]), diff.dot(&diff))
 }
-/// Determines whether a point `test` is to the left, right, or colinear with `edge`.
+
+/// Determines whether a point `test` is to the left, right, or collinear with `edge`.
 ///
 /// # Warning
 ///
@@ -55,82 +136,140 @@ fn predicate_orient2d((p, q): (Cartesian<2>, Cartesian<2>), test: Cartesian<2>) 
     }
 }
 
-/// Compute the convex hull of points in two dimensions using a Graham scan.
-///
-/// Mutates the input vector in-place, rearranging and truncating to contain
-/// only the hull vertices.
-///
-/// # Returns
-///
-/// `()` if the hull was computed, [`Error`] if a hull could not be generated.
-///
-/// # Errors
-///
-/// Returns [`Error`] if the input vertices do not form a convex body with 3 or more points.
-#[inline]
-pub fn construct_convex_hull_2d(vertices: &mut Vec<Cartesian<2>>) -> Result<(), Error> {
-    // No need to try and triangulate if the hull is degenerate
-    if vertices.len() < 3 {
-        return Err(Error::DegeneratePolytope);
+impl ConvexSurfaceMesh2d {
+    /// Create an convex surface mesh from the convex hull of the given set of points.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_geometry::shape::ConvexSurfaceMesh2d;
+    ///
+    /// # fn main() -> Result<(), hoomd_geometry::Error> {
+    /// let equilateral_triangle = ConvexSurfaceMesh2d::from_point_set(vec![
+    ///     [1.0, 0.0].into(),
+    ///     [0.5, f64::sqrt(3.0) / 2.0].into(),
+    ///     [-0.5, f64::sqrt(3.0) / 2.0].into(),
+    /// ])?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    /// # Errors
+    ///
+    /// * `[Error::DegeneratePolytope]` when there are fewer than 3 non-collinear points..
+    #[inline]
+    pub fn from_point_set<I>(points: I) -> Result<Self, Error>
+    where
+        I: IntoIterator<Item = Cartesian<2>>,
+    {
+        let vertices = Self::construct_convex_hull(points.into_iter().collect())?;
+
+        Ok(Self {
+            bounding_radius: ConvexPolytope::<2>::bounding_radius(&vertices),
+            vertices,
+        })
     }
-
-    let anchor_idx = find_lowest_leftmost(vertices).ok_or(Error::DegeneratePolytope)?;
-
-    // Move the anchor to the front of the list of vertices, as it is always in the hull
-    vertices.swap(0, anchor_idx);
-    let anchor = vertices[0];
-
-    // Sort the remainder of the slice in-place
-    vertices[1..].sort_unstable_by(|&a, &b| {
-        let (a0, a1) = get_graham_key(a, anchor);
-        let (b0, b1) = get_graham_key(b, anchor);
-        a0.total_cmp(&b0).then(a1.total_cmp(&b1))
-    });
-
-    // Now vertices[..2] is an edge on the hull. Initialize counters for the hull length
-    // and number of vertices on the hull
-    let mut n_vertices_on_hull = 2;
-    let mut next_candidate = 2;
-
-    // Repeat until all interior points are gone
-    while next_candidate < vertices.len() {
-        let c = vertices[next_candidate];
-        while n_vertices_on_hull >= 2 {
-            let p = vertices[n_vertices_on_hull - 2];
-            let n = vertices[n_vertices_on_hull - 1];
-
-            if predicate_orient2d((p, n), c) <= 0 {
-                // Point n is inside the hull, remove it by shrinking the hull
-                n_vertices_on_hull -= 1;
-            } else {
-                break;
-            }
+    
+    
+    /// Compute the convex hull of points in two dimensions.
+    ///
+    /// The resulting vector contains a subset of the given points, including
+    /// only the non-degenerate points on the convex hull. The output
+    /// vertices are arranged in a counter-clockwise order.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error`] if the input vertices do not form a convex body with 3 or more points.
+    #[inline]
+    pub fn construct_convex_hull(mut points: Vec<Cartesian<2>>) -> Result<Vec<Cartesian<2>>, Error> {
+        // No need to try and triangulate if the hull is degenerate
+        if points.len() < 3 {
+            return Err(Error::DegeneratePolytope);
         }
-        // Swap the vertex c onto the end of the hull, extending it by one
-        vertices.swap(next_candidate, n_vertices_on_hull);
-        n_vertices_on_hull += 1;
-        next_candidate += 1;
+
+        let anchor_idx = find_lowest_leftmost(&points).ok_or(Error::DegeneratePolytope)?;
+
+        // Move the anchor to the front of the list of vertices, as it is always in the hull
+        points.swap(0, anchor_idx);
+        let anchor = points[0];
+
+        // Sort the remainder of the slice in-place
+        points[1..].sort_unstable_by(|&a, &b| {
+            let (a0, a1) = get_graham_key(a, anchor);
+            let (b0, b1) = get_graham_key(b, anchor);
+            a0.total_cmp(&b0).then(a1.total_cmp(&b1))
+        });
+
+        // Now vertices[..2] is an edge on the hull. Initialize counters for the hull length
+        // and number of vertices on the hull
+        let mut n_vertices_on_hull = 2;
+        let mut next_candidate = 2;
+
+        // Repeat until all interior points are gone
+        while next_candidate < points.len() {
+            let c = points[next_candidate];
+            while n_vertices_on_hull >= 2 {
+                let p = points[n_vertices_on_hull - 2];
+                let n = points[n_vertices_on_hull - 1];
+
+                if predicate_orient2d((p, n), c) <= 0 {
+                    // Point n is inside the hull, remove it by shrinking the hull
+                    n_vertices_on_hull -= 1;
+                } else {
+                    break;
+                }
+            }
+            // Swap the vertex c onto the end of the hull, extending it by one
+            points.swap(next_candidate, n_vertices_on_hull);
+            n_vertices_on_hull += 1;
+            next_candidate += 1;
+        }
+
+        points.truncate(n_vertices_on_hull);
+        if points.len() >= 3 {
+            Ok(points)
+        } else {
+            Err(Error::DegeneratePolytope)
+        }
     }
 
-    vertices.truncate(n_vertices_on_hull);
-    if vertices.len() >= 3 {
-        Ok(())
-    } else {
-        Err(Error::DegeneratePolytope)
+    /// The vertices of the convex polygon in counter-clockwise order.
+    #[inline]
+    #[must_use]
+    pub fn vertices(&self) -> &[Cartesian<2>] {
+        &self.vertices
+    }
+}
+
+impl SupportMapping<Cartesian<2>> for ConvexSurfaceMesh2d
+{
+    #[inline]
+    fn support_mapping(&self, n: &Cartesian<2>) -> Cartesian<2> {
+            *self
+                .vertices
+                .iter()
+                .max_by(|a, b| {
+                    a.dot(n)
+                        .partial_cmp(&b.dot(n))
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                })
+                .expect("there should be at least 3 vertices")
+    }
+}
+
+impl BoundingSphereRadius for ConvexSurfaceMesh2d
+{
+    #[inline]
+    fn bounding_sphere_radius(&self) -> PositiveReal {
+        self.bounding_radius
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use approxim::assert_relative_eq;
+    use assert2::check;
     use super::*;
     use rand::{RngExt, SeedableRng, rngs::StdRng};
     use rstest::*;
-
-    /// Helper to check if a point is approximately in the hull
-    fn hull_contains(hull: &[Cartesian<2>], point: [f64; 2], tol: f64) -> bool {
-        hull.iter()
-            .any(|h| (h[0] - point[0]).abs() < tol && (h[1] - point[1]).abs() < tol)
-    }
 
     #[rstest]
     #[case::single_point(vec![[1.0, 2.0]], 0)]
@@ -167,11 +306,11 @@ mod tests {
 
     #[rstest]
     fn test_square_corners() {
-        let mut vertices: Vec<Cartesian<2>> = vec![[1.0, 1.0], [1.0, 0.0], [0.0, 0.0], [0.0, 1.0]]
+        let points: Vec<Cartesian<2>> = vec![[1.0, 1.0], [1.0, 0.0], [0.0, 0.0], [0.0, 1.0]]
             .into_iter()
             .map(Cartesian::from)
             .collect();
-        construct_convex_hull_2d(&mut vertices).unwrap();
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
         assert_eq!(vertices.len(), 4);
 
         let hull = [
@@ -185,7 +324,7 @@ mod tests {
 
     #[rstest]
     fn test_square_corners_big() {
-        let mut vertices: Vec<Cartesian<2>> = vec![
+        let points: Vec<Cartesian<2>> = vec![
             [101.0, 101.0],
             [101.0, 100.0],
             [100.0, 101.0],
@@ -194,7 +333,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        construct_convex_hull_2d(&mut vertices).unwrap();
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
         assert_eq!(vertices.len(), 4);
 
         let hull = [
@@ -208,7 +347,7 @@ mod tests {
 
     #[rstest]
     fn test_square_with_edge_points() {
-        let mut vertices: Vec<Cartesian<2>> = vec![
+        let points: Vec<Cartesian<2>> = vec![
             [0.0, 0.0],
             [0.5, 0.0],
             [1.0, 0.0], // bottom edge
@@ -221,7 +360,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        construct_convex_hull_2d(&mut vertices).unwrap();
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
         // Hull should have 4 corners (interior edge points excluded)
         assert_eq!(vertices.len(), 4);
         let hull = [
@@ -252,8 +391,8 @@ mod tests {
         for i in 0..20 {
             pts.push([0.0, f64::from(i) / 19.0]);
         }
-        let mut vertices: Vec<Cartesian<2>> = pts.into_iter().map(Cartesian::from).collect();
-        construct_convex_hull_2d(&mut vertices).unwrap();
+        let points: Vec<Cartesian<2>> = pts.into_iter().map(Cartesian::from).collect();
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
         assert_eq!(vertices.len(), 4);
 
         let hull = [
@@ -268,13 +407,13 @@ mod tests {
     #[rstest]
     fn test_circle_uniform() {
         let n = 20;
-        let mut vertices: Vec<Cartesian<2>> = (0..n)
+        let points: Vec<Cartesian<2>> = (0..n)
             .map(|i| {
                 let angle = 2.0 * std::f64::consts::PI * i as f64 / n as f64;
                 Cartesian::from([angle.cos(), angle.sin()])
             })
             .collect();
-        construct_convex_hull_2d(&mut vertices).unwrap();
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
         // All points on circle should be in hull
         assert_eq!(vertices.len(), n);
     }
@@ -282,29 +421,29 @@ mod tests {
     #[rstest]
     fn test_circle_with_interior_points() {
         let n_boundary = 12;
-        let mut vertices: Vec<Cartesian<2>> = (0..n_boundary)
+        let mut points: Vec<Cartesian<2>> = (0..n_boundary)
             .map(|i| {
                 let angle = 2.0 * std::f64::consts::PI * i as f64 / n_boundary as f64;
                 Cartesian::from([angle.cos(), angle.sin()])
             })
             .collect();
         // Add interior points
-        vertices.extend([[0.0, 0.0], [0.3, 0.3], [-0.2, 0.1], [0.1, -0.4]].map(Cartesian::from));
-        construct_convex_hull_2d(&mut vertices).unwrap();
+        points.extend([[0.0, 0.0], [0.3, 0.3], [-0.2, 0.1], [0.1, -0.4]].map(Cartesian::from));
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
         // Only boundary points should be in hull
         assert_eq!(vertices.len(), n_boundary);
     }
 
     #[rstest]
     fn test_circle_partial_arc() {
-        let mut vertices: Vec<Cartesian<2>> = (0..10)
+        let points: Vec<Cartesian<2>> = (0..10)
             .map(|i| {
                 let angle = -std::f64::consts::FRAC_PI_4
                     + (std::f64::consts::FRAC_PI_2 * f64::from(i) / 9.0);
                 Cartesian::from([angle.cos(), angle.sin()])
             })
             .collect();
-        construct_convex_hull_2d(&mut vertices).unwrap();
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
         // All points on partial arc should be in hull
         assert_eq!(vertices.len(), 10);
     }
@@ -315,8 +454,8 @@ mod tests {
         let original: Vec<Cartesian<2>> = (0..50)
             .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
             .collect();
-        let mut vertices = original.clone();
-        construct_convex_hull_2d(&mut vertices).unwrap();
+        let points = original.clone();
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
         // Hull should have at least 3 points
         assert!(vertices.len() >= 3);
         // All hull points should be in original set
@@ -328,7 +467,7 @@ mod tests {
     #[rstest]
     fn test_random_gaussian() {
         let mut rng = StdRng::seed_from_u64(42);
-        let mut vertices: Vec<Cartesian<2>> = (0..100)
+        let points: Vec<Cartesian<2>> = (0..100)
             .map(|_| {
                 Cartesian::from([
                     rng.random::<f64>() * 2.0 - 1.0,
@@ -336,7 +475,7 @@ mod tests {
                 ])
             })
             .collect();
-        construct_convex_hull_2d(&mut vertices).unwrap();
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
         assert!(vertices.len() >= 3);
     }
 
@@ -344,16 +483,16 @@ mod tests {
     fn test_random_deterministic_output() {
         for _ in 0..3 {
             let mut rng = StdRng::seed_from_u64(123);
-            let mut vertices1: Vec<Cartesian<2>> = (0..30)
+            let points1: Vec<Cartesian<2>> = (0..30)
                 .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
                 .collect();
-            construct_convex_hull_2d(&mut vertices1).unwrap();
+        let vertices1 = ConvexSurfaceMesh2d::construct_convex_hull(points1).expect("hard-coded points should lie on a convex hull");
 
             let mut rng = StdRng::seed_from_u64(123);
-            let mut vertices2: Vec<Cartesian<2>> = (0..30)
+            let points2: Vec<Cartesian<2>> = (0..30)
                 .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
                 .collect();
-            construct_convex_hull_2d(&mut vertices2).unwrap();
+        let vertices2 = ConvexSurfaceMesh2d::construct_convex_hull(points2).expect("hard-coded points should lie on a convex hull");
 
             assert_eq!(vertices1.len(), vertices2.len());
         }
@@ -361,7 +500,7 @@ mod tests {
 
     #[rstest]
     fn test_duplicate_lowest_points() {
-        let mut vertices: Vec<Cartesian<2>> = vec![
+        let points: Vec<Cartesian<2>> = vec![
             [0.0, 0.0],
             [0.0, 0.0],
             [0.0, 0.0], // Three duplicates of lowest
@@ -372,7 +511,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        construct_convex_hull_2d(&mut vertices).unwrap();
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
         assert!(vertices.len() >= 3);
 
         let hull = [
@@ -386,7 +525,7 @@ mod tests {
 
     #[rstest]
     fn test_many_duplicates_few_unique() {
-        let mut vertices: Vec<Cartesian<2>> = vec![
+        let points: Vec<Cartesian<2>> = vec![
             [0.0, 0.0],
             [0.0, 0.0],
             [0.0, 0.0],
@@ -399,7 +538,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        construct_convex_hull_2d(&mut vertices).unwrap();
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
         // Should handle duplicates gracefully
         assert!(vertices.len() >= 3);
 
@@ -409,7 +548,7 @@ mod tests {
 
     #[rstest]
     fn test_collinear_bottom_edge() {
-        let mut vertices: Vec<Cartesian<2>> = vec![
+        let points: Vec<Cartesian<2>> = vec![
             [0.0, 0.0],
             [0.5, 0.0],
             [1.0, 0.0],
@@ -419,7 +558,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        construct_convex_hull_2d(&mut vertices).unwrap();
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
         // Should pick leftmost of bottom points and include apex
         assert!(vertices.len() >= 3);
 
@@ -429,7 +568,7 @@ mod tests {
 
     #[rstest]
     fn test_leftmost_selected() {
-        let mut vertices: Vec<Cartesian<2>> = vec![
+        let points: Vec<Cartesian<2>> = vec![
             [0.5, 0.0],
             [1.0, 0.0],
             [0.0, 0.0], // All y=0, but [0,0] is leftmost
@@ -438,27 +577,25 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        construct_convex_hull_2d(&mut vertices).unwrap();
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
         // [0, 0] should be the anchor point
-        assert!(hull_contains(&vertices, [0.0, 0.0], 1e-10));
-
         let hull = [[0.0, 0.0].into(), [1.0, 0.0].into(), [0.5, 1.0].into()];
         itertools::assert_equal(&vertices, &hull);
     }
 
     #[rstest]
     fn test_many_bottom_points() {
-        let mut pts: Vec<[f64; 2]> = (0..10).map(|i| [f64::from(i) * 2.0 / 9.0, 0.0]).collect();
-        pts.push([1.0, 1.0]); // Apex
-        let mut vertices: Vec<Cartesian<2>> = pts.into_iter().map(Cartesian::from).collect();
-        construct_convex_hull_2d(&mut vertices).unwrap();
+        let mut points: Vec<[f64; 2]> = (0..10).map(|i| [f64::from(i) * 2.0 / 9.0, 0.0]).collect();
+        points.push([1.0, 1.0]); // Apex
+        let points: Vec<Cartesian<2>> = points.into_iter().map(Cartesian::from).collect();
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
         // Leftmost [0,0] and rightmost [2,0] should be in hull with apex
         assert!(vertices.len() >= 3);
     }
 
     #[rstest]
     fn test_collinear_from_anchor() {
-        let mut vertices: Vec<Cartesian<2>> = vec![
+        let points: Vec<Cartesian<2>> = vec![
             [0.0, 0.0], // Anchor (lowest leftmost)
             [1.0, 1.0],
             [2.0, 2.0],
@@ -469,7 +606,7 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        construct_convex_hull_2d(&mut vertices).unwrap();
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
         // Should only keep furthest point in each direction
         assert!(vertices.len() >= 3);
 
@@ -484,7 +621,7 @@ mod tests {
 
     #[rstest]
     fn test_radial_collinear_multiple_directions() {
-        let mut vertices: Vec<Cartesian<2>> = vec![
+        let points: Vec<Cartesian<2>> = vec![
             [0.0, 0.0], // Anchor
             [1.0, 0.0],
             [2.0, 0.0],
@@ -500,33 +637,33 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        construct_convex_hull_2d(&mut vertices).unwrap();
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
         // Should keep only outermost points
         assert!(vertices.len() >= 3);
     }
 
     #[rstest]
     fn test_star_pattern() {
-        let mut vertices: Vec<Cartesian<2>> = vec![Cartesian::from([0.0, 0.0])]; // Anchor
+        let mut points: Vec<Cartesian<2>> = vec![Cartesian::from([0.0, 0.0])]; // Anchor
         // Create points along 8 rays
         for i in 0..8 {
             let angle = 2.0 * std::f64::consts::PI * f64::from(i) / 8.0;
             for r in [0.5, 1.0, 1.5] {
-                vertices.push(Cartesian::from([r * angle.cos(), r * angle.sin()]));
+                points.push(Cartesian::from([r * angle.cos(), r * angle.sin()]));
             }
         }
-        construct_convex_hull_2d(&mut vertices).unwrap();
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
         // Outer points should form the hull
         assert!(vertices.len() >= 8); // At least 8 outer points
     }
 
     #[rstest]
     fn test_minimum_triangle() {
-        let mut vertices: Vec<Cartesian<2>> = vec![[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]]
+        let points: Vec<Cartesian<2>> = vec![[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]]
             .into_iter()
             .map(Cartesian::from)
             .collect();
-        construct_convex_hull_2d(&mut vertices).unwrap();
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
         assert_eq!(vertices.len(), 3);
 
         let hull = [[0.0, 0.0].into(), [1.0, 0.0].into(), [0.5, 1.0].into()];
@@ -535,12 +672,12 @@ mod tests {
 
     #[rstest]
     fn test_negative_coordinates() {
-        let mut vertices: Vec<Cartesian<2>> =
+        let points: Vec<Cartesian<2>> =
             vec![[1.0, 1.0], [1.0, -1.0], [-1.0, 1.0], [-1.0, -1.0]]
                 .into_iter()
                 .map(Cartesian::from)
                 .collect();
-        construct_convex_hull_2d(&mut vertices).unwrap();
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
         assert_eq!(vertices.len(), 4);
 
         let hull = [
@@ -554,11 +691,11 @@ mod tests {
 
     #[rstest]
     fn test_large_coordinates() {
-        let mut vertices: Vec<Cartesian<2>> = vec![[0.0, 0.0], [1e6, 0.0], [1e6, 1e6], [0.0, 1e6]]
+        let points: Vec<Cartesian<2>> = vec![[0.0, 0.0], [1e6, 0.0], [1e6, 1e6], [0.0, 1e6]]
             .into_iter()
             .map(Cartesian::from)
             .collect();
-        construct_convex_hull_2d(&mut vertices).unwrap();
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
         assert_eq!(vertices.len(), 4);
 
         let hull = [
@@ -568,5 +705,45 @@ mod tests {
             [0.0, 1e6].into(),
         ];
         itertools::assert_equal(&vertices, &hull);
+    }
+
+    #[rstest]
+    fn test_degenerate() {
+        let points: Vec<Cartesian<2>> =
+            vec![[0.0, 0.0], [0.5, 0.5], [0.25, 0.25], [1.0, 1.0]]
+                .into_iter()
+                .map(Cartesian::from)
+                .collect();
+        let result = ConvexSurfaceMesh2d::construct_convex_hull(points);
+        check!(result == Err(Error::DegeneratePolytope));
+    }
+
+
+    #[test]
+    fn support_mapping_2d() {
+        let cuboid = ConvexSurfaceMesh2d::from_point_set([
+            [-1.0, -2.0].into(),
+            [1.0, -2.0].into(),
+            [1.0, 2.0].into(),
+            [-1.0, 2.0].into(),
+        ])
+        .expect("hard-coded vertices form a polygon");
+
+        assert_relative_eq!(
+            cuboid.support_mapping(&Cartesian::from([1.0, 0.1])),
+            [1.0, 2.0].into()
+        );
+        assert_relative_eq!(
+            cuboid.support_mapping(&Cartesian::from([1.0, -0.1])),
+            [1.0, -2.0].into()
+        );
+        assert_relative_eq!(
+            cuboid.support_mapping(&Cartesian::from([-0.1, 1.0])),
+            [-1.0, 2.0].into()
+        );
+        assert_relative_eq!(
+            cuboid.support_mapping(&Cartesian::from([-0.1, -1.0])),
+            [-1.0, -2.0].into()
+        );
     }
 }

--- a/hoomd-geometry/src/shape/convex_surface_mesh_2d.rs
+++ b/hoomd-geometry/src/shape/convex_surface_mesh_2d.rs
@@ -172,8 +172,7 @@ impl ConvexSurfaceMesh2d {
             vertices,
         })
     }
-    
-    
+
     /// Compute the convex hull of points in two dimensions.
     ///
     /// The resulting vector contains a subset of the given points, including
@@ -200,7 +199,9 @@ impl ConvexSurfaceMesh2d {
     /// # }
     /// ```
     #[inline]
-    pub fn construct_convex_hull(mut points: Vec<Cartesian<2>>) -> Result<Vec<Cartesian<2>>, Error> {
+    pub fn construct_convex_hull(
+        mut points: Vec<Cartesian<2>>,
+    ) -> Result<Vec<Cartesian<2>>, Error> {
         // No need to try and triangulate if the hull is degenerate
         if points.len() < 3 {
             return Err(Error::DegeneratePolytope);
@@ -260,24 +261,22 @@ impl ConvexSurfaceMesh2d {
     }
 }
 
-impl SupportMapping<Cartesian<2>> for ConvexSurfaceMesh2d
-{
+impl SupportMapping<Cartesian<2>> for ConvexSurfaceMesh2d {
     #[inline]
     fn support_mapping(&self, n: &Cartesian<2>) -> Cartesian<2> {
-            *self
-                .vertices
-                .iter()
-                .max_by(|a, b| {
-                    a.dot(n)
-                        .partial_cmp(&b.dot(n))
-                        .unwrap_or(std::cmp::Ordering::Equal)
-                })
-                .expect("there should be at least 3 vertices")
+        *self
+            .vertices
+            .iter()
+            .max_by(|a, b| {
+                a.dot(n)
+                    .partial_cmp(&b.dot(n))
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .expect("there should be at least 3 vertices")
     }
 }
 
-impl BoundingSphereRadius for ConvexSurfaceMesh2d
-{
+impl BoundingSphereRadius for ConvexSurfaceMesh2d {
     #[inline]
     fn bounding_sphere_radius(&self) -> PositiveReal {
         self.bounding_radius
@@ -286,9 +285,9 @@ impl BoundingSphereRadius for ConvexSurfaceMesh2d
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use approxim::assert_relative_eq;
     use assert2::check;
-    use super::*;
     use rand::{RngExt, SeedableRng, rngs::StdRng};
     use rstest::*;
 
@@ -331,7 +330,8 @@ mod tests {
             .into_iter()
             .map(Cartesian::from)
             .collect();
-        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)
+            .expect("hard-coded points should lie on a convex hull");
         assert_eq!(vertices.len(), 4);
 
         let hull = [
@@ -354,7 +354,8 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)
+            .expect("hard-coded points should lie on a convex hull");
         assert_eq!(vertices.len(), 4);
 
         let hull = [
@@ -381,7 +382,8 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)
+            .expect("hard-coded points should lie on a convex hull");
         // Hull should have 4 corners (interior edge points excluded)
         assert_eq!(vertices.len(), 4);
         let hull = [
@@ -413,7 +415,8 @@ mod tests {
             pts.push([0.0, f64::from(i) / 19.0]);
         }
         let points: Vec<Cartesian<2>> = pts.into_iter().map(Cartesian::from).collect();
-        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)
+            .expect("hard-coded points should lie on a convex hull");
         assert_eq!(vertices.len(), 4);
 
         let hull = [
@@ -434,7 +437,8 @@ mod tests {
                 Cartesian::from([angle.cos(), angle.sin()])
             })
             .collect();
-        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)
+            .expect("hard-coded points should lie on a convex hull");
         // All points on circle should be in hull
         assert_eq!(vertices.len(), n);
     }
@@ -450,7 +454,8 @@ mod tests {
             .collect();
         // Add interior points
         points.extend([[0.0, 0.0], [0.3, 0.3], [-0.2, 0.1], [0.1, -0.4]].map(Cartesian::from));
-        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)
+            .expect("hard-coded points should lie on a convex hull");
         // Only boundary points should be in hull
         assert_eq!(vertices.len(), n_boundary);
     }
@@ -464,7 +469,8 @@ mod tests {
                 Cartesian::from([angle.cos(), angle.sin()])
             })
             .collect();
-        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)
+            .expect("hard-coded points should lie on a convex hull");
         // All points on partial arc should be in hull
         assert_eq!(vertices.len(), 10);
     }
@@ -476,7 +482,8 @@ mod tests {
             .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
             .collect();
         let points = original.clone();
-        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)
+            .expect("hard-coded points should lie on a convex hull");
         // Hull should have at least 3 points
         assert!(vertices.len() >= 3);
         // All hull points should be in original set
@@ -496,7 +503,8 @@ mod tests {
                 ])
             })
             .collect();
-        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)
+            .expect("hard-coded points should lie on a convex hull");
         assert!(vertices.len() >= 3);
     }
 
@@ -507,13 +515,15 @@ mod tests {
             let points1: Vec<Cartesian<2>> = (0..30)
                 .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
                 .collect();
-        let vertices1 = ConvexSurfaceMesh2d::construct_convex_hull(points1).expect("hard-coded points should lie on a convex hull");
+            let vertices1 = ConvexSurfaceMesh2d::construct_convex_hull(points1)
+                .expect("hard-coded points should lie on a convex hull");
 
             let mut rng = StdRng::seed_from_u64(123);
             let points2: Vec<Cartesian<2>> = (0..30)
                 .map(|_| Cartesian::from([rng.random::<f64>(), rng.random::<f64>()]))
                 .collect();
-        let vertices2 = ConvexSurfaceMesh2d::construct_convex_hull(points2).expect("hard-coded points should lie on a convex hull");
+            let vertices2 = ConvexSurfaceMesh2d::construct_convex_hull(points2)
+                .expect("hard-coded points should lie on a convex hull");
 
             assert_eq!(vertices1.len(), vertices2.len());
         }
@@ -532,7 +542,8 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)
+            .expect("hard-coded points should lie on a convex hull");
         assert!(vertices.len() >= 3);
 
         let hull = [
@@ -559,7 +570,8 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)
+            .expect("hard-coded points should lie on a convex hull");
         // Should handle duplicates gracefully
         assert!(vertices.len() >= 3);
 
@@ -579,7 +591,8 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)
+            .expect("hard-coded points should lie on a convex hull");
         // Should pick leftmost of bottom points and include apex
         assert!(vertices.len() >= 3);
 
@@ -598,7 +611,8 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)
+            .expect("hard-coded points should lie on a convex hull");
         // [0, 0] should be the anchor point
         let hull = [[0.0, 0.0].into(), [1.0, 0.0].into(), [0.5, 1.0].into()];
         itertools::assert_equal(&vertices, &hull);
@@ -609,7 +623,8 @@ mod tests {
         let mut points: Vec<[f64; 2]> = (0..10).map(|i| [f64::from(i) * 2.0 / 9.0, 0.0]).collect();
         points.push([1.0, 1.0]); // Apex
         let points: Vec<Cartesian<2>> = points.into_iter().map(Cartesian::from).collect();
-        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)
+            .expect("hard-coded points should lie on a convex hull");
         // Leftmost [0,0] and rightmost [2,0] should be in hull with apex
         assert!(vertices.len() >= 3);
     }
@@ -627,7 +642,8 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)
+            .expect("hard-coded points should lie on a convex hull");
         // Should only keep furthest point in each direction
         assert!(vertices.len() >= 3);
 
@@ -658,7 +674,8 @@ mod tests {
         .into_iter()
         .map(Cartesian::from)
         .collect();
-        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)
+            .expect("hard-coded points should lie on a convex hull");
         // Should keep only outermost points
         assert!(vertices.len() >= 3);
     }
@@ -673,7 +690,8 @@ mod tests {
                 points.push(Cartesian::from([r * angle.cos(), r * angle.sin()]));
             }
         }
-        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)
+            .expect("hard-coded points should lie on a convex hull");
         // Outer points should form the hull
         assert!(vertices.len() >= 8); // At least 8 outer points
     }
@@ -684,7 +702,8 @@ mod tests {
             .into_iter()
             .map(Cartesian::from)
             .collect();
-        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)
+            .expect("hard-coded points should lie on a convex hull");
         assert_eq!(vertices.len(), 3);
 
         let hull = [[0.0, 0.0].into(), [1.0, 0.0].into(), [0.5, 1.0].into()];
@@ -693,12 +712,12 @@ mod tests {
 
     #[rstest]
     fn test_negative_coordinates() {
-        let points: Vec<Cartesian<2>> =
-            vec![[1.0, 1.0], [1.0, -1.0], [-1.0, 1.0], [-1.0, -1.0]]
-                .into_iter()
-                .map(Cartesian::from)
-                .collect();
-        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
+        let points: Vec<Cartesian<2>> = vec![[1.0, 1.0], [1.0, -1.0], [-1.0, 1.0], [-1.0, -1.0]]
+            .into_iter()
+            .map(Cartesian::from)
+            .collect();
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)
+            .expect("hard-coded points should lie on a convex hull");
         assert_eq!(vertices.len(), 4);
 
         let hull = [
@@ -716,7 +735,8 @@ mod tests {
             .into_iter()
             .map(Cartesian::from)
             .collect();
-        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points).expect("hard-coded points should lie on a convex hull");
+        let vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)
+            .expect("hard-coded points should lie on a convex hull");
         assert_eq!(vertices.len(), 4);
 
         let hull = [
@@ -730,15 +750,13 @@ mod tests {
 
     #[rstest]
     fn test_degenerate() {
-        let points: Vec<Cartesian<2>> =
-            vec![[0.0, 0.0], [0.5, 0.5], [0.25, 0.25], [1.0, 1.0]]
-                .into_iter()
-                .map(Cartesian::from)
-                .collect();
+        let points: Vec<Cartesian<2>> = vec![[0.0, 0.0], [0.5, 0.5], [0.25, 0.25], [1.0, 1.0]]
+            .into_iter()
+            .map(Cartesian::from)
+            .collect();
         let result = ConvexSurfaceMesh2d::construct_convex_hull(points);
         check!(result == Err(Error::DegeneratePolytope));
     }
-
 
     #[test]
     fn support_mapping_2d() {

--- a/hoomd-geometry/src/shape/convex_surface_mesh_2d.rs
+++ b/hoomd-geometry/src/shape/convex_surface_mesh_2d.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize};
 
 use std::cmp::Ordering;
 
-use crate::{BoundingSphereRadius, Error, IsPointInside, SupportMapping, Volume, shape::ConvexPolytope};
+use crate::{
+    BoundingSphereRadius, Error, IsPointInside, SupportMapping, Volume, shape::ConvexPolytope,
+};
 use hoomd_utility::valid::PositiveReal;
 use hoomd_vector::{Cartesian, InnerProduct};
 use itertools::Itertools;
@@ -283,7 +285,7 @@ impl SupportMapping<Cartesian<2>> for ConvexSurfaceMesh2d {
     ///     [-1.5, -1.0].into(),
     ///     [1.5, -1.0].into(),
     ///     [-1.5, 1.0].into(),
-    ///     [1.5, 1.0].into()
+    ///     [1.5, 1.0].into(),
     /// ])?;
     /// let rounded_rectangle = Convex(Sphero {
     ///     shape: rectangle,
@@ -382,7 +384,8 @@ impl Volume for ConvexSurfaceMesh2d {
 
         let mut previous = self.vertices.len() - 1;
         for current in 0..self.vertices.len() {
-            volume += self.vertices[previous][0] * self.vertices[current][1] - self.vertices[current][0] * self.vertices[previous][1];
+            volume += self.vertices[previous][0] * self.vertices[current][1]
+                - self.vertices[current][0] * self.vertices[previous][1];
 
             previous = current;
         }
@@ -428,7 +431,7 @@ impl IsPointInside<Cartesian<2>> for ConvexSurfaceMesh2d {
 
             previous = current;
         }
-                
+
         true
     }
 }

--- a/hoomd-geometry/src/shape/convex_surface_mesh_2d.rs
+++ b/hoomd-geometry/src/shape/convex_surface_mesh_2d.rs
@@ -139,12 +139,20 @@ fn predicate_orient2d((p, q): (Cartesian<2>, Cartesian<2>), test: Cartesian<2>) 
 impl ConvexSurfaceMesh2d {
     /// Create an convex surface mesh from the convex hull of the given set of points.
     ///
+    /// The resulting shape contains a subset of the given points, including
+    /// only the non-degenerate points on the convex hull. The result's vertices
+    /// are arranged in a counter-clockwise order.
+    ///
+    /// # Errors
+    ///
+    /// * `[Error::DegeneratePolytope]` when there are fewer than 3 non-collinear points.
+    ///
     /// # Example
     /// ```
     /// use hoomd_geometry::shape::ConvexSurfaceMesh2d;
     ///
     /// # fn main() -> Result<(), hoomd_geometry::Error> {
-    /// let equilateral_triangle = ConvexSurfaceMesh2d::from_point_set(vec![
+    /// let equilateral_triangle = ConvexSurfaceMesh2d::from_point_set([
     ///     [1.0, 0.0].into(),
     ///     [0.5, f64::sqrt(3.0) / 2.0].into(),
     ///     [-0.5, f64::sqrt(3.0) / 2.0].into(),
@@ -152,9 +160,6 @@ impl ConvexSurfaceMesh2d {
     /// # Ok(())
     /// # }
     /// ```
-    /// # Errors
-    ///
-    /// * `[Error::DegeneratePolytope]` when there are fewer than 3 non-collinear points..
     #[inline]
     pub fn from_point_set<I>(points: I) -> Result<Self, Error>
     where
@@ -172,12 +177,28 @@ impl ConvexSurfaceMesh2d {
     /// Compute the convex hull of points in two dimensions.
     ///
     /// The resulting vector contains a subset of the given points, including
-    /// only the non-degenerate points on the convex hull. The output
-    /// vertices are arranged in a counter-clockwise order.
+    /// only the non-degenerate points on the convex hull. The output vertices
+    /// are arranged in a counter-clockwise order.
     ///
     /// # Errors
     ///
     /// Returns [`Error`] if the input vertices do not form a convex body with 3 or more points.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_geometry::shape::ConvexSurfaceMesh2d;
+    ///
+    /// # fn main() -> Result<(), hoomd_geometry::Error> {
+    /// let points = vec![
+    ///     [1.0, 0.0].into(),
+    ///     [0.5, f64::sqrt(3.0) / 2.0].into(),
+    ///     [-0.5, f64::sqrt(3.0) / 2.0].into(),
+    /// ];
+    ///
+    /// let hull_vertices = ConvexSurfaceMesh2d::construct_convex_hull(points)?;
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     pub fn construct_convex_hull(mut points: Vec<Cartesian<2>>) -> Result<Vec<Cartesian<2>>, Error> {
         // No need to try and triangulate if the hull is degenerate

--- a/hoomd-geometry/src/shape/mod.rs
+++ b/hoomd-geometry/src/shape/mod.rs
@@ -40,3 +40,6 @@ pub use sphere::{Circle, Hypersphere, Sphere};
 
 mod sphero;
 pub use sphero::Sphero;
+
+mod convex_surface_mesh_2d;
+pub use convex_surface_mesh_2d::ConvexSurfaceMesh2d;


### PR DESCRIPTION
## Description

This PR adds a two dimensional convex hull algorithm based on the Graham scan, which sorts points relative to a known anchor before pruning vertices inside the hull. The upside is an `n log n` runtime, fewer calls to the numerically problematic `orient2d` predicate than gift wrapping, and a simpler implementation than quickhull.

## Design Decision (TODO)

Because the hull code requires a fixed dimension, it cannot go directly into `with_vertices`. I propose we rename the previous code to `with_vertices_unchecked` (which would result in panics if the input is empty, but this seems OK to me), and have the correctly validated code be `with_vertices`. I will write a 3d hull at some point soon, which could provide the N=3 variant of that method. @joaander , let me know what you think when you're back from break.

### predicates

I use a [modified version of the standard determinant-based orientation predicate](https://observablehq.com/@mourner/non-robust-arithmetic-as-art), which uses the coordinates of a simplex formed by an edge+point in global coordinates, rather than the simpler local coordinates.

I do not implement the fully robust predicate, although we could use the implementation Michelle uses for Voronoi -- that being said, in 2D all but the most extreme degenerate cases will be hulled correctly even without robust predicates.

The following is a plot of the output of the predicate associated with this PR, highlighting the accuracy improvements compared to the standard predicate. Note the plots show squares of side length $2^{-42}$.

| Naive Predicate | Improved Predicate |
| ------------- | ------------- |
| ![naive_predicate](https://github.com/user-attachments/assets/514c1a49-78bc-465d-b1e6-f42060822328)  | ![symmetric_predicate](https://github.com/user-attachments/assets/7ff9d487-c5bf-4ebf-a751-1e83e2dc56a5)  |






## Motivation and context



This allows us to validate 2d convex polygon inputs, and implement separating planes for hard polygons

## How has this been tested?

New tests have been added.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**hoomd-rs Contributor Agreement**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/credits.md`) in the pull request source branch.
- [ ] I have summarized these changes in `CHANGELOG.md` following the established format.