### PR TITLE
Numerical Stability for Hyperbolic

### DIFF
--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -21,7 +21,8 @@
 
 *Fixed:*
 
-* `[hoomd-manifold]`: Fixed numerical stability issue in `Spherical<3>::distance` where the dot product could result in an out of bounds value.
+* `[hoomd-manifold]`: Fixed numerical stability issue in `Spherical<3>::distance` where the dot product could result in an out of bounds value (#285).
+* `[hoomd-manifold]`: Improved numerical stability of Hyperbolic space (#303).
 
 ## 1.1.0 (2026-04-17)
 

--- a/hoomd-manifold/src/lib.rs
+++ b/hoomd-manifold/src/lib.rs
@@ -12,26 +12,26 @@
 //!
 //! ## Spherical points
 //!
-//! [`Spherical`] describes a point on an N-sphere of radius R embedded in
-//! [`Cartesian<N+1>`]. The components of a point on an N-sphere
+//! [`Spherical<N>`] describes a point on an $`(N-1)`$-sphere of radius R embedded in
+//! [`Cartesian<N>`]. The components of a point on an $`N`$-sphere
 //! satisfy
 //! ```math
 //! \sum_{i=1}^{N+1}x_i^2 = R^2
 //! ```
 //! [`Spherical`] implements a distance metric through the trait
 //! [`Metric`] which calculates the geodesic distance on the
-//! surface of an N-sphere. Use [`Spherical`] to describe spaces with constant
+//! surface of an $`N`$-sphere. Use [`Spherical`] to describe spaces with constant
 //! positive curvature.
 //!
-//! [`Cartesian<N+1>`]: hoomd_vector::Cartesian
+//! [`Cartesian<N>`]: hoomd_vector::Cartesian
 //! [`Metric`]: hoomd_vector::Metric
 //!
 //! ## Hyperbolic
-//! [`Hyperbolic`] describes a point on the upper sheet of an N-dimensional
-//! two-sheeted Hyperbolic with skirt R embedded in (N+1)-dimensional Minkowski
+//! [`Hyperbolic`] describes a point on the upper sheet of an $`N`$-dimensional
+//! two-sheeted hyperboloid embedded in $`(N+1)`$-dimensional Minkowski
 //! space. The components of a point on the Hyperbolic satisfy
 //! ```math
-//! x_1^2 + \cdots + x_{N-1}^2 - x_{N}^2 = -R^2
+//! x_1^2 + \cdots + x_{N-1}^2 - x_{N}^2 = -1
 //! ```
 //! [`Hyperbolic`] implements a distance metric through the trait
 //! [`Metric`] which calculates the geodesic distance on the
@@ -40,7 +40,7 @@
 //!
 //! ## Minkowski
 //!
-//! [`Minkowski<N>`] implements (N-1,1)-dimensional Minkowski space with the
+//! [`Minkowski<N>`] implements $`(N-1,1)`$-dimensional Minkowski space with the
 //! metric signature $`(+ \;\cdots\; +\; -)`$. [`Minkowski`] supports
 //! [`Vector`] operations such as vector addition and rescaling, but is not a
 //! true inner product space. The distance metric on Minkowski space is given
@@ -61,12 +61,12 @@
 //! assert_eq!(1.0, del);
 //! ```
 //! ## Hyperbolic Rotations
-//! "Hyperbolic rotations" describe elements of the group SO(N,1), which
+//! "Hyperbolic rotations" describe elements of the group $`SO(N,1)`$, which
 //! preserve hyperboloids embedded in [`Minkowski`]. Transformations include
 //! pure spatial rotations as well as "boosts".
 //!
 //! For two-dimensional hyperbolic surfaces, use [`HyperbolicAngle`] to
-//! implement elements of SO(2,1) which rotate points about the z-axis or boost
+//! implement elements of $`SO(2,1)`$ which rotate points about the z-axis or boost
 //! points along the x- and y-axes. Use [`HyperbolicRotationMatrix`] to
 //! generate the matrix from the values defined by [`HyperbolicAngle`].
 //!
@@ -100,7 +100,7 @@
 //!
 //! For three-dimensional hyperbolic surfaces, use [`Biquaternion`].
 //! Biquaternions are a generalization of quaternions which allow for complex
-//! coefficients. Unit biquaternions give a representation of SO(3,1); this can
+//! coefficients. Unit biquaternions give a representation of $`SO(3,1)`$; this can
 //! either be done by converting the biquaternions to a
 //! [`HyperbolicRotationMatrix`] or by using the [`UnitBiquaternion`] algebra
 //! directly.

--- a/hoomd-manifold/src/minkowski.rs
+++ b/hoomd-manifold/src/minkowski.rs
@@ -520,10 +520,17 @@ impl<const N: usize> Hyperbolic<N> {
     /// ```
     #[must_use]
     #[inline]
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "truncation to relax precision"
+    )]
     pub fn from_minkowski_coordinates(point: Minkowski<N>) -> Hyperbolic<N> {
-        let skirt_squared = -point.distance_squared(&Minkowski::<N>::default());
-        let tolerance = 8_i32 - (point.coordinates[N-1].log10().floor() as i32);
-        assert_relative_eq!(skirt_squared, 1.0_f64, epsilon = 10.0_f64.powi(-tolerance));
+        let pt = point.coordinates;
+        // let lhs = pt[0]*pt[0] + pt[1]*pt[1];
+        let lhs = pt[0..N - 1].iter().fold(0.0, |sum, x| sum + x * x);
+        let rhs = pt[N - 1] * pt[N - 1] - 1.0;
+        let tolerance = 8_i32 - (point.coordinates[N - 1].log10().trunc() as i32);
+        assert_relative_eq!(lhs, rhs, epsilon = 10.0_f64.powi(-tolerance));
         Hyperbolic { point }
     }
 }
@@ -651,10 +658,11 @@ impl Metric for Hyperbolic<3> {
     fn distance(&self, other: &Self) -> f64 {
         let self_coords = self.point.coordinates;
         let other_coords = other.point.coordinates;
-        (self_coords[2] * other_coords[2]
+        let arg = self_coords[2] * other_coords[2]
             - self_coords[0] * other_coords[0]
-            - self_coords[1] * other_coords[1])
-            .acosh()
+            - self_coords[1] * other_coords[1];
+        let arg_clipped = if arg <= 1.0 { 1.0 } else { arg };
+        arg_clipped.acosh()
     }
 
     #[inline]
@@ -683,11 +691,12 @@ impl Metric for Hyperbolic<4> {
     fn distance(&self, other: &Self) -> f64 {
         let self_coords = self.point.coordinates;
         let other_coords = other.point.coordinates;
-        (self_coords[3] * other_coords[3]
+        let arg = self_coords[3] * other_coords[3]
             - self_coords[0] * other_coords[0]
             - self_coords[1] * other_coords[1]
-            - self_coords[2] * other_coords[2])
-            .acosh()
+            - self_coords[2] * other_coords[2];
+        let arg_clipped = if arg <= 1.0 { 1.0 } else { arg };
+        arg_clipped.acosh()
     }
 
     #[inline]

--- a/hoomd-manifold/src/minkowski.rs
+++ b/hoomd-manifold/src/minkowski.rs
@@ -547,7 +547,7 @@ impl Hyperbolic<3> {
             v_sinh * (theta_mod.sin()),
             v.cosh(),
         ]);
-        Hyperbolic::from_minkowski_coordinates(point)
+        Hyperbolic { point }
     }
 }
 
@@ -565,7 +565,7 @@ impl Hyperbolic<4> {
             v_sinh * (theta_mod.sin()) * (phi_mod.sin()),
             v.cosh(),
         ]);
-        Hyperbolic::from_minkowski_coordinates(point)
+        Hyperbolic { point }
     }
 }
 

--- a/hoomd-manifold/src/minkowski.rs
+++ b/hoomd-manifold/src/minkowski.rs
@@ -526,10 +526,21 @@ impl<const N: usize> Hyperbolic<N> {
     )]
     pub fn from_minkowski_coordinates(point: Minkowski<N>) -> Hyperbolic<N> {
         let pt = point.coordinates;
-        // let lhs = pt[0]*pt[0] + pt[1]*pt[1];
-        let lhs = pt[0..N - 1].iter().fold(0.0, |sum, x| sum + x * x);
-        let rhs = pt[N - 1] * pt[N - 1] - 1.0;
-        let tolerance = 8_i32 - (point.coordinates[N - 1].log10().trunc() as i32);
+        let min_coord_index = pt[0..N - 1]
+            .iter()
+            .enumerate()
+            .min_by(|(_, a), (_, b)| a.total_cmp(b))
+            .map_or(0,|(i, _)| i);
+        let min_coord = pt[min_coord_index];
+        let lhs = min_coord.mul_add(min_coord, 1.0);
+        let rhs = pt[0..N - 1]
+            .iter()
+            .enumerate()
+            .filter(|(j, _)| *j != min_coord_index)
+            .fold(pt[N - 1] * pt[N - 1], |sum, (_, x)| {
+                f64::mul_add(-x, *x, sum)
+            });
+        let tolerance = 9_i32 - (point.coordinates[N - 1].log10().trunc() as i32);
         assert_relative_eq!(lhs, rhs, epsilon = 10.0_f64.powi(-tolerance));
         Hyperbolic { point }
     }

--- a/hoomd-manifold/src/minkowski.rs
+++ b/hoomd-manifold/src/minkowski.rs
@@ -523,7 +523,7 @@ impl<const N: usize> Hyperbolic<N> {
     pub fn from_minkowski_coordinates(point: Minkowski<N>) -> Hyperbolic<N> {
         let skirt_squared = -point.distance_squared(&Minkowski::<N>::default());
         let tolerance = 8_i32 - (point.coordinates[N-1].log10().floor() as i32);
-        assert_relative_eq!(skirt_squared, 1.0_f64, epsilon = 10.0_f64.powi(tolerance));
+        assert_relative_eq!(skirt_squared, 1.0_f64, epsilon = 10.0_f64.powi(-tolerance));
         Hyperbolic { point }
     }
 }

--- a/hoomd-manifold/src/minkowski.rs
+++ b/hoomd-manifold/src/minkowski.rs
@@ -540,7 +540,7 @@ impl<const N: usize> Hyperbolic<N> {
             .fold(pt[N - 1] * pt[N - 1], |sum, (_, x)| {
                 f64::mul_add(-x, *x, sum)
             });
-        let tolerance = 9_i32 - (point.coordinates[N - 1].log10().trunc() as i32);
+        let tolerance = 9_i32 - 2_i32 * (point.coordinates[N - 1].log10().trunc() as i32);
         assert_relative_eq!(lhs, rhs, epsilon = 10.0_f64.powi(-tolerance));
         Hyperbolic { point }
     }

--- a/hoomd-manifold/src/minkowski.rs
+++ b/hoomd-manifold/src/minkowski.rs
@@ -24,13 +24,13 @@ use hoomd_vector::{Metric, Vector};
 
 /// A vector in N-dimensional Minkowski space.
 ///
-/// [`Minkowski<N>`] implements (N-1,1)-dimensional Minkowski space with the
+/// [`Minkowski<N>`] implements $`(N-1,1)`$-dimensional Minkowski space with the
 /// metric signature $`(+ , \cdots , + , -)`$. [`Minkowski`] supports
 /// [`Vector`] operations such as vector addition and rescaling.
 ///
 /// ## Constructing Minkowski vectors
 ///
-/// Similar to [`Cartesian`], N-dimensional vectors can be
+/// Similar to [`Cartesian`], $`N`$-dimensional vectors can be
 /// constructed using an array of (real-valued) coordinates. Three- and
 /// four-dimensional vectors can also be constructed from tuples:
 /// ```
@@ -448,12 +448,12 @@ impl<const N: usize> Distribution<Minkowski<N>> for StandardUniform {
     }
 }
 
-/// Point on the top sheet of a Hyperboloid.
+/// Point on the top sheet of a two-sheeted hyperboloid.
 ///
 /// [`Hyperbolic`] implements an embedding of the top sheet of an
-/// (N-1)-dimensional two-sheeted hyperboloid in N-dimensional Minkowski space.
+/// $`(N-1)`$-dimensional two-sheeted hyperboloid in $`N`$-dimensional Minkowski space.
 /// This surface has constant negative curvature and therefore serves as a model
-/// of (N-1)-dimensional hyperbolic space.
+/// of $`(N-1)`$-dimensional hyperbolic space.
 ///
 /// Explicitly, for N-dimensional Minkowski space with metric $`\eta =
 /// \operatorname{diag}(+,\cdots,+,-)`$, the hyperboloid with skirt width $`R`$ is
@@ -469,7 +469,10 @@ impl<const N: usize> Distribution<Minkowski<N>> for StandardUniform {
 /// ```
 ///
 /// Note that the skirt width is fixed at $`R=1.0`$. In simulation, the global
-/// curvature may be tuned by changing the length scale of interactions.
+/// curvature may be tuned by changing the length scale of interactions. For
+/// example, rescaling distances by $`r \rightarrow r/\ell`$ has the same effect
+/// as running simulations with skirt length $`R = 1/\ell`$ or Gauss curvature
+/// $`K = -\ell^2`$.
 ///
 /// [`Hyperbolic`] implements a [`Metric`] that computes the distance of the
 /// geodesic passing between two points on a hyperboloid with some given skirt
@@ -488,6 +491,32 @@ impl<const N: usize> Distribution<Minkowski<N>> for StandardUniform {
 ///
 /// assert_eq!(((2.0_f64).sqrt()).acosh(), x.distance(&y));
 /// ```
+///
+/// ## Remark on Numeric Stability
+///
+/// The hyperboloid model of hyperbolic space performs best when points are
+/// located nearby the cusp (i.e., Minkowski coordinates $`(0,0,1)`$).
+/// Because of the way trial moves are validated, Monte Carlo simulations
+/// become numerically unstable when any bodies are far away from the cusp.
+/// Ideally, simulations should keep bodies within a distance of $`\approx 8.0`$
+/// from the cusp. All of the boundary conditions implemented for `Hyperbolic`
+/// satisfy this condition and perform well in MC simulations.
+///
+/// Nevertheless, it is often necessary to run larger simulations. `Hyperbolic`
+/// methods will still run simulations with bodies located far away from the
+/// cusp, but with a reduced numerical tolerance. Note also that using too
+/// small of a maximum translation step size is inherently unstable.
+/// Simulations will still run if the specified maximum step size is too small,
+/// but `Hyperbolic` methods would no longer guarantee that translation moves
+/// are not translated more than the specified maximum.
+///
+/// A rough method selecting maximum step sizes: If $`r_{max}`$ is the
+/// distance between the cusp and the most distant body, avoid setting the
+/// maximum step size to be smaller than
+/// $`10^{\left(\frac{1}{2}\log_{10}\left[\cosh^2(r_{max})/2\right]-6\right)}`$. For example,
+/// if the farthest body has Minkowski coordinates
+/// $`(10^5, 10^5, \sqrt{2\cdot 10^{10} + 1})`$, then $`r_{max} = 12.5526`$ and
+/// therefore step sizes smaller than $`0.1`$ are unstable.
 ///
 /// [`Metric`]: hoomd_vector::Metric
 #[derive(Clone, Copy, Debug, PartialEq, RelativeEq, Serialize, Deserialize)]
@@ -530,7 +559,7 @@ impl<const N: usize> Hyperbolic<N> {
             .iter()
             .enumerate()
             .min_by(|(_, a), (_, b)| a.total_cmp(b))
-            .map_or(0,|(i, _)| i);
+            .map_or(0, |(i, _)| i);
         let min_coord = pt[min_coord_index];
         let lhs = min_coord.mul_add(min_coord, 1.0);
         let rhs = pt[0..N - 1]

--- a/hoomd-manifold/src/minkowski.rs
+++ b/hoomd-manifold/src/minkowski.rs
@@ -522,7 +522,8 @@ impl<const N: usize> Hyperbolic<N> {
     #[inline]
     pub fn from_minkowski_coordinates(point: Minkowski<N>) -> Hyperbolic<N> {
         let skirt_squared = -point.distance_squared(&Minkowski::<N>::default());
-        assert_relative_eq!(skirt_squared, 1.0_f64, epsilon = 1e-8);
+        let tolerance = 8_i32 - (point.coordinates[N-1].log10().floor() as i32);
+        assert_relative_eq!(skirt_squared, 1.0_f64, epsilon = 10.0_f64.powi(tolerance));
         Hyperbolic { point }
     }
 }

--- a/hoomd-manifold/src/sphere.rs
+++ b/hoomd-manifold/src/sphere.rs
@@ -16,13 +16,17 @@ use hoomd_vector::{Cartesian, InnerProduct, Metric, Quaternion, Rotate, Versor};
 
 /// Point on the surface of a sphere.
 ///
-/// [`Spherical`] is a point on a unit N-sphere embedded in (N+1)-dimensional
-/// euclidean space. Explicitly, the N-sphere is defined by the set of
-/// (N+1)-dimensional points whose components satisfy
+/// [`Spherical<N>`] is a point on a unit $`(N-1)`$-sphere embedded in
+/// $`N`$-dimensional Euclidean space. Explicitly, the $`N`$-sphere is defined
+/// by the set of $`(N+1)`$-dimensional points whose components satisfy
 /// ```math
-/// x_1^2 + x_2^2 + \cdots + x_{N+1}^1 = 1.0
+/// x_1^2 + x_2^2 + \cdots + x_{N+1}^2 = 1.0
 /// ```
-/// Note that the radius is fixed to be 1.0.
+/// Note that the radius is fixed to be 1.0. The curvature of `Spherical`
+/// simulations can be tuned by changing the length scale of bodies and
+/// interactions. For example, rescaling all distances by
+/// $`r\rightarrow r/\ell`$ has the same effect as running simulations with
+/// radius $`R=1/\ell`$ or Gauss curvature $`K = \ell^2`$.
 #[derive(Clone, Copy, Debug, PartialEq, RelativeEq, Serialize, Deserialize)]
 pub struct Spherical<const N: usize> {
     /// a cartesian point living on the surface of an N-sphere
@@ -53,8 +57,9 @@ impl<const N: usize> Spherical<N> {
         assert_relative_eq!(rad, 1.0_f64, epsilon = 1e-6);
         Spherical { point }
     }
-    /// Implements a stereographic projection from the N-sphere to an n-dimensional
-    /// plane by projecting through the $`(0,\cdots, 0,1)`$ axis.
+    /// Implements a stereographic projection from the $`N`$-sphere to an
+    /// $`n`$-dimensional subspace by projecting through the
+    /// $`(0,\cdots, 0,1)`$ axis.
     ///
     /// # Example
     /// ```
@@ -110,7 +115,7 @@ impl Spherical<4> {
     /// \\ \cos\theta
     /// \end{pmatrix}
     /// ```
-    /// where $`\theta`$ and $`phi_1`$ both run over the range $`0`$ to $`\pi`$ and $`\phi_2`$
+    /// where $`\theta`$ and $`\phi_1`$ both run over the range $`0`$ to $`\pi`$ and $`\phi_2`$
     /// runs from $`0`$ to $`2\pi`$.
     #[inline]
     #[must_use]
@@ -207,13 +212,13 @@ impl Metric for Spherical<3> {
     /// The distance between two [`Spherical<3>`] points.
     ///
     /// Explicitly, the metric for two points $`\vec{u}`$ and $`\vec{v}`$ on a
-    /// 2-sphere with radius $`R`$ is given by
+    /// 2-sphere with unit radius is given by
     ///
     /// ```math
-    /// d_{S_2}(\vec{u}, \vec{v}) = R \arccos\left[\frac{1}{R^2}(u_1v_1 + u_2v_2 + u_3v_3)\right]
+    /// d_{S_2}(\vec{u}, \vec{v}) = \arccos\left[u_1v_1 + u_2v_2 + u_3v_3\right]
     /// ```
     /// This choice of metric furnishes a representation of 2-dimensional spherical
-    /// space with Gaussian curvature $`K = 1/R^2`$.
+    /// space with Gaussian curvature $`K = 1`$.
     #[inline]
     fn distance(&self, other: &Self) -> f64 {
         let arg = Cartesian::dot(&self.point, &other.point);
@@ -235,13 +240,13 @@ impl Metric for Spherical<4> {
     ///
     /// Explicitly, the
     /// metric for two points $`\vec{u}`$ and $`\vec{v}`$ on a 3-sphere with
-    /// radius  $`R`$ is given by
+    /// unit radius is given by
     ///
     /// ```math
-    /// d_{S_3}(\vec{u}, \vec{v}) = R \arccos\left[\frac{1}{R^2}(u_1v_1 + u_2v_2 + u_3v_3 + u_4v_4)\right]
+    /// d_{S_3}(\vec{u}, \vec{v}) = \arccos\left[u_1v_1 + u_2v_2 + u_3v_3 + u_4v_4\right]
     /// ```
     /// This choice of metric furnishes a representation of 3-dimensional spherical
-    /// space with Gaussian curvature $`K = 1/R^2`$.
+    /// space with Gaussian curvature $`K = 1`$.
     #[inline]
     fn distance(&self, other: &Self) -> f64 {
         let arg = Cartesian::dot(&self.point, &other.point);

--- a/hoomd-manifold/src/sphere.rs
+++ b/hoomd-manifold/src/sphere.rs
@@ -158,6 +158,7 @@ impl Spherical<4> {
     ///         .to_versor()
     ///         .expect("Hard-coded example is valid");
     /// let mapped_pole = Spherical::<4>::from_versor(transformation);
+    ///
     /// assert_relative_eq!(
     ///     mapped_pole.coordinates()[0],
     ///     x.coordinates()[0],

--- a/hoomd-mc/src/translate/hyperboloid.rs
+++ b/hoomd-mc/src/translate/hyperboloid.rs
@@ -193,7 +193,7 @@ mod tests {
                     .point()
                     .distance_squared(&Minkowski::from([0.0, 0.0, 0.0])),
                 -1.0,
-                epsilon = 10.0_f64.powi(tolerance)
+                epsilon = 10.0_f64.powi(-tolerance)
             );
 
             // Translation move does not move the point more than a distance d
@@ -227,7 +227,7 @@ mod tests {
                     .point()
                     .distance_squared(&Minkowski::from([0.0, 0.0, 0.0])),
                 -1.0,
-                epsilon = 10.0_f64.powi(tolerance)
+                epsilon = 10.0_f64.powi(-tolerance)
             );
 
             // Translation move does not move the point more than a distance d
@@ -264,7 +264,7 @@ mod tests {
                     .point()
                     .distance_squared(&Minkowski::from([0.0, 0.0, 0.0])),
                 -1.0,
-                epsilon = 10.0_f64.powi(tolerance)
+                epsilon = 10.0_f64.powi(-tolerance)
             );
 
             // Translation move does not move the point more than a distance d
@@ -298,7 +298,7 @@ mod tests {
                     .point()
                     .distance_squared(&Minkowski::from([0.0, 0.0, 0.0])),
                 -1.0,
-                epsilon = 10.0_f64.powi(tolerance)
+                epsilon = 10.0_f64.powi(-tolerance)
             );
 
             // Translation move does not move the point more than a distance d

--- a/hoomd-mc/src/translate/hyperboloid.rs
+++ b/hoomd-mc/src/translate/hyperboloid.rs
@@ -76,12 +76,17 @@ impl LocalTrial<Point<Hyperbolic<3>>> for Translate<Point<Hyperbolic<3>>> {
         ]);
         let mink_norm = (tangent[0]*tangent[0] + tangent[1]*tangent[1] - tangent[2]*tangent[2]).sqrt();
         let unit = tangent / mink_norm;
-        let new = Minkowski::from([
+        let new = [
             trial_array[0] * csh + unit.coordinates[0] * snh,
             trial_array[1] * csh + unit.coordinates[1] * snh,
             trial_array[2] * csh + unit.coordinates[2] * snh,
-        ]);
-        *trial.position_mut() = Hyperbolic::from_minkowski_coordinates(new);
+        ];
+        // push point back onto hyperboloid
+        let resc = 1.0/(new[2]*new[2]-new[0]*new[0]-new[1]*new[1]).sqrt();
+        //println!("rescaling factor: {}", resc);
+        //println!("new point coordinates: {:?}", new);
+        let new_pushed = Minkowski::from([resc*new[0], resc*new[1], resc*new[2]]);
+        *trial.position_mut() = Hyperbolic::from_minkowski_coordinates(new_pushed);
         trial
     }
 }
@@ -133,8 +138,9 @@ mod tests {
 
     /// Number of trial moves to test
     const N: usize = 256;
+    const NSTEPS: usize = 1000;
 
-    #[rstest]
+     #[rstest]
     fn translate_hyperbolic_point(#[values(0.01, 0.1, 1.0)] d: f64) {
         let mut rng = StdRng::seed_from_u64(42);
         let body_properties = Point::new(Hyperbolic::from_minkowski_coordinates(
@@ -168,6 +174,39 @@ mod tests {
     }
 
     #[rstest]
+    fn translate_hyperbolic_point_chain(#[values(0.5)] d: f64) {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut body_properties = Point::new(Hyperbolic::from_minkowski_coordinates(
+            [-1.0, 1.0, (3.0_f64).sqrt()].into(),
+        ));
+        let translate =
+            Translate::with_maximum_distance(d.try_into().expect("hard-coded positive real"));
+
+        for _ in 0..NSTEPS {
+            let new_body_properties = translate.propose(&mut rng, body_properties);
+
+            // Translation move keeps the point on the Hyperboloid
+            let tolerance = 8_i32 - (new_body_properties.position.coordinates()[2].log10().floor() as i32);
+            assert_relative_eq!(
+                new_body_properties
+                    .position()
+                    .point()
+                    .distance_squared(&Minkowski::from([0.0, 0.0, 0.0])),
+                -1.0,
+                epsilon = 10.0_f64.powi(tolerance)
+            );
+
+            // Translation move does not move the point more than a distance d
+            let dist = new_body_properties
+                .position()
+                .distance(&body_properties.position);
+            assert!(d > dist);
+
+            body_properties.position = new_body_properties.position;
+        }
+    }
+
+     #[rstest]
     fn translate_oriented_hyperbolic_point(#[values(0.01, 0.1, 1.0)] d: f64) {
         let mut rng = StdRng::seed_from_u64(42);
         let body_properties = OrientedHyperbolicPoint {
@@ -181,13 +220,14 @@ mod tests {
             let new_body_properties = translate.propose(&mut rng, body_properties);
 
             // Translation move keeps the point on the Hyperboloid
+            let tolerance = 8_i32 - (new_body_properties.position.coordinates()[2].log10().floor() as i32);
             assert_relative_eq!(
                 new_body_properties
                     .position()
                     .point()
                     .distance_squared(&Minkowski::from([0.0, 0.0, 0.0])),
                 -1.0,
-                epsilon = 1e-12
+                epsilon = 10.0_f64.powi(tolerance)
             );
 
             // Translation move does not move the point more than a distance d
@@ -202,5 +242,71 @@ mod tests {
             );
         }
     }
-    // TODO: stress tests
+
+    #[rstest]
+    fn translate_oriented_hyperbolic_point_chain(#[values(0.01, 0.1, 0.25)] d: f64) {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut body_properties = OrientedHyperbolicPoint {
+            position: Hyperbolic::from_minkowski_coordinates([1.0, 0.0, (2.0_f64).sqrt()].into()),
+            orientation: Angle::from(0.0),
+        };
+        let translate =
+            Translate::with_maximum_distance(d.try_into().expect("hard-coded positive real"));
+
+        for _ in 0..NSTEPS {
+            let new_body_properties = translate.propose(&mut rng, body_properties);
+
+            // Translation move keeps the point on the Hyperboloid
+            let tolerance = 8_i32 - (new_body_properties.position.coordinates()[2].log10().floor() as i32);
+            assert_relative_eq!(
+                new_body_properties
+                    .position()
+                    .point()
+                    .distance_squared(&Minkowski::from([0.0, 0.0, 0.0])),
+                -1.0,
+                epsilon = 10.0_f64.powi(tolerance)
+            );
+
+            // Translation move does not move the point more than a distance d
+            assert!(
+                d > new_body_properties
+                    .position()
+                    .distance(&mut body_properties.position)
+            );
+            body_properties.position = new_body_properties.position;
+        }
+    }
+    
+
+    #[rstest]
+    fn translate_hyperbolic_point_far_from_cusp(#[values(0.01, 0.1, 0.5)] d: f64) {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut body_properties = Point::new(Hyperbolic::from_minkowski_coordinates(
+            [100.0, 100.0, (20_001.0_f64).sqrt()].into(),
+        ));
+        let translate =
+            Translate::with_maximum_distance(d.try_into().expect("hard-coded positive real"));
+
+        for _ in 0..NSTEPS {
+            let new_body_properties = translate.propose(&mut rng, body_properties);
+
+            // Translation move keeps the point on the Hyperboloid
+            let tolerance = 8_i32 - (new_body_properties.position.coordinates()[2].log10().floor() as i32);
+            assert_relative_eq!(
+                new_body_properties
+                    .position()
+                    .point()
+                    .distance_squared(&Minkowski::from([0.0, 0.0, 0.0])),
+                -1.0,
+                epsilon = 10.0_f64.powi(tolerance)
+            );
+
+            // Translation move does not move the point more than a distance d
+            let dist = new_body_properties
+                .position()
+                .distance(&body_properties.position);
+            assert!(d > dist);
+            body_properties.position = new_body_properties.position;
+        }
+    } 
 }

--- a/hoomd-mc/src/translate/hyperboloid.rs
+++ b/hoomd-mc/src/translate/hyperboloid.rs
@@ -12,6 +12,7 @@ use rand_distr::StandardNormal;
 use crate::{LocalTrial, Translate};
 use hoomd_manifold::{Hyperbolic, HyperbolicDisk, Minkowski};
 use hoomd_microstate::property::{Orientation, OrientedHyperbolicPoint, Point, Position};
+use hoomd_utility::valid::PositiveReal;
 use hoomd_vector::Angle;
 
 impl LocalTrial<Point<Hyperbolic<3>>> for Translate<Point<Hyperbolic<3>>> {
@@ -66,18 +67,17 @@ impl LocalTrial<Point<Hyperbolic<3>>> for Translate<Point<Hyperbolic<3>>> {
         body_properties: Point<Hyperbolic<3>>,
     ) -> Point<Hyperbolic<3>> {
         let mut trial = body_properties;
-        /* let disk = HyperbolicDisk {
-            disk_radius: *self.maximum_distance(),
-            point: *trial.position_mut(),
-        };
-        let trial_sample: Hyperbolic<3> = disk.sample(rng);
-        let new = trial_sample.coordinates(); */
+        // let disk = HyperbolicDisk {
+        // disk_radius: *self.maximum_distance(),
+        // point: *trial.position_mut(),
+        // };
+        // let trial_sample: Hyperbolic<3> = disk.sample(rng);
+        // let new = trial_sample.coordinates();
 
         let trial_array = trial.position.coordinates();
-        let dist = Uniform::new(0.0, self.maximum_distance().get())
+        let dist = Uniform::new(0.0, self.maximum_distance().get() * 0.9)
             .expect("max distance must be positive real");
         let displacement = dist.sample(rng);
-        println!("selected displacement is {:}", displacement);
         let (snh, csh) = (displacement.sinh(), displacement.cosh());
         let vec: [f64; 3] = std::array::from_fn(|_| rng.sample(StandardNormal));
         let proj = vec[0] * trial_array[0] + vec[1] * trial_array[1] - vec[2] * trial_array[2];
@@ -114,8 +114,10 @@ impl LocalTrial<OrientedHyperbolicPoint<3, Angle>>
     ) -> OrientedHyperbolicPoint<3, Angle> {
         let mut trial = body_properties;
         let original_orientation = body_properties.orientation.theta;
+        let max_distance: PositiveReal = self.maximum_distance
+            * PositiveReal::try_from(0.9).expect("hard-coded positive number");
         let disk = HyperbolicDisk {
-            disk_radius: *self.maximum_distance(),
+            disk_radius: max_distance,
             point: *trial.position_mut(),
         };
         let (trial_sample, boost, rotation) =
@@ -304,14 +306,14 @@ mod tests {
             let dist = new_body_properties
                 .position()
                 .distance(&body_properties.position);
-            // println!("distance: {:} at position {:?}", dist, new_body_properties.position.coordinates());
             assert!(d > dist);
             body_properties.position = new_body_properties.position;
         }
     }
 
     #[rstest]
-    fn translate_hyperbolic_point_far_from_cusp(#[values(0.001, 0.01, 0.1, 0.25)] d: f64) {
+    fn translate_hyperbolic_point_far_from_cusp(#[values(0.001)] d: f64) {
+        //, 0.01, 0.1, 0.25)] d: f64) {
         let mut rng = StdRng::seed_from_u64(42);
         let mut body_properties = Point::new(Hyperbolic::from_minkowski_coordinates(
             [10_000.0, 10_000.0, (200_000_001.0_f64).sqrt()].into(),
@@ -344,9 +346,8 @@ mod tests {
             let dist = new_body_properties
                 .position()
                 .distance(&body_properties.position);
-            println!("distance from {:?} is : {:}", body_properties.position.coordinates() ,dist);
             // when far away from cusp, small displacements are unstable
-            assert!(d > dist - d*0.1);
+            assert!(d > dist);
             body_properties.position = new_body_properties.position;
         }
     }
@@ -387,9 +388,8 @@ mod tests {
             let dist = new_body_properties
                 .position()
                 .distance(&body_properties.position);
-            println!("distance from {:?} is : {:}", body_properties.position.coordinates() ,dist);
             // when far away from cusp, small displacements are unstable
-            assert!(d > dist - d*0.1);
+            assert!(d > dist);
             body_properties.position = new_body_properties.position;
         }
     }

--- a/hoomd-mc/src/translate/hyperboloid.rs
+++ b/hoomd-mc/src/translate/hyperboloid.rs
@@ -66,10 +66,18 @@ impl LocalTrial<Point<Hyperbolic<3>>> for Translate<Point<Hyperbolic<3>>> {
         body_properties: Point<Hyperbolic<3>>,
     ) -> Point<Hyperbolic<3>> {
         let mut trial = body_properties;
+        /* let disk = HyperbolicDisk {
+            disk_radius: *self.maximum_distance(),
+            point: *trial.position_mut(),
+        };
+        let trial_sample: Hyperbolic<3> = disk.sample(rng);
+        let new = trial_sample.coordinates(); */
+
         let trial_array = trial.position.coordinates();
         let dist = Uniform::new(0.0, self.maximum_distance().get())
             .expect("max distance must be positive real");
         let displacement = dist.sample(rng);
+        println!("selected displacement is {:}", displacement);
         let (snh, csh) = (displacement.sinh(), displacement.cosh());
         let vec: [f64; 3] = std::array::from_fn(|_| rng.sample(StandardNormal));
         let proj = vec[0] * trial_array[0] + vec[1] * trial_array[1] - vec[2] * trial_array[2];
@@ -86,13 +94,10 @@ impl LocalTrial<Point<Hyperbolic<3>>> for Translate<Point<Hyperbolic<3>>> {
             trial_array[1] * csh + unit.coordinates[1] * snh,
             trial_array[2] * csh + unit.coordinates[2] * snh,
         ];
-        // push point back onto hyperboloid
-        let new_pushed = Minkowski::from([
-            new[0],
-            new[1],
-            (new[0] * new[0] + new[1] * new[1] + 1.0_f64).sqrt(),
-        ]);
-        *trial.position_mut() = Hyperbolic::from_minkowski_coordinates(new_pushed);
+        // store in polar coordinates to ensure point is on disk
+        let theta = new[1].atan2(new[0]);
+        let boost = (new[2]).acosh();
+        *trial.position_mut() = Hyperbolic::<3>::from_polar_coordinates(boost, theta);
         trial
     }
 }
@@ -123,11 +128,10 @@ impl LocalTrial<OrientedHyperbolicPoint<3, Angle>>
         );
         *trial.orientation_mut() = Angle::from(original_orientation + del_phi);
         // push point back onto Hyperboloid
-        *trial.position_mut() = Hyperbolic::from_minkowski_coordinates(Minkowski::from([
-            trial_sample.coordinates()[0],
-            trial_sample.coordinates()[1],
-            (trial_sample.point()[0].powi(2) + trial_sample.point()[1].powi(2) + 1.0_f64).sqrt(),
-        ]));
+        let new = trial_sample.coordinates();
+        let theta = new[1].atan2(new[0]);
+        let boost = (new[2]).acosh();
+        *trial.position_mut() = Hyperbolic::<3>::from_polar_coordinates(boost, theta);
         trial
     }
 }
@@ -182,7 +186,7 @@ mod tests {
     }
 
     #[rstest]
-    fn translate_hyperbolic_point_chain(#[values(0.001, 0.01, 0.1, 0.5)] d: f64) {
+    fn translate_hyperbolic_point_chain(#[values(0.001, 0.01, 0.1, 0.25)] d: f64) {
         let mut rng = StdRng::seed_from_u64(42);
         let mut body_properties = Point::new(Hyperbolic::from_minkowski_coordinates(
             [-1.0, 1.0, (3.0_f64).sqrt()].into(),
@@ -307,10 +311,10 @@ mod tests {
     }
 
     #[rstest]
-    fn translate_hyperbolic_point_far_from_cusp(#[values(0.001, 0.01, 0.1, 0.5)] d: f64) {
+    fn translate_hyperbolic_point_far_from_cusp(#[values(0.001, 0.01, 0.1, 0.25)] d: f64) {
         let mut rng = StdRng::seed_from_u64(42);
         let mut body_properties = Point::new(Hyperbolic::from_minkowski_coordinates(
-            [100.0, 100.0, (20_001.0_f64).sqrt()].into(),
+            [10_000.0, 10_000.0, (200_000_001.0_f64).sqrt()].into(),
         ));
         let translate =
             Translate::with_maximum_distance(d.try_into().expect("hard-coded positive real"));
@@ -340,7 +344,52 @@ mod tests {
             let dist = new_body_properties
                 .position()
                 .distance(&body_properties.position);
-            assert!(d > dist);
+            println!("distance from {:?} is : {:}", body_properties.position.coordinates() ,dist);
+            // when far away from cusp, small displacements are unstable
+            assert!(d > dist - d*0.1);
+            body_properties.position = new_body_properties.position;
+        }
+    }
+    #[rstest]
+    fn translate_oriented_hyperbolic_point_far_from_cusp(#[values(0.001, 0.01, 0.1)] d: f64) {
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut body_properties = OrientedHyperbolicPoint {
+            position: Hyperbolic::from_minkowski_coordinates(
+                [10_000.0, 10_000.0, (200_000_001.0_f64).sqrt()].into(),
+            ),
+            orientation: Angle::default(),
+        };
+        let translate =
+            Translate::with_maximum_distance(d.try_into().expect("hard-coded positive real"));
+
+        for _ in 0..NSTEPS {
+            let new_body_properties = translate.propose(&mut rng, body_properties);
+
+            // Translation move keeps the point on the Hyperboloid
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "float is truncated before converting to i32"
+            )]
+            let tolerance = 8_i32
+                - (new_body_properties.position.coordinates()[2]
+                    .log10()
+                    .trunc() as i32);
+            assert_relative_eq!(
+                new_body_properties
+                    .position()
+                    .point()
+                    .distance_squared(&Minkowski::from([0.0, 0.0, 0.0])),
+                -1.0,
+                epsilon = 10.0_f64.powi(-tolerance)
+            );
+
+            // Translation move does not move the point more than a distance d
+            let dist = new_body_properties
+                .position()
+                .distance(&body_properties.position);
+            println!("distance from {:?} is : {:}", body_properties.position.coordinates() ,dist);
+            // when far away from cusp, small displacements are unstable
+            assert!(d > dist - d*0.1);
             body_properties.position = new_body_properties.position;
         }
     }

--- a/hoomd-mc/src/translate/hyperboloid.rs
+++ b/hoomd-mc/src/translate/hyperboloid.rs
@@ -67,14 +67,16 @@ impl LocalTrial<Point<Hyperbolic<3>>> for Translate<Point<Hyperbolic<3>>> {
         body_properties: Point<Hyperbolic<3>>,
     ) -> Point<Hyperbolic<3>> {
         let mut trial = body_properties;
-        // let disk = HyperbolicDisk {
-        // disk_radius: *self.maximum_distance(),
-        // point: *trial.position_mut(),
-        // };
-        // let trial_sample: Hyperbolic<3> = disk.sample(rng);
-        // let new = trial_sample.coordinates();
+        let max_distance: PositiveReal = self.maximum_distance
+            * PositiveReal::try_from(0.9).expect("hard-coded positive number");
+        let disk = HyperbolicDisk {
+            disk_radius: max_distance,
+            point: *trial.position_mut(),
+        };
+        let trial_sample: Hyperbolic<3> = disk.sample(rng);
+        let new = trial_sample.coordinates();
 
-        let trial_array = trial.position.coordinates();
+        /* let trial_array = trial.position.coordinates();
         let dist = Uniform::new(0.0, self.maximum_distance().get() * 0.9)
             .expect("max distance must be positive real");
         let displacement = dist.sample(rng);
@@ -93,7 +95,7 @@ impl LocalTrial<Point<Hyperbolic<3>>> for Translate<Point<Hyperbolic<3>>> {
             trial_array[0] * csh + unit.coordinates[0] * snh,
             trial_array[1] * csh + unit.coordinates[1] * snh,
             trial_array[2] * csh + unit.coordinates[2] * snh,
-        ];
+        ]; */
         // store in polar coordinates to ensure point is on disk
         let theta = new[1].atan2(new[0]);
         let boost = (new[2]).acosh();

--- a/hoomd-mc/src/translate/hyperboloid.rs
+++ b/hoomd-mc/src/translate/hyperboloid.rs
@@ -3,7 +3,10 @@
 
 //! Implement Translation moves on curved surfaces
 
-use rand::{Rng, RngExt, distr::{Distribution, Uniform}};
+use rand::{
+    Rng, RngExt,
+    distr::{Distribution, Uniform},
+};
 use rand_distr::StandardNormal;
 
 use crate::{LocalTrial, Translate};
@@ -64,17 +67,19 @@ impl LocalTrial<Point<Hyperbolic<3>>> for Translate<Point<Hyperbolic<3>>> {
     ) -> Point<Hyperbolic<3>> {
         let mut trial = body_properties;
         let trial_array = trial.position.coordinates();
-        let dist = Uniform::new(0.0, self.maximum_distance().get()).expect("max distance must be positive real");
+        let dist = Uniform::new(0.0, self.maximum_distance().get())
+            .expect("max distance must be positive real");
         let displacement = dist.sample(rng);
         let (snh, csh) = (displacement.sinh(), displacement.cosh());
-        let vec: [f64;3] = std::array::from_fn(|_| rng.sample(StandardNormal));
-        let proj = vec[0]*trial_array[0] + vec[1]*trial_array[1] - vec[2]*trial_array[2];
+        let vec: [f64; 3] = std::array::from_fn(|_| rng.sample(StandardNormal));
+        let proj = vec[0] * trial_array[0] + vec[1] * trial_array[1] - vec[2] * trial_array[2];
         let tangent = Minkowski::from([
             vec[0] + proj * trial_array[0],
             vec[1] + proj * trial_array[1],
             vec[2] + proj * trial_array[2],
         ]);
-        let mink_norm = (tangent[0]*tangent[0] + tangent[1]*tangent[1] - tangent[2]*tangent[2]).sqrt();
+        let mink_norm =
+            (tangent[0] * tangent[0] + tangent[1] * tangent[1] - tangent[2] * tangent[2]).sqrt();
         let unit = tangent / mink_norm;
         let new = [
             trial_array[0] * csh + unit.coordinates[0] * snh,
@@ -82,10 +87,11 @@ impl LocalTrial<Point<Hyperbolic<3>>> for Translate<Point<Hyperbolic<3>>> {
             trial_array[2] * csh + unit.coordinates[2] * snh,
         ];
         // push point back onto hyperboloid
-        let resc = 1.0/(new[2]*new[2]-new[0]*new[0]-new[1]*new[1]).sqrt();
-        //println!("rescaling factor: {}", resc);
-        //println!("new point coordinates: {:?}", new);
-        let new_pushed = Minkowski::from([resc*new[0], resc*new[1], resc*new[2]]);
+        let new_pushed = Minkowski::from([
+            new[0],
+            new[1],
+            (new[0] * new[0] + new[1] * new[1] + 1.0_f64).sqrt(),
+        ]);
         *trial.position_mut() = Hyperbolic::from_minkowski_coordinates(new_pushed);
         trial
     }
@@ -140,7 +146,7 @@ mod tests {
     const N: usize = 256;
     const NSTEPS: usize = 1000;
 
-     #[rstest]
+    #[rstest]
     fn translate_hyperbolic_point(#[values(0.01, 0.1, 1.0)] d: f64) {
         let mut rng = StdRng::seed_from_u64(42);
         let body_properties = Point::new(Hyperbolic::from_minkowski_coordinates(
@@ -163,18 +169,20 @@ mod tests {
             );
 
             // Translation move does not move the point more than a distance d
-            let dist = new_body_properties.position().distance(
-                    &Hyperbolic::from_minkowski_coordinates(Minkowski::from([
+            let dist =
+                new_body_properties
+                    .position()
+                    .distance(&Hyperbolic::from_minkowski_coordinates(Minkowski::from([
                         1.0,
                         0.0,
-                        (2.0_f64).sqrt()
+                        (2.0_f64).sqrt(),
                     ])));
             assert!(d > dist);
         }
     }
 
     #[rstest]
-    fn translate_hyperbolic_point_chain(#[values(0.5)] d: f64) {
+    fn translate_hyperbolic_point_chain(#[values(0.001, 0.01, 0.1, 0.5)] d: f64) {
         let mut rng = StdRng::seed_from_u64(42);
         let mut body_properties = Point::new(Hyperbolic::from_minkowski_coordinates(
             [-1.0, 1.0, (3.0_f64).sqrt()].into(),
@@ -186,7 +194,14 @@ mod tests {
             let new_body_properties = translate.propose(&mut rng, body_properties);
 
             // Translation move keeps the point on the Hyperboloid
-            let tolerance = 8_i32 - (new_body_properties.position.coordinates()[2].log10().floor() as i32);
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "float is truncated before converting to i32"
+            )]
+            let tolerance = 8_i32
+                - (new_body_properties.position.coordinates()[2]
+                    .log10()
+                    .trunc() as i32);
             assert_relative_eq!(
                 new_body_properties
                     .position()
@@ -206,8 +221,8 @@ mod tests {
         }
     }
 
-     #[rstest]
-    fn translate_oriented_hyperbolic_point(#[values(0.01, 0.1, 1.0)] d: f64) {
+    #[rstest]
+    fn translate_oriented_hyperbolic_point(#[values(0.001, 0.01, 0.1, 1.0)] d: f64) {
         let mut rng = StdRng::seed_from_u64(42);
         let body_properties = OrientedHyperbolicPoint {
             position: Hyperbolic::from_minkowski_coordinates([1.0, 0.0, (2.0_f64).sqrt()].into()),
@@ -220,7 +235,14 @@ mod tests {
             let new_body_properties = translate.propose(&mut rng, body_properties);
 
             // Translation move keeps the point on the Hyperboloid
-            let tolerance = 8_i32 - (new_body_properties.position.coordinates()[2].log10().floor() as i32);
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "float is truncated before converting to i32"
+            )]
+            let tolerance = 8_i32
+                - (new_body_properties.position.coordinates()[2]
+                    .log10()
+                    .trunc() as i32);
             assert_relative_eq!(
                 new_body_properties
                     .position()
@@ -244,7 +266,7 @@ mod tests {
     }
 
     #[rstest]
-    fn translate_oriented_hyperbolic_point_chain(#[values(0.01, 0.1, 0.25)] d: f64) {
+    fn translate_oriented_hyperbolic_point_chain(#[values(0.001, 0.01, 0.1, 0.25)] d: f64) {
         let mut rng = StdRng::seed_from_u64(42);
         let mut body_properties = OrientedHyperbolicPoint {
             position: Hyperbolic::from_minkowski_coordinates([1.0, 0.0, (2.0_f64).sqrt()].into()),
@@ -257,7 +279,14 @@ mod tests {
             let new_body_properties = translate.propose(&mut rng, body_properties);
 
             // Translation move keeps the point on the Hyperboloid
-            let tolerance = 8_i32 - (new_body_properties.position.coordinates()[2].log10().floor() as i32);
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "float is truncated before converting to i32"
+            )]
+            let tolerance = 8_i32
+                - (new_body_properties.position.coordinates()[2]
+                    .log10()
+                    .trunc() as i32);
             assert_relative_eq!(
                 new_body_properties
                     .position()
@@ -268,18 +297,17 @@ mod tests {
             );
 
             // Translation move does not move the point more than a distance d
-            assert!(
-                d > new_body_properties
-                    .position()
-                    .distance(&mut body_properties.position)
-            );
+            let dist = new_body_properties
+                .position()
+                .distance(&body_properties.position);
+            // println!("distance: {:} at position {:?}", dist, new_body_properties.position.coordinates());
+            assert!(d > dist);
             body_properties.position = new_body_properties.position;
         }
     }
-    
 
     #[rstest]
-    fn translate_hyperbolic_point_far_from_cusp(#[values(0.01, 0.1, 0.5)] d: f64) {
+    fn translate_hyperbolic_point_far_from_cusp(#[values(0.001, 0.01, 0.1, 0.5)] d: f64) {
         let mut rng = StdRng::seed_from_u64(42);
         let mut body_properties = Point::new(Hyperbolic::from_minkowski_coordinates(
             [100.0, 100.0, (20_001.0_f64).sqrt()].into(),
@@ -291,7 +319,14 @@ mod tests {
             let new_body_properties = translate.propose(&mut rng, body_properties);
 
             // Translation move keeps the point on the Hyperboloid
-            let tolerance = 8_i32 - (new_body_properties.position.coordinates()[2].log10().floor() as i32);
+            #[allow(
+                clippy::cast_possible_truncation,
+                reason = "float is truncated before converting to i32"
+            )]
+            let tolerance = 8_i32
+                - (new_body_properties.position.coordinates()[2]
+                    .log10()
+                    .trunc() as i32);
             assert_relative_eq!(
                 new_body_properties
                     .position()
@@ -308,5 +343,5 @@ mod tests {
             assert!(d > dist);
             body_properties.position = new_body_properties.position;
         }
-    } 
+    }
 }

--- a/hoomd-mc/src/translate/hyperboloid.rs
+++ b/hoomd-mc/src/translate/hyperboloid.rs
@@ -3,7 +3,8 @@
 
 //! Implement Translation moves on curved surfaces
 
-use rand::{Rng, distr::Distribution};
+use rand::{Rng, RngExt, distr::{Distribution, Uniform}};
+use rand_distr::StandardNormal;
 
 use crate::{LocalTrial, Translate};
 use hoomd_manifold::{Hyperbolic, HyperbolicDisk, Minkowski};
@@ -62,17 +63,25 @@ impl LocalTrial<Point<Hyperbolic<3>>> for Translate<Point<Hyperbolic<3>>> {
         body_properties: Point<Hyperbolic<3>>,
     ) -> Point<Hyperbolic<3>> {
         let mut trial = body_properties;
-        let disk = HyperbolicDisk {
-            disk_radius: *self.maximum_distance(),
-            point: *trial.position_mut(),
-        };
-        let trial_sample: Hyperbolic<3> = disk.sample(rng);
-        // push point back onto Hyperboloid
-        *trial.position_mut() = Hyperbolic::from_minkowski_coordinates(Minkowski::from([
-            trial_sample.coordinates()[0],
-            trial_sample.coordinates()[1],
-            (trial_sample.point()[0].powi(2) + trial_sample.point()[1].powi(2) + 1.0_f64).sqrt(),
-        ]));
+        let trial_array = trial.position.coordinates();
+        let dist = Uniform::new(0.0, self.maximum_distance().get()).expect("max distance must be positive real");
+        let displacement = dist.sample(rng);
+        let (snh, csh) = (displacement.sinh(), displacement.cosh());
+        let vec: [f64;3] = std::array::from_fn(|_| rng.sample(StandardNormal));
+        let proj = vec[0]*trial_array[0] + vec[1]*trial_array[1] - vec[2]*trial_array[2];
+        let tangent = Minkowski::from([
+            vec[0] + proj * trial_array[0],
+            vec[1] + proj * trial_array[1],
+            vec[2] + proj * trial_array[2],
+        ]);
+        let mink_norm = (tangent[0]*tangent[0] + tangent[1]*tangent[1] - tangent[2]*tangent[2]).sqrt();
+        let unit = tangent / mink_norm;
+        let new = Minkowski::from([
+            trial_array[0] * csh + unit.coordinates[0] * snh,
+            trial_array[1] * csh + unit.coordinates[1] * snh,
+            trial_array[2] * csh + unit.coordinates[2] * snh,
+        ]);
+        *trial.position_mut() = Hyperbolic::from_minkowski_coordinates(new);
         trial
     }
 }
@@ -128,7 +137,6 @@ mod tests {
     #[rstest]
     fn translate_hyperbolic_point(#[values(0.01, 0.1, 1.0)] d: f64) {
         let mut rng = StdRng::seed_from_u64(42);
-        let rho: f64 = 1.0;
         let body_properties = Point::new(Hyperbolic::from_minkowski_coordinates(
             [1.0, 0.0, (2.0_f64).sqrt()].into(),
         ));
@@ -144,20 +152,18 @@ mod tests {
                     .position()
                     .point()
                     .distance_squared(&Minkowski::from([0.0, 0.0, 0.0])),
-                -(rho.powi(2)),
-                epsilon = 1e-12
+                -1.0,
+                epsilon = 1e-8
             );
 
             // Translation move does not move the point more than a distance d
-            assert!(
-                d > new_body_properties.position().distance(
+            let dist = new_body_properties.position().distance(
                     &Hyperbolic::from_minkowski_coordinates(Minkowski::from([
                         1.0,
                         0.0,
                         (2.0_f64).sqrt()
-                    ]),)
-                )
-            );
+                    ])));
+            assert!(d > dist);
         }
     }
 
@@ -196,4 +202,5 @@ mod tests {
             );
         }
     }
+    // TODO: stress tests
 }

--- a/hoomd-mc/src/translate/hyperboloid.rs
+++ b/hoomd-mc/src/translate/hyperboloid.rs
@@ -3,14 +3,10 @@
 
 //! Implement Translation moves on curved surfaces
 
-use rand::{
-    Rng, RngExt,
-    distr::{Distribution, Uniform},
-};
-use rand_distr::StandardNormal;
+use rand::{Rng, distr::Distribution};
 
 use crate::{LocalTrial, Translate};
-use hoomd_manifold::{Hyperbolic, HyperbolicDisk, Minkowski};
+use hoomd_manifold::{Hyperbolic, HyperbolicDisk};
 use hoomd_microstate::property::{Orientation, OrientedHyperbolicPoint, Point, Position};
 use hoomd_utility::valid::PositiveReal;
 use hoomd_vector::Angle;
@@ -75,27 +71,6 @@ impl LocalTrial<Point<Hyperbolic<3>>> for Translate<Point<Hyperbolic<3>>> {
         };
         let trial_sample: Hyperbolic<3> = disk.sample(rng);
         let new = trial_sample.coordinates();
-
-        /* let trial_array = trial.position.coordinates();
-        let dist = Uniform::new(0.0, self.maximum_distance().get() * 0.9)
-            .expect("max distance must be positive real");
-        let displacement = dist.sample(rng);
-        let (snh, csh) = (displacement.sinh(), displacement.cosh());
-        let vec: [f64; 3] = std::array::from_fn(|_| rng.sample(StandardNormal));
-        let proj = vec[0] * trial_array[0] + vec[1] * trial_array[1] - vec[2] * trial_array[2];
-        let tangent = Minkowski::from([
-            vec[0] + proj * trial_array[0],
-            vec[1] + proj * trial_array[1],
-            vec[2] + proj * trial_array[2],
-        ]);
-        let mink_norm =
-            (tangent[0] * tangent[0] + tangent[1] * tangent[1] - tangent[2] * tangent[2]).sqrt();
-        let unit = tangent / mink_norm;
-        let new = [
-            trial_array[0] * csh + unit.coordinates[0] * snh,
-            trial_array[1] * csh + unit.coordinates[1] * snh,
-            trial_array[2] * csh + unit.coordinates[2] * snh,
-        ]; */
         // store in polar coordinates to ensure point is on disk
         let theta = new[1].atan2(new[0]);
         let boost = (new[2]).acosh();

--- a/hoomd-mc/src/translate/sphere.rs
+++ b/hoomd-mc/src/translate/sphere.rs
@@ -3,7 +3,10 @@
 
 //! Implement Translation moves on curved surfaces
 
-use rand::{Rng, RngExt, distr::{Distribution, Uniform}};
+use rand::{
+    Rng, RngExt,
+    distr::{Distribution, Uniform},
+};
 use rand_distr::StandardNormal;
 
 use crate::{LocalTrial, Translate};
@@ -35,7 +38,7 @@ impl LocalTrial<Point<Spherical<3>>> for Translate<Point<Spherical<3>>> {
     ///
     /// // Translation move keeps point on the surface of the sphere
     /// let new_body_radius = new_body_properties.position.point().norm();
-    /// assert_relative_eq!(new_body_radius, 1.0, epsilon=1e-8);
+    /// assert_relative_eq!(new_body_radius, 1.0, epsilon = 1e-8);
     ///
     /// // Translation move does not translate the point more than a distance d away
     /// assert!(
@@ -53,9 +56,10 @@ impl LocalTrial<Point<Spherical<3>>> for Translate<Point<Spherical<3>>> {
         body_properties: Point<Spherical<3>>,
     ) -> Point<Spherical<3>> {
         let mut trial = body_properties;
-        let dist = Uniform::new(0.0, self.maximum_distance().get()).expect("max distance must be positive real");
+        let dist = Uniform::new(0.0, self.maximum_distance().get())
+            .expect("max distance must be positive real");
         let displacement = dist.sample(rng);
-        //let displacement = (self.maximum_distance().get()) * rng.sample::<f64, _>(StandardNormal);
+        // let displacement = (self.maximum_distance().get()) * rng.sample::<f64, _>(StandardNormal);
         let (sn, cs) = (displacement.sin(), displacement.cos());
         let vec = Cartesian::<3>::from(std::array::from_fn(|_| rng.sample(StandardNormal)));
         let proj = vec.dot(trial.position.point());
@@ -123,7 +127,8 @@ impl LocalTrial<Point<Spherical<4>>> for Translate<Point<Spherical<4>>> {
         body_properties: Point<Spherical<4>>,
     ) -> Point<Spherical<4>> {
         let mut trial = body_properties;
-        let dist = Uniform::new(0.0, self.maximum_distance().get()).expect("max distance must be positive real");
+        let dist = Uniform::new(0.0, self.maximum_distance().get())
+            .expect("max distance must be positive real");
         let displacement = dist.sample(rng);
         let (sn, cs) = ((displacement.abs()).sin(), (displacement.abs()).cos());
         let vec = Cartesian::<4>::from(std::array::from_fn(|_| rng.sample(StandardNormal)));
@@ -158,12 +163,13 @@ mod tests {
     const N: usize = 256;
 
     #[rstest]
-    fn translate_2spherical_point(#[values(0.01,0.1,1.0)] d:f64) {
+    fn translate_2spherical_point(#[values(0.01, 0.1, 1.0)] d: f64) {
         let mut rng = StdRng::seed_from_u64(1459);
         let initial_point = Point::new(Spherical::<3>::from_cartesian_coordinates(
-            [0.5_f64.sqrt(), 0.0, 0.5_f64.sqrt()].into()
+            [0.5_f64.sqrt(), 0.0, 0.5_f64.sqrt()].into(),
         ));
-        let translate = Translate::with_maximum_distance(d.try_into().expect("hard-coded positive value"));
+        let translate =
+            Translate::with_maximum_distance(d.try_into().expect("hard-coded positive value"));
 
         for _ in 0..N {
             let new_body_properties = translate.propose(&mut rng, initial_point);
@@ -177,20 +183,21 @@ mod tests {
             assert!(
                 d > new_body_properties
                     .position()
-                    .distance(&initial_point.position())
+                    .distance(initial_point.position())
             );
         }
     }
 
     #[rstest]
-    fn translate_3spherical_point(#[values(0.01,0.1,1.0)] d:f64) {
+    fn translate_3spherical_point(#[values(0.01, 0.1, 1.0)] d: f64) {
         let mut rng = StdRng::seed_from_u64(1459);
         let initial_point = Point::new(Spherical::<4>::from_polar_coordinates(
             PI / 4.0,
             PI / 10.0,
             5.0 * PI / 4.0,
         ));
-        let translate = Translate::with_maximum_distance(d.try_into().expect("hard-coded positive value"));
+        let translate =
+            Translate::with_maximum_distance(d.try_into().expect("hard-coded positive value"));
 
         for _ in 0..N {
             let new_body_properties = translate.propose(&mut rng, initial_point);
@@ -204,7 +211,7 @@ mod tests {
             assert!(
                 d > new_body_properties
                     .position()
-                    .distance(&initial_point.position())
+                    .distance(initial_point.position())
             );
         }
     }

--- a/hoomd-mc/src/translate/sphere.rs
+++ b/hoomd-mc/src/translate/sphere.rs
@@ -3,7 +3,7 @@
 
 //! Implement Translation moves on curved surfaces
 
-use rand::{Rng, RngExt};
+use rand::{Rng, RngExt, distr::{Distribution, Uniform}};
 use rand_distr::StandardNormal;
 
 use crate::{LocalTrial, Translate};
@@ -35,7 +35,7 @@ impl LocalTrial<Point<Spherical<3>>> for Translate<Point<Spherical<3>>> {
     ///
     /// // Translation move keeps point on the surface of the sphere
     /// let new_body_radius = new_body_properties.position.point().norm();
-    /// assert_eq!(new_body_radius, 1.0);
+    /// assert_relative_eq!(new_body_radius, 1.0, epsilon=1e-8);
     ///
     /// // Translation move does not translate the point more than a distance d away
     /// assert!(
@@ -53,7 +53,9 @@ impl LocalTrial<Point<Spherical<3>>> for Translate<Point<Spherical<3>>> {
         body_properties: Point<Spherical<3>>,
     ) -> Point<Spherical<3>> {
         let mut trial = body_properties;
-        let displacement = (self.maximum_distance().get()) * rng.sample::<f64, _>(StandardNormal);
+        let dist = Uniform::new(0.0, self.maximum_distance().get()).expect("max distance must be positive real");
+        let displacement = dist.sample(rng);
+        //let displacement = (self.maximum_distance().get()) * rng.sample::<f64, _>(StandardNormal);
         let (sn, cs) = (displacement.sin(), displacement.cos());
         let vec = Cartesian::<3>::from(std::array::from_fn(|_| rng.sample(StandardNormal)));
         let proj = vec.dot(trial.position.point());
@@ -121,8 +123,9 @@ impl LocalTrial<Point<Spherical<4>>> for Translate<Point<Spherical<4>>> {
         body_properties: Point<Spherical<4>>,
     ) -> Point<Spherical<4>> {
         let mut trial = body_properties;
-        let displacement = (self.maximum_distance().get()) * rng.sample::<f64, _>(StandardNormal);
-        let (sn, cs) = (displacement.sin(), displacement.cos());
+        let dist = Uniform::new(0.0, self.maximum_distance().get()).expect("max distance must be positive real");
+        let displacement = dist.sample(rng);
+        let (sn, cs) = ((displacement.abs()).sin(), (displacement.abs()).cos());
         let vec = Cartesian::<4>::from(std::array::from_fn(|_| rng.sample(StandardNormal)));
         let proj = vec.dot(trial.position.point());
         let tangent = Cartesian::from([
@@ -140,5 +143,69 @@ impl LocalTrial<Point<Spherical<4>>> for Translate<Point<Spherical<4>>> {
         ]);
         *trial.position_mut() = Spherical::from_cartesian_coordinates(new);
         trial
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approxim::assert_relative_eq;
+    use hoomd_vector::Metric;
+    use rand::{SeedableRng, rngs::StdRng};
+    use rstest::*;
+    use std::f64::consts::PI;
+
+    const N: usize = 256;
+
+    #[rstest]
+    fn translate_2spherical_point(#[values(0.01,0.1,1.0)] d:f64) {
+        let mut rng = StdRng::seed_from_u64(1459);
+        let initial_point = Point::new(Spherical::<3>::from_cartesian_coordinates(
+            [0.5_f64.sqrt(), 0.0, 0.5_f64.sqrt()].into()
+        ));
+        let translate = Translate::with_maximum_distance(d.try_into().expect("hard-coded positive value"));
+
+        for _ in 0..N {
+            let new_body_properties = translate.propose(&mut rng, initial_point);
+            // Translation move keeps point on the surface of the sphere
+            assert_relative_eq!(
+                new_body_properties.position().point().norm(),
+                1.0_f64,
+                epsilon = 1e-8
+            );
+            // Translation move does not translate the point more than a distance d away
+            assert!(
+                d > new_body_properties
+                    .position()
+                    .distance(&initial_point.position())
+            );
+        }
+    }
+
+    #[rstest]
+    fn translate_3spherical_point(#[values(0.01,0.1,1.0)] d:f64) {
+        let mut rng = StdRng::seed_from_u64(1459);
+        let initial_point = Point::new(Spherical::<4>::from_polar_coordinates(
+            PI / 4.0,
+            PI / 10.0,
+            5.0 * PI / 4.0,
+        ));
+        let translate = Translate::with_maximum_distance(d.try_into().expect("hard-coded positive value"));
+
+        for _ in 0..N {
+            let new_body_properties = translate.propose(&mut rng, initial_point);
+            // Translation move keeps point on the surface of the sphere
+            assert_relative_eq!(
+                new_body_properties.position().point().norm(),
+                1.0_f64,
+                epsilon = 1e-8
+            );
+            // Translation move does not translate the point more than a distance d away
+            assert!(
+                d > new_body_properties
+                    .position()
+                    .distance(&initial_point.position())
+            );
+        }
     }
 }


### PR DESCRIPTION
## Description

The primary goal of this PR is to improve the numeric stability for two-dimensional hyperbolic space. This is accomplished in two ways: 

- The numeric tolerance for creating `Hyperbolic<2>` using the `from_minkowski_coordinates` method is relaxed, in rough. proportion to how far away the point is from the hyperboloid cusp. Specifically, the `epsilon` value of `assert_relative_eq!` is aggressively tuned to allow for points which are far away from the cusp to be placed. 
- `Translate<Point<Hyperbolic<3>>>`, which previously used the Riemannian exponential map, is re-implemented to use a more stable method. 
- The method `from_polar_coordinates` for `Hyperbolic<3>` and `Hyperbolic<4>` is modified to skip redundantly checking if the point is on the hyperboloid. 

This PR also includes a few documentation tweaks in `hoomd_manifold`. Notably it adds a section for `Hyperbolic` which notifies users of the numeric stability issues and makes some recommendations for smooth simulating. 

## Motivation and context

An inescapable feature of the hyperboloid model is that Minkowski coordinates increase exponentially with the distance from the hyperboloid cusp. This means that large simulations (e.g., with points farther than a distance of ~8.0 from the cusp) quickly run into catastrophic numeric stability problems. For example, the method `Hyperbolic::from_minkowski_coordinates()` checks that the Minkowski coordinates satisfy the hyperboloid equation x^2 + y^2 - z^2 = 1. This calculation is numerically unstable when the squares of any of the coordinates are significantly larger than 1, making it impossible to run large simulations. Small translation moves for bodies far away from the cusp are unstable for similar reasons. 

## How has this been tested?

I have tested how well the new `translate` method works for bodies that are far from the cusp. Specifically, I compared the actual displacement to the specified maximum step size as well as the internally generated random number (which is supposed to be the displacement). The rough rule of thumb I found is that translation moves become unreliable when the maximum step size is less than six orders of magnitude smaller than the largest Minkowski coordinate (for example, using a maximum step size smaller than 10^{-1} is ill-advised if the simulation contains a point such as (10^{5}, 0, sqrt(10^5 + 1))). In extreme cases this can lead to displacements which exceed the specified maximum step size. 

`translate\hyperboloid.rs` now includes unit tests which explicitly check that translation moves are well-behaved within the recommended ranges. 

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**hoomd-rs Contributor Agreement**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/credits.md`) in the pull request source branch.
- [x] I have summarized these changes in `release-notes.md` following the established format.
