### PR TITLE
Manifold gsd

### DIFF
--- a/.github/workflows/interactive-examples.yaml
+++ b/.github/workflows/interactive-examples.yaml
@@ -59,7 +59,7 @@ jobs:
       with:
         key: wasm32-unknown-unknown-${{ hashFiles('Cargo.lock') }}
         cache-bin: false
-        save-if: ${{ github.ref == 'refs/heads/trunk' }}
+        save-if: ${{ github.ref != 'refs/heads/trunk' }}
 
     - name: Create output directory
       run: mkdir -p web

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -6,6 +6,7 @@
 
 * `[hoomd-manifold]`: Add `Spherical<4>::from_versor` and the corresponding `::to_versor` (#285).
 * `[hoomd-mc]`: Implement translation moves for `Point<Spherical<4>>` (#287).
+* `[hoomd-microstate]`: Implement `AppendMicrostate` for the site types `Point<Spherical<3>>`, `Point<Spherical<4>>`, `OrientedHyperbolicPoint<3, Angle>`, and `Point<Hyperbolic<3>>` (#286).
 * `[hoomd-utility]`: Implement `Eq`, `PartialOrd`, and `Ord` for `PositiveReal` (#287).
 
 *Changed:*

--- a/hoomd-bevy/src/representation/hyperbolic_disk.rs
+++ b/hoomd-bevy/src/representation/hyperbolic_disk.rs
@@ -129,7 +129,7 @@ impl<T: Send + Sync + 'static> HyperbolicDisk<T> {
     }
 }
 
-/// Project coordinates to Poincare disk
+/// Project coordinates to Poincaré disk
 fn poincare(point: &Minkowski<3>, diameter: f64) -> ([f32; 3], f32) {
     let pt = Hyperbolic::from_minkowski_coordinates(*point);
     let proj = pt.to_poincare();

--- a/hoomd-bevy/src/representation/hyperbolic_polygon.rs
+++ b/hoomd-bevy/src/representation/hyperbolic_polygon.rs
@@ -129,7 +129,7 @@ impl<T: Send + Sync + 'static> HyperbolicPolygon<T> {
     }
 }
 
-/// Project coordinates to Poincare disk
+/// Project coordinates to Poincaré disk
 fn poincare(point: &Minkowski<3>, radius: f64, angle: f32) -> ([f32; 3], f32) {
     let pt = Hyperbolic::from_minkowski_coordinates(*point);
     let proj = pt.to_poincare();

--- a/hoomd-manifold/src/minkowski.rs
+++ b/hoomd-manifold/src/minkowski.rs
@@ -588,7 +588,7 @@ impl<const N: usize> Hyperbolic<N> {
         (self.point.coordinates[N - 1]).acosh()
     }
 
-    /// Projects points on the hyperboloid onto the Poincare disk/ball.
+    /// Projects points on the hyperboloid onto the Poincaré disk/ball.
     ///
     /// # Example
     /// ```

--- a/hoomd-microstate/src/append.rs
+++ b/hoomd-microstate/src/append.rs
@@ -210,7 +210,7 @@ impl<B, X, C> AppendMicrostate<B, Point<Spherical<3>>, X, C> for HoomdGsdFile {
         microstate: &Microstate<B, Point<Spherical<3>>, X, C>,
     ) -> Result<Frame<'_>, AppendError> {
         self.append_frame(microstate.step())?
-            .configuration_box([5.0, 5.0, 5.0, 0.0, 0.0, 0.0])?
+            .configuration_box([2.0, 2.0, 2.0, 0.0, 0.0, 0.0])?
             .configuration_dimensions(Dimensions::Three)?
             .particles_position(microstate.iter_sites_tag_order().map(|s| {
                 let pt = *s.properties.position.point()
@@ -225,7 +225,7 @@ impl<B, X, C> AppendMicrostate<B, Point<Spherical<4>>, X, C> for HoomdGsdFile {
         microstate: &Microstate<B, Point<Spherical<4>>, X, C>,
     ) -> Result<Frame<'_>, AppendError> {
         self.append_frame(microstate.step())?
-            .configuration_box([5.0, 5.0, 5.0, 0.0, 0.0, 0.0])?
+            .configuration_box([2.0, 2.0, 2.0, 0.0, 0.0, 0.0])?
             .configuration_dimensions(Dimensions::Three)?
             .particles_position(microstate.iter_sites_tag_order().map(|s| {
                 let proj: Vec<f64> = s.properties.position.stereographic_projection();
@@ -241,7 +241,7 @@ impl<B, X, C> AppendMicrostate<B, OrientedHyperbolicPoint<3, Angle>, X, C> for H
         microstate: &Microstate<B, OrientedHyperbolicPoint<3, Angle>, X, C>,
     ) -> Result<Frame<'_>, AppendError> {
         self.append_frame(microstate.step())?
-            .configuration_box([2.0, 2.0, 2.0, 0.0, 0.0, 0.0])?
+            .configuration_box([2.0, 2.0, 0.0, 0.0, 0.0, 0.0])?
             .configuration_dimensions(Dimensions::Two)?
             .particles_position(
                 microstate
@@ -272,7 +272,7 @@ impl<B, X, C> AppendMicrostate<B, Point<Hyperbolic<3>>, X, C> for HoomdGsdFile {
         microstate: &Microstate<B, Point<Hyperbolic<3>>, X, C>,
     ) -> Result<Frame<'_>, AppendError> {
         self.append_frame(microstate.step())?
-            .configuration_box([2.0, 2.0, 2.0, 0.0, 0.0, 0.0])?
+            .configuration_box([2.0, 2.0, 0.0, 0.0, 0.0, 0.0])?
             .configuration_dimensions(Dimensions::Two)?
             .particles_position(
                 microstate

--- a/hoomd-microstate/src/append.rs
+++ b/hoomd-microstate/src/append.rs
@@ -213,8 +213,7 @@ impl<B, X, C> AppendMicrostate<B, Point<Spherical<3>>, X, C> for HoomdGsdFile {
             .configuration_box([5.0, 5.0, 5.0, 0.0, 0.0, 0.0])?
             .configuration_dimensions(Dimensions::Three)?
             .particles_position(microstate.iter_sites_tag_order().map(|s| {
-                let pt = *s.properties.position.coordinates();
-                pt.into()
+                let pt = *s.properties.position.point()
             }))
     }
 }

--- a/hoomd-microstate/src/append.rs
+++ b/hoomd-microstate/src/append.rs
@@ -5,12 +5,13 @@
 
 use hoomd_geometry::shape::Hypercuboid;
 use hoomd_gsd::hoomd::{AppendError, Dimensions, Frame, HoomdGsdFile};
+use hoomd_manifold::{Hyperbolic, Spherical};
 use hoomd_vector::{Angle, Cartesian, Versor};
 
 use crate::{
     AppendMicrostate, Microstate,
-    boundary::{Closed, Periodic},
-    property::{OrientedPoint, Point},
+    boundary::{Closed, Open, Periodic},
+    property::{OrientedHyperbolicPoint, OrientedPoint, Point},
 };
 
 impl<B, X> AppendMicrostate<B, Point<Cartesian<2>>, X, Closed<Hypercuboid<2>>> for HoomdGsdFile {
@@ -202,15 +203,81 @@ impl<B, X> AppendMicrostate<B, OrientedPoint<Cartesian<3>, Versor>, X, Periodic<
     }
 }
 
+impl<B, X> AppendMicrostate<B, Point<Spherical<4>>, X, Open> for HoomdGsdFile {
+    #[inline]
+    fn append_microstate(
+        &mut self,
+        microstate: &Microstate<B, Point<Spherical<4>>, X, Open>,
+    ) -> Result<Frame<'_>, AppendError> {
+        self.append_frame(microstate.step())?
+            .configuration_box([5.0, 5.0, 5.0, 0.0, 0.0, 0.0])?
+            .configuration_dimensions(Dimensions::Three)?
+            .particles_position(microstate.iter_sites_tag_order().map(|s| {
+                let proj: Vec<f64> = s.properties.position.stereographic_projection();
+                [proj[0], proj[1], proj[2]].into()
+            }))
+    }
+}
+
+impl<B, X, C> AppendMicrostate<B, OrientedHyperbolicPoint<3, Angle>, X, C> for HoomdGsdFile {
+    #[inline]
+    fn append_microstate(
+        &mut self,
+        microstate: &Microstate<B, OrientedHyperbolicPoint<3, Angle>, X, C>,
+    ) -> Result<Frame<'_>, AppendError> {
+        self.append_frame(microstate.step())?
+            .configuration_box([2.0, 2.0, 2.0, 0.0, 0.0, 0.0])?
+            .configuration_dimensions(Dimensions::Two)?
+            .particles_position(
+                microstate
+                    .iter_sites_tag_order()
+                    .map(|s| s.properties.position.to_poincare())
+                    .map(|p| [p[0], p[1], 0.0].into()),
+            )?
+            .particles_orientation(
+                microstate
+                    .iter_sites_tag_order()
+                    .map(|s| s.properties.orientation.theta)
+                    .map(|a| {
+                        Versor::from_axis_angle(
+                            [0.0, 0.0, 1.0]
+                                .try_into()
+                                .expect("hard-coded vector can be normalized"),
+                            a,
+                        )
+                    }),
+            )
+    }
+}
+
+impl<B, X, C> AppendMicrostate<B, Point<Hyperbolic<3>>, X, C> for HoomdGsdFile {
+    #[inline]
+    fn append_microstate(
+        &mut self,
+        microstate: &Microstate<B, Point<Hyperbolic<3>>, X, C>,
+    ) -> Result<Frame<'_>, AppendError> {
+        self.append_frame(microstate.step())?
+            .configuration_box([2.0, 2.0, 2.0, 0.0, 0.0, 0.0])?
+            .configuration_dimensions(Dimensions::Two)?
+            .particles_position(
+                microstate
+                    .iter_sites_tag_order()
+                    .map(|s| s.properties.position.to_poincare())
+                    .map(|p| [p[0], p[1], 0.0].into()),
+            )
+    }
+}
+
 #[cfg(test)]
 mod test {
+    use approxim::assert_relative_eq;
     use assert2::assert;
     use std::f64::consts::PI;
     use tempfile::tempdir;
 
     use super::*;
     use crate::Body;
-    use hoomd_geometry::shape::Rectangle;
+    use hoomd_geometry::shape::{EightEight, Rectangle};
     use hoomd_gsd::file_layer::{GsdFile, Mode};
 
     #[test]
@@ -295,6 +362,273 @@ mod test {
         let box_ = gsd_file.iter_scalars::<f32>(0, "configuration/box")?;
         itertools::assert_equal(box_, [12.0_f32, 18.0, 0.0, 0.0, 0.0, 0.0]);
 
+        Ok(())
+    }
+
+    #[test]
+    fn point_spherical_3d() -> anyhow::Result<()> {
+        let microstate = Microstate::builder()
+            .boundary(Open)
+            .bodies([
+                Body::point(Spherical::from_cartesian_coordinates(Cartesian::from([
+                    1.0, 0.0, 0.0, 0.0,
+                ]))),
+                Body::point(Spherical::from_cartesian_coordinates(Cartesian::from([
+                    0.0, 1.0, 0.0, 0.0,
+                ]))),
+                Body::point(Spherical::from_cartesian_coordinates(Cartesian::from([
+                    0.0, 0.0, 1.0, 0.0,
+                ]))),
+            ])
+            .step(1234)
+            .try_build()?;
+
+        let tmp_dir = tempdir()?;
+        let path = tmp_dir.path().join("test.gsd");
+        let mut hoomd_gsd_file = HoomdGsdFile::create(path.clone())?;
+        hoomd_gsd_file.append_microstate(&microstate)?;
+
+        drop(hoomd_gsd_file);
+
+        let gsd_file = GsdFile::open(path, Mode::Read)?;
+
+        assert!(gsd_file.n_frames() == 1);
+
+        let step = gsd_file.iter_scalars::<u64>(0, "configuration/step")?;
+        itertools::assert_equal(step, [1234]);
+
+        let positions: Vec<[f32; 3]> = gsd_file
+            .iter_arrays::<f32, 3>(0, "particles/position")?
+            .collect();
+        assert_relative_eq!(positions[0][0], 1.0);
+        assert_relative_eq!(positions[0][1], 0.0);
+        assert_relative_eq!(positions[0][2], 0.0);
+        assert_relative_eq!(positions[1][0], 0.0);
+        assert_relative_eq!(positions[1][1], 1.0);
+        assert_relative_eq!(positions[1][2], 0.0);
+        assert_relative_eq!(positions[2][0], 0.0);
+        assert_relative_eq!(positions[2][1], 0.0);
+        assert_relative_eq!(positions[2][2], 1.0);
+        Ok(())
+    }
+
+    #[test]
+    fn point_hyperbolic_2d_open() -> anyhow::Result<()> {
+        let microstate = Microstate::builder()
+            .boundary(Open)
+            .bodies([
+                Body::point(Hyperbolic::<3>::from_polar_coordinates(1.2, 0.0)),
+                Body::point(Hyperbolic::<3>::from_polar_coordinates(0.6, 1.5)),
+            ])
+            .step(1234)
+            .try_build()?;
+
+        let tmp_dir = tempdir()?;
+        let path = tmp_dir.path().join("test.gsd");
+        let mut hoomd_gsd_file = HoomdGsdFile::create(path.clone())?;
+        hoomd_gsd_file.append_microstate(&microstate)?;
+
+        drop(hoomd_gsd_file);
+
+        let gsd_file = GsdFile::open(path, Mode::Read)?;
+
+        assert!(gsd_file.n_frames() == 1);
+
+        let step = gsd_file.iter_scalars::<u64>(0, "configuration/step")?;
+        itertools::assert_equal(step, [1234]);
+
+        let positions: Vec<[f32; 3]> = gsd_file
+            .iter_arrays::<f32, 3>(0, "particles/position")?
+            .collect();
+        assert_relative_eq!(positions[0][0], (f32::sinh(1.2)) / (1.0 + f32::cosh(1.2)));
+        assert_relative_eq!(positions[0][1], 0.0);
+        assert_relative_eq!(
+            positions[1][0],
+            (f32::sinh(0.6) * f32::cos(1.5)) / (1.0 + f32::cosh(0.6))
+        );
+        assert_relative_eq!(
+            positions[1][1],
+            (f32::sinh(0.6) * f32::sin(1.5)) / (1.0 + f32::cosh(0.6))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn point_hyperbolic_2d_eighteight_periodic() -> anyhow::Result<()> {
+        let boundary = Periodic::new(0.6, EightEight {})?;
+        let microstate = Microstate::builder()
+            .boundary(boundary)
+            .bodies([
+                Body::point(Hyperbolic::<3>::from_polar_coordinates(0.2, 0.3)),
+                Body::point(Hyperbolic::<3>::from_polar_coordinates(0.6, 0.7)),
+            ])
+            .step(1234)
+            .try_build()?;
+
+        let tmp_dir = tempdir()?;
+        let path = tmp_dir.path().join("test.gsd");
+        let mut hoomd_gsd_file = HoomdGsdFile::create(path.clone())?;
+        hoomd_gsd_file.append_microstate(&microstate)?;
+
+        drop(hoomd_gsd_file);
+
+        let gsd_file = GsdFile::open(path, Mode::Read)?;
+
+        assert!(gsd_file.n_frames() == 1);
+
+        let step = gsd_file.iter_scalars::<u64>(0, "configuration/step")?;
+        itertools::assert_equal(step, [1234]);
+
+        let positions: Vec<[f32; 3]> = gsd_file
+            .iter_arrays::<f32, 3>(0, "particles/position")?
+            .collect();
+        assert_relative_eq!(
+            positions[0][0],
+            (f32::sinh(0.2) * f32::cos(0.3)) / (1.0 + f32::cosh(0.2))
+        );
+        assert_relative_eq!(
+            positions[0][1],
+            (f32::sinh(0.2) * f32::sin(0.3)) / (1.0 + f32::cosh(0.2))
+        );
+        assert_relative_eq!(
+            positions[1][0],
+            (f32::sinh(0.6) * f32::cos(0.7)) / (1.0 + f32::cosh(0.6))
+        );
+        assert_relative_eq!(
+            positions[1][1],
+            (f32::sinh(0.6) * f32::sin(0.7)) / (1.0 + f32::cosh(0.6))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn oriented_point_hyperbolic_2d_open() -> anyhow::Result<()> {
+        let microstate = Microstate::builder()
+            .boundary(Open)
+            .bodies([
+                Body {
+                    properties: OrientedHyperbolicPoint {
+                        position: Hyperbolic::<3>::from_polar_coordinates(0.5, 0.6),
+                        orientation: Angle::from(0.3),
+                    },
+                    sites: vec![OrientedHyperbolicPoint {
+                        position: Hyperbolic::<3>::default(),
+                        orientation: Angle::default(),
+                    }],
+                },
+                Body {
+                    properties: OrientedHyperbolicPoint {
+                        position: Hyperbolic::<3>::from_polar_coordinates(0.9, 0.3),
+                        orientation: Angle::from(1.2),
+                    },
+                    sites: vec![OrientedHyperbolicPoint {
+                        position: Hyperbolic::<3>::default(),
+                        orientation: Angle::default(),
+                    }],
+                },
+            ])
+            .step(1234)
+            .try_build()?;
+
+        let tmp_dir = tempdir()?;
+        let path = tmp_dir.path().join("test.gsd");
+        let mut hoomd_gsd_file = HoomdGsdFile::create(path.clone())?;
+        hoomd_gsd_file.append_microstate(&microstate)?;
+
+        drop(hoomd_gsd_file);
+
+        let gsd_file = GsdFile::open(path, Mode::Read)?;
+
+        assert!(gsd_file.n_frames() == 1);
+
+        let step = gsd_file.iter_scalars::<u64>(0, "configuration/step")?;
+        itertools::assert_equal(step, [1234]);
+
+        let positions: Vec<[f32; 3]> = gsd_file
+            .iter_arrays::<f32, 3>(0, "particles/position")?
+            .collect();
+        assert_relative_eq!(
+            positions[0][0],
+            (f32::sinh(0.5) * f32::cos(0.6)) / (1.0 + f32::cosh(0.5))
+        );
+        assert_relative_eq!(
+            positions[0][1],
+            (f32::sinh(0.5) * f32::sin(0.6)) / (1.0 + f32::cosh(0.5))
+        );
+        assert_relative_eq!(
+            positions[1][0],
+            (f32::sinh(0.9) * f32::cos(0.3)) / (1.0 + f32::cosh(0.9))
+        );
+        assert_relative_eq!(
+            positions[1][1],
+            (f32::sinh(0.9) * f32::sin(0.3)) / (1.0 + f32::cosh(0.9))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn oriented_point_hyperbolic_2d_periodic_eighteight() -> anyhow::Result<()> {
+        let boundary = Periodic::new(0.6, EightEight {})?;
+        let microstate = Microstate::builder()
+            .boundary(boundary)
+            .bodies([
+                Body {
+                    properties: OrientedHyperbolicPoint {
+                        position: Hyperbolic::<3>::from_polar_coordinates(0.5, 0.6),
+                        orientation: Angle::from(0.3),
+                    },
+                    sites: vec![OrientedHyperbolicPoint {
+                        position: Hyperbolic::<3>::default(),
+                        orientation: Angle::default(),
+                    }],
+                },
+                Body {
+                    properties: OrientedHyperbolicPoint {
+                        position: Hyperbolic::<3>::from_polar_coordinates(0.9, 0.3),
+                        orientation: Angle::from(1.2),
+                    },
+                    sites: vec![OrientedHyperbolicPoint {
+                        position: Hyperbolic::<3>::default(),
+                        orientation: Angle::default(),
+                    }],
+                },
+            ])
+            .step(1234)
+            .try_build()?;
+
+        let tmp_dir = tempdir()?;
+        let path = tmp_dir.path().join("test.gsd");
+        let mut hoomd_gsd_file = HoomdGsdFile::create(path.clone())?;
+        hoomd_gsd_file.append_microstate(&microstate)?;
+
+        drop(hoomd_gsd_file);
+
+        let gsd_file = GsdFile::open(path, Mode::Read)?;
+
+        assert!(gsd_file.n_frames() == 1);
+
+        let step = gsd_file.iter_scalars::<u64>(0, "configuration/step")?;
+        itertools::assert_equal(step, [1234]);
+
+        let positions: Vec<[f32; 3]> = gsd_file
+            .iter_arrays::<f32, 3>(0, "particles/position")?
+            .collect();
+        assert_relative_eq!(
+            positions[0][0],
+            (f32::sinh(0.5) * f32::cos(0.6)) / (1.0 + f32::cosh(0.5))
+        );
+        assert_relative_eq!(
+            positions[0][1],
+            (f32::sinh(0.5) * f32::sin(0.6)) / (1.0 + f32::cosh(0.5))
+        );
+        assert_relative_eq!(
+            positions[1][0],
+            (f32::sinh(0.9) * f32::cos(0.3)) / (1.0 + f32::cosh(0.9))
+        );
+        assert_relative_eq!(
+            positions[1][1],
+            (f32::sinh(0.9) * f32::sin(0.3)) / (1.0 + f32::cosh(0.9))
+        );
         Ok(())
     }
 

--- a/hoomd-microstate/src/append.rs
+++ b/hoomd-microstate/src/append.rs
@@ -10,7 +10,7 @@ use hoomd_vector::{Angle, Cartesian, Versor};
 
 use crate::{
     AppendMicrostate, Microstate,
-    boundary::{Closed, Open, Periodic},
+    boundary::{Closed, Periodic},
     property::{OrientedHyperbolicPoint, OrientedPoint, Point},
 };
 
@@ -203,11 +203,27 @@ impl<B, X> AppendMicrostate<B, OrientedPoint<Cartesian<3>, Versor>, X, Periodic<
     }
 }
 
-impl<B, X> AppendMicrostate<B, Point<Spherical<4>>, X, Open> for HoomdGsdFile {
+impl<B, X, C> AppendMicrostate<B, Point<Spherical<3>>, X, C> for HoomdGsdFile {
     #[inline]
     fn append_microstate(
         &mut self,
-        microstate: &Microstate<B, Point<Spherical<4>>, X, Open>,
+        microstate: &Microstate<B, Point<Spherical<3>>, X, C>,
+    ) -> Result<Frame<'_>, AppendError> {
+        self.append_frame(microstate.step())?
+            .configuration_box([5.0, 5.0, 5.0, 0.0, 0.0, 0.0])?
+            .configuration_dimensions(Dimensions::Three)?
+            .particles_position(microstate.iter_sites_tag_order().map(|s| {
+                let pt = *s.properties.position.coordinates();
+                pt.into()
+            }))
+    }
+}
+
+impl<B, X, C> AppendMicrostate<B, Point<Spherical<4>>, X, C> for HoomdGsdFile {
+    #[inline]
+    fn append_microstate(
+        &mut self,
+        microstate: &Microstate<B, Point<Spherical<4>>, X, C>,
     ) -> Result<Frame<'_>, AppendError> {
         self.append_frame(microstate.step())?
             .configuration_box([5.0, 5.0, 5.0, 0.0, 0.0, 0.0])?
@@ -276,7 +292,7 @@ mod test {
     use tempfile::tempdir;
 
     use super::*;
-    use crate::Body;
+    use crate::{Body, boundary::Open};
     use hoomd_geometry::shape::{EightEight, Rectangle};
     use hoomd_gsd::file_layer::{GsdFile, Mode};
 
@@ -366,6 +382,57 @@ mod test {
     }
 
     #[test]
+    fn point_spherical_2d() -> anyhow::Result<()> {
+        let microstate = Microstate::builder()
+            .boundary(Open)
+            .bodies([
+                Body::point(Spherical::from_cartesian_coordinates(Cartesian::from([
+                    -1.0, 0.0, 0.0,
+                ]))),
+                Body::point(Spherical::from_cartesian_coordinates(Cartesian::from([
+                    0.0,
+                    f64::sqrt(0.5),
+                    f64::sqrt(0.5),
+                ]))),
+                Body::point(Spherical::from_cartesian_coordinates(Cartesian::from([
+                    -f64::sqrt(0.25),
+                    0.0,
+                    f64::sqrt(0.75),
+                ]))),
+            ])
+            .step(1234)
+            .try_build()?;
+
+        let tmp_dir = tempdir()?;
+        let path = tmp_dir.path().join("test.gsd");
+        let mut hoomd_gsd_file = HoomdGsdFile::create(path.clone())?;
+        hoomd_gsd_file.append_microstate(&microstate)?;
+
+        drop(hoomd_gsd_file);
+
+        let gsd_file = GsdFile::open(path, Mode::Read)?;
+
+        assert!(gsd_file.n_frames() == 1);
+
+        let step = gsd_file.iter_scalars::<u64>(0, "configuration/step")?;
+        itertools::assert_equal(step, [1234]);
+
+        let positions: Vec<[f32; 3]> = gsd_file
+            .iter_arrays::<f32, 3>(0, "particles/position")?
+            .collect();
+        assert_relative_eq!(positions[0][0], -1.0);
+        assert_relative_eq!(positions[0][1], 0.0);
+        assert_relative_eq!(positions[0][2], 0.0);
+        assert_relative_eq!(positions[1][0], 0.0);
+        assert_relative_eq!(positions[1][1], f32::sqrt(0.5));
+        assert_relative_eq!(positions[1][2], f32::sqrt(0.5));
+        assert_relative_eq!(positions[2][0], -f32::sqrt(0.25));
+        assert_relative_eq!(positions[2][1], 0.0);
+        assert_relative_eq!(positions[2][2], f32::sqrt(0.75));
+        Ok(())
+    }
+
+    #[test]
     fn point_spherical_3d() -> anyhow::Result<()> {
         let microstate = Microstate::builder()
             .boundary(Open)
@@ -374,10 +441,16 @@ mod test {
                     1.0, 0.0, 0.0, 0.0,
                 ]))),
                 Body::point(Spherical::from_cartesian_coordinates(Cartesian::from([
-                    0.0, 1.0, 0.0, 0.0,
+                    f64::sqrt(1.0 / 3.0),
+                    -f64::sqrt(1.0 / 3.0),
+                    f64::sqrt(1.0 / 3.0),
+                    0.0,
                 ]))),
                 Body::point(Spherical::from_cartesian_coordinates(Cartesian::from([
-                    0.0, 0.0, 1.0, 0.0,
+                    0.0,
+                    0.0,
+                    f64::sqrt(0.5),
+                    f64::sqrt(0.5),
                 ]))),
             ])
             .step(1234)
@@ -403,12 +476,12 @@ mod test {
         assert_relative_eq!(positions[0][0], 1.0);
         assert_relative_eq!(positions[0][1], 0.0);
         assert_relative_eq!(positions[0][2], 0.0);
-        assert_relative_eq!(positions[1][0], 0.0);
-        assert_relative_eq!(positions[1][1], 1.0);
-        assert_relative_eq!(positions[1][2], 0.0);
+        assert_relative_eq!(positions[1][0], f32::sqrt(1.0 / 3.0));
+        assert_relative_eq!(positions[1][1], -f32::sqrt(1.0 / 3.0));
+        assert_relative_eq!(positions[1][2], f32::sqrt(1.0 / 3.0));
         assert_relative_eq!(positions[2][0], 0.0);
         assert_relative_eq!(positions[2][1], 0.0);
-        assert_relative_eq!(positions[2][2], 1.0);
+        assert_relative_eq!(positions[2][2], f32::sqrt(0.5) / (1.0 - f32::sqrt(0.5)));
         Ok(())
     }
 

--- a/hoomd-microstate/src/append.rs
+++ b/hoomd-microstate/src/append.rs
@@ -212,9 +212,11 @@ impl<B, X, C> AppendMicrostate<B, Point<Spherical<3>>, X, C> for HoomdGsdFile {
         self.append_frame(microstate.step())?
             .configuration_box([2.0, 2.0, 2.0, 0.0, 0.0, 0.0])?
             .configuration_dimensions(Dimensions::Three)?
-            .particles_position(microstate.iter_sites_tag_order().map(|s| {
-                let pt = *s.properties.position.point()
-            }))
+            .particles_position(
+                microstate
+                    .iter_sites_tag_order()
+                    .map(|s| *s.properties.position.point()),
+            )
     }
 }
 

--- a/hoomd-microstate/src/boundary/periodic/eighteight.rs
+++ b/hoomd-microstate/src/boundary/periodic/eighteight.rs
@@ -745,7 +745,7 @@ mod tests {
         let wrapped_point = periodic.wrap(point).expect("hard-coded");
         let wrapped_poincare = wrapped_point.position.to_poincare();
 
-        // Check that mapping is consistent with Poincare transformation
+        // Check that mapping is consistent with Poincaré transformation
         let (q_u, q_v) = (
             point.position.to_poincare()[0],
             point.position.to_poincare()[1],

--- a/hoomd-microstate/src/lib.rs
+++ b/hoomd-microstate/src/lib.rs
@@ -486,6 +486,25 @@ pub enum Error {
 /// # }
 /// ```
 ///
+/// # Curved space implementations
+///
+/// `append_microstate` is implemented for `Point<Spherical<3>>`,
+/// `Point<Spherical<4>>`, `Point<Hyperbolic<3>>`, and
+/// `OrientedHyperbolicPoint<3, Angle>`. For curved-space types,
+/// `append_microstate` stores particle positions in projected coordinates
+/// rather than the coordinates of the embedding space. The table below
+/// lists which projection is used for each curved space.
+///
+/// | Curved space | Projection |
+/// | :---: | :---: |
+/// | `Spherical<3>` | none; stored as cartesian embedding |
+/// | `Spherical<4>` | stereographic projection |
+/// | `Hyperbolic<3>` | Poincare disk |
+/// | `OrientedHyperbolicPoint<3,Angle>` | Poincare disk |
+///
+/// See [`hoomd_manifold::Spherical::stereographic_projection()`] and 
+/// [`hoomd_manifold::Hyperbolic::to_poincare()`] for further details.
+/// 
 /// # Custom implementations
 ///
 /// You can implement [`AppendMicrostate`] for your custom site type and/or

--- a/hoomd-microstate/src/lib.rs
+++ b/hoomd-microstate/src/lib.rs
@@ -502,9 +502,9 @@ pub enum Error {
 /// | `Hyperbolic<3>` | Poincare disk |
 /// | `OrientedHyperbolicPoint<3,Angle>` | Poincare disk |
 ///
-/// See [`hoomd_manifold::Spherical::stereographic_projection()`] and 
+/// See [`hoomd_manifold::Spherical::stereographic_projection()`] and
 /// [`hoomd_manifold::Hyperbolic::to_poincare()`] for further details.
-/// 
+///
 /// # Custom implementations
 ///
 /// You can implement [`AppendMicrostate`] for your custom site type and/or

--- a/hoomd-microstate/src/lib.rs
+++ b/hoomd-microstate/src/lib.rs
@@ -499,8 +499,8 @@ pub enum Error {
 /// | :---: | :---: |
 /// | `Spherical<3>` | none; stored as cartesian embedding |
 /// | `Spherical<4>` | stereographic projection |
-/// | `Hyperbolic<3>` | Poincare disk |
-/// | `OrientedHyperbolicPoint<3,Angle>` | Poincare disk |
+/// | `Hyperbolic<3>` | Poincaré disk |
+/// | `OrientedHyperbolicPoint<3,Angle>` | Poincaré disk |
 ///
 /// See [`hoomd_manifold::Spherical::stereographic_projection()`] and
 /// [`hoomd_manifold::Hyperbolic::to_poincare()`] for further details.

--- a/hoomd-microstate/src/property/oriented_hyperbolic_point.rs
+++ b/hoomd-microstate/src/property/oriented_hyperbolic_point.rs
@@ -115,7 +115,7 @@ impl OrientedHyperbolicPoint<3, Angle> {
     /// Compute the change in orientation associated with a transformation from a given
     /// position. Isometries of hyperbolic space can be expressed as a boost conjugated
     /// by a rotation, i.e., $`R(\theta) T(\eta) R(-\theta)`$. Such a transformation can
-    /// be expressed in the Poincare disk representation as the Mobius transformation
+    /// be expressed in the Poincaré disk representation as the Mobius transformation
     /// ```math
     /// g(z) = \begin{bmatrix} \cosh(\eta/2) & e^{i\theta} \sinh(\eta/2) \\ e^{-i\theta}\sinh(\eta/2) & \cosh(\eta/2) \end{bmatrix}
     /// ```


### PR DESCRIPTION
## Description

This PR implements `append_microstate` for `Spherical<3>`, `Spherical<4>`, `Hyperbolic<3>`, and `OrientedHyperbolicPoint<3, Angle>`. 

## Motivation and context

`append_microstate` is necessary to save Monte Carlo trajectories as GSD files. The four aforementioned manifold types are currently the four supported non-Euclidean manifold types. 

## How has this been tested?

This PR includes unit tests for each of the four manifold types with every relevant combination of boundary conditions. I have also been using these functions for production simulations and verified that they work as intended. 

## Checklist:

- [ X ] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/CONTRIBUTING.md).
- [ X ] I agree with the terms of the [**hoomd-rs Contributor Agreement**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/ContributorAgreement.md).
- [ X ] My name is on the list of contributors (`doc/src/credits.md`) in the pull request source branch.
- [x] I have summarized these changes in `release-notes.md` following the established format.
