### PR TITLE
implement Ord (and Eq) for PositiveReal

### DIFF
--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -4,6 +4,8 @@
 
 *Added:*
 
+* `[hoomd-utility]`: Implement `Eq`, `PartialOrd`, and `Ord` for `PositiveReal` (#287).
+
 *Changed:*
 
 *Deprecated:*

--- a/hoomd-utility/src/valid/positive_real.rs
+++ b/hoomd-utility/src/valid/positive_real.rs
@@ -5,6 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::{
+    cmp::Ordering,
     fmt,
     ops::{Div, DivAssign, Mul, MulAssign},
 };
@@ -44,6 +45,22 @@ impl PositiveReal {
     #[inline]
     pub fn get(&self) -> f64 {
         self.0
+    }
+}
+
+impl Eq for PositiveReal {}
+
+impl PartialOrd for PositiveReal {
+    #[inline]
+    fn partial_cmp(&self, other: &PositiveReal) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for PositiveReal {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.get().total_cmp(&other.get())
     }
 }
 


### PR DESCRIPTION
## Description

PositiveReal types avoid the ambiguity present in floating point comparisons, allowing for a correct implementation of `Ord` rather than just `PartialOrd`. This PR is a minimal implementation, using `total_cmp` for the implementation. Note we could probably improve performance by casting to u64 and doing comparisons there but it seems like overkill.

## Motivation and context

This allows for ::max and ::min reductions (and heaps, etc) based on positive real types

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**hoomd-rs Contributor Agreement**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/credits.md`) in the pull request source branch.
- [ ] I have summarized these changes in `release-notes.md` following the established format.
