### PR TITLE
Implement BoundingSphereRadius for Simplex3

### DIFF
--- a/hoomd-geometry/src/shape/simplex3.rs
+++ b/hoomd-geometry/src/shape/simplex3.rs
@@ -484,18 +484,18 @@ impl BoundingSphereRadius for Simplex3 {
     /// ```
     #[inline]
     fn bounding_sphere_radius(&self) -> PositiveReal {
-        self.vertices
-            .map(|v| {
-                PositiveReal::try_from((v - self.centroid()).norm_squared())
-                    .expect("Square of an f64 should be positive.")
-            })
-            .iter()
-            .max()
-            .expect("Max of Ord type should be Some.")
-            .get()
-            .sqrt()
-            .try_into()
-            .expect("Square root should be positive")
+        // Norm squared is positive
+        f64::from_bits(
+            *self
+                .vertices
+                .map(|v| v.norm_squared().to_bits())
+                .iter()
+                .max()
+                .expect("Max of Ord type should be Some."),
+        )
+        .sqrt()
+        .try_into()
+        .expect("sqrt is positive")
     }
 }
 

--- a/hoomd-geometry/src/shape/simplex3.rs
+++ b/hoomd-geometry/src/shape/simplex3.rs
@@ -463,9 +463,9 @@ where
 }
 
 impl BoundingSphereRadius for Simplex3 {
-    /// Radius of a circle that bounds the shape.
+    /// Radius of a sphere that bounds the shape.
     ///
-    /// The circle has the same local origin as the shape `self`.
+    /// The sphere has the same local origin as the shape `self`.
     ///
     /// # Example
     ///

--- a/hoomd-geometry/src/shape/simplex3.rs
+++ b/hoomd-geometry/src/shape/simplex3.rs
@@ -484,6 +484,10 @@ impl BoundingSphereRadius for Simplex3 {
     /// ```
     #[inline]
     fn bounding_sphere_radius(&self) -> PositiveReal {
+        // For positive, non-nan floats, comparisons of the bit representation are
+        // equivalent to comparisons of the float itself, e.g. a.to_bits() < b.to_bits()
+        // if and only if a < b. For nan values this is untrue, so we explicitly handle
+        // that case.
         f64::from_bits(
             *self
                 .vertices

--- a/hoomd-geometry/src/shape/simplex3.rs
+++ b/hoomd-geometry/src/shape/simplex3.rs
@@ -471,18 +471,14 @@ impl BoundingSphereRadius for Simplex3 {
     ///
     /// ```
     /// use approxim::assert_relative_eq;
-    /// use hoomd_geometry::{BoundingSphereRadius, shape::ConvexSurfaceMesh2d};
+    /// use hoomd_geometry::{BoundingSphereRadius, shape::Simplex3};
     ///
     /// # fn main() -> Result<(), hoomd_geometry::Error> {
-    /// let triangle = ConvexSurfaceMesh2d::from_point_set([
-    ///     [1.0, -1.0].into(),
-    ///     [-1.0, -1.0].into(),
-    ///     [0.0, 1.0].into(),
-    /// ])?;
+    /// let tet = Simplex3::default();
     ///
-    /// let bounding_radius = triangle.bounding_sphere_radius();
+    /// let bounding_radius = tet.bounding_sphere_radius();
     ///
-    /// assert_relative_eq!(bounding_radius.get(), 2.0_f64.sqrt());
+    /// assert_relative_eq!(bounding_radius.get(), 3.0_f64.sqrt());
     /// # Ok(())
     /// # }
     /// ```

--- a/hoomd-geometry/src/shape/simplex3.rs
+++ b/hoomd-geometry/src/shape/simplex3.rs
@@ -484,24 +484,13 @@ impl BoundingSphereRadius for Simplex3 {
     /// ```
     #[inline]
     fn bounding_sphere_radius(&self) -> PositiveReal {
-        // For positive, non-nan floats, comparisons of the bit representation are
-        // equivalent to comparisons of the float itself, e.g. a.to_bits() < b.to_bits()
-        // if and only if a < b. For nan values this is untrue, so we explicitly handle
-        // that case.
-        f64::from_bits(
-            *self
-                .vertices
-                .map(|v| {
-                    let n = v.norm_squared();
-                    if n.is_nan() { 0u64 } else { n.to_bits() }
-                })
-                .iter()
-                .max()
-                .expect("Iterator over [...; 4] should have nonzero length."),
-        )
-        .sqrt()
-        .try_into()
-        .expect("All norms are zero or NaN -- check your inputs!")
+        self.vertices
+            .iter()
+            .map(Cartesian::norm_squared)
+            .fold(0.0, &f64::max)
+            .sqrt()
+            .try_into()
+            .expect("All norms are zero or NaN -- check your inputs!")
     }
 }
 

--- a/hoomd-geometry/src/shape/simplex3.rs
+++ b/hoomd-geometry/src/shape/simplex3.rs
@@ -501,7 +501,7 @@ impl BoundingSphereRadius for Simplex3 {
         )
         .sqrt()
         .try_into()
-        .expect("All norms are NaN -- check your inputs!")
+        .expect("All norms are zero or NaN -- check your inputs!")
     }
 }
 

--- a/hoomd-geometry/src/shape/simplex3.rs
+++ b/hoomd-geometry/src/shape/simplex3.rs
@@ -484,18 +484,27 @@ impl BoundingSphereRadius for Simplex3 {
     /// ```
     #[inline]
     fn bounding_sphere_radius(&self) -> PositiveReal {
-        // Norm squared is positive
-        f64::from_bits(
-            *self
-                .vertices
-                .map(|v| v.norm_squared().to_bits())
-                .iter()
-                .max()
-                .expect("Max of Ord type should be Some."),
-        )
-        .sqrt()
-        .try_into()
-        .expect("sqrt is positive")
+        // Norm squared is positive and *usually* not NaN.
+        // f64::from_bits(
+        //     *self
+        //         .vertices
+        //         .map(|v| v.norm_squared().to_bits())
+        //         .iter()
+        //         .max()
+        //         .expect("Iterator over [...; 4] should have nonzero length."),
+        // )
+        // .sqrt()
+        // .try_into()
+        // .expect("sqrt is positive")
+        self.vertices
+            .map(|v| v.norm_squared())
+            .iter()
+            .filter(|val| !val.is_nan())
+            .max_by(|a, b| a.total_cmp(b))
+            .expect("Iterator over [...; 4] should have nonzero length.")
+            .sqrt()
+            .try_into()
+            .expect("All norms are NaN -- check your inputs!")
     }
 }
 

--- a/hoomd-geometry/src/shape/simplex3.rs
+++ b/hoomd-geometry/src/shape/simplex3.rs
@@ -488,11 +488,15 @@ impl BoundingSphereRadius for Simplex3 {
     /// ```
     #[inline]
     fn bounding_sphere_radius(&self) -> PositiveReal {
-        let arr = self.vertices.map(|v| {
-            PositiveReal::try_from((v - self.centroid()).norm())
-                .expect("Square of an f64 should be positive.")
-        });
-        *arr.iter().max().expect("Max of Ord type should be Some.")
+        *self
+            .vertices
+            .map(|v| {
+                PositiveReal::try_from((v - self.centroid()).norm())
+                    .expect("Square of an f64 should be positive.")
+            })
+            .iter()
+            .max()
+            .expect("Max of Ord type should be Some.")
     }
 }
 

--- a/hoomd-geometry/src/shape/simplex3.rs
+++ b/hoomd-geometry/src/shape/simplex3.rs
@@ -484,22 +484,12 @@ impl BoundingSphereRadius for Simplex3 {
     /// ```
     #[inline]
     fn bounding_sphere_radius(&self) -> PositiveReal {
-        // Norm squared is positive and *usually* not NaN.
-        // f64::from_bits(
-        //     *self
-        //         .vertices
-        //         .map(|v| v.norm_squared().to_bits())
-        //         .iter()
-        //         .max()
-        //         .expect("Iterator over [...; 4] should have nonzero length."),
-        // )
-        // .sqrt()
-        // .try_into()
-        // .expect("sqrt is positive")
         self.vertices
-            .map(|v| v.norm_squared())
+            .map(|v| {
+                let n = v.norm_squared();
+                if n.is_nan() { -f64::NEG_INFINITY } else { n }
+            })
             .iter()
-            .filter(|val| !val.is_nan())
             .max_by(|a, b| a.total_cmp(b))
             .expect("Iterator over [...; 4] should have nonzero length.")
             .sqrt()

--- a/hoomd-geometry/src/shape/simplex3.rs
+++ b/hoomd-geometry/src/shape/simplex3.rs
@@ -484,15 +484,18 @@ impl BoundingSphereRadius for Simplex3 {
     /// ```
     #[inline]
     fn bounding_sphere_radius(&self) -> PositiveReal {
-        *self
-            .vertices
+        self.vertices
             .map(|v| {
-                PositiveReal::try_from((v - self.centroid()).norm())
+                PositiveReal::try_from((v - self.centroid()).norm_squared())
                     .expect("Square of an f64 should be positive.")
             })
             .iter()
             .max()
             .expect("Max of Ord type should be Some.")
+            .get()
+            .sqrt()
+            .try_into()
+            .expect("Square root should be positive")
     }
 }
 

--- a/hoomd-geometry/src/shape/simplex3.rs
+++ b/hoomd-geometry/src/shape/simplex3.rs
@@ -484,17 +484,20 @@ impl BoundingSphereRadius for Simplex3 {
     /// ```
     #[inline]
     fn bounding_sphere_radius(&self) -> PositiveReal {
-        self.vertices
-            .map(|v| {
-                let n = v.norm_squared();
-                if n.is_nan() { -f64::NEG_INFINITY } else { n }
-            })
-            .iter()
-            .max_by(|a, b| a.total_cmp(b))
-            .expect("Iterator over [...; 4] should have nonzero length.")
-            .sqrt()
-            .try_into()
-            .expect("All norms are NaN -- check your inputs!")
+        f64::from_bits(
+            *self
+                .vertices
+                .map(|v| {
+                    let n = v.norm_squared();
+                    if n.is_nan() { 0u64 } else { n.to_bits() }
+                })
+                .iter()
+                .max()
+                .expect("Iterator over [...; 4] should have nonzero length."),
+        )
+        .sqrt()
+        .try_into()
+        .expect("All norms are NaN -- check your inputs!")
     }
 }
 

--- a/hoomd-geometry/src/shape/simplex3.rs
+++ b/hoomd-geometry/src/shape/simplex3.rs
@@ -3,13 +3,14 @@
 
 //! A tetrahedron in three dimensions. This struct should be viewed as a prototype for
 //! more complex geometries in addition to its standalone functionality.
+use hoomd_utility::valid::PositiveReal;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::{array, fmt};
 
 use hoomd_vector::{Cartesian, Cross, InnerProduct, Rotate, Rotation, RotationMatrix};
 
-use crate::{IntersectsAt, IntersectsAtGlobal, SupportMapping, Volume};
+use crate::{BoundingSphereRadius, IntersectsAt, IntersectsAtGlobal, SupportMapping, Volume};
 
 /// The hull of any 4 noncoplanar points in three dimensions.
 ///
@@ -460,6 +461,41 @@ where
         true // No separating planes -> intersection!
     }
 }
+
+impl BoundingSphereRadius for Simplex3 {
+    /// Radius of a circle that bounds the shape.
+    ///
+    /// The circle has the same local origin as the shape `self`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use approxim::assert_relative_eq;
+    /// use hoomd_geometry::{BoundingSphereRadius, shape::ConvexSurfaceMesh2d};
+    ///
+    /// # fn main() -> Result<(), hoomd_geometry::Error> {
+    /// let triangle = ConvexSurfaceMesh2d::from_point_set([
+    ///     [1.0, -1.0].into(),
+    ///     [-1.0, -1.0].into(),
+    ///     [0.0, 1.0].into(),
+    /// ])?;
+    ///
+    /// let bounding_radius = triangle.bounding_sphere_radius();
+    ///
+    /// assert_relative_eq!(bounding_radius.get(), 2.0_f64.sqrt());
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    fn bounding_sphere_radius(&self) -> PositiveReal {
+        let arr = self.vertices.map(|v| {
+            PositiveReal::try_from((v - self.centroid()).norm())
+                .expect("Square of an f64 should be positive.")
+        });
+        *arr.iter().max().expect("Max of Ord type should be Some.")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::xenocollide::collide3d;


### PR DESCRIPTION
## Description

Implement a minimal centered bounding sphere radius for the Simplex3 type.

@joaander -- is this correct in that we should return the origin-centered bounding sphere? Or is a local bounding sphere radius correct? The current code seems to match ConvexSurfaceMesh2d but I figured I would ask.

> NOTE: if we do not care to handle NaN (which ConvexSurfaceMesh2d and ConvexPolytope do not), we can simplify the code. Performance is fine either way, but I want to make sure computing the radius for pre-overlap filtering works well.


## Motivation and Context
## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [ ] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**hoomd-rs Contributor Agreement**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/ContributorAgreement.md).
- [ ] My name is on the list of contributors (`doc/src/credits.md`) in the pull request source branch.
- [ ] I have summarized these changes in `release-notes.md` following the established format.
