### PR TITLE
Implement a four-dimensional cross-product analog

### DIFF
--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -7,6 +7,7 @@
 * `[hoomd-manifold]`: Add `Spherical<4>::from_versor` and the corresponding `::to_versor` (#285).
 * `[hoomd-mc]`: Implement translation moves for `Point<Spherical<4>>` (#287).
 * `[hoomd-utility]`: Implement `Eq`, `PartialOrd`, and `Ord` for `PositiveReal` (#287).
+* `[hoomd-vector]`: Implement `Cartesian<4>::counary_cross` (#305).
 
 *Changed:*
 

--- a/hoomd-vector/benches/cartesian.rs
+++ b/hoomd-vector/benches/cartesian.rs
@@ -99,6 +99,22 @@ fn cross_vec3(bencher: Bencher) {
         .with_inputs(|| create_random_vector_pair::<3, _>(&mut rng))
         .bench_local_values(|(a, b)| black_box(a.cross(&b)));
 }
+#[divan::bench(sample_size = 1000)]
+fn counary_cross_vec4(bencher: Bencher) {
+    let mut rng = StdRng::seed_from_u64(1);
+
+    bencher
+        .counter(ItemsCount::from(1_u32))
+        .with_inputs(|| {
+            (
+                create_random_vector_pair::<4, _>(&mut rng),
+                create_random_vector_pair::<4, _>(&mut rng),
+            )
+        })
+        .bench_local_values(|((a, b), (c, _))| {
+            black_box(Cartesian::<4>::counary_cross(&[a, b, c]))
+        });
+}
 
 #[divan::bench(consts = DIMENSIONS)]
 fn gen_random<const N: usize>(bencher: Bencher) {

--- a/hoomd-vector/src/cartesian.rs
+++ b/hoomd-vector/src/cartesian.rs
@@ -18,7 +18,10 @@ use rand::{
 };
 
 use crate::{Cross, Error, InnerProduct, Metric, Rotate, Unit, Vector};
-use hoomd_linear_algebra::{MatMul, matrix::Matrix};
+use hoomd_linear_algebra::{
+    MatMul,
+    matrix::{Matrix, Matrix33},
+};
 
 /// A [`Vector`] represented by `N` `f64` coordinates.
 ///
@@ -463,8 +466,19 @@ impl Cartesian<4> {
     ///
     /// [co-unary]: https://ncatlab.org/nlab/show/cross+product#counary
     #[inline]
-    fn counary_cross(vectors: &[Self; 3]) -> Self {
-        todo!()
+    #[must_use]
+    pub fn counary_cross(vectors: &[Self; 3]) -> Self {
+        std::array::from_fn(|skip| {
+            Matrix33 {
+                rows: std::array::from_fn(|r| {
+                    // Skip the column 'skip' by adding 1 to the index when c >= skip
+                    std::array::from_fn(|c| vectors[r][c + usize::from(c >= skip)])
+                }),
+            }
+            .determinant()
+                * if skip.is_multiple_of(2) { 1.0 } else { -1.0 }
+        })
+        .into()
     }
 }
 
@@ -1195,5 +1209,34 @@ mod tests {
         for (a, b) in transposed.rows().iter().zip(inverted.rows().iter()) {
             assert_relative_eq!(a, b);
         }
+    }
+
+    #[rstest]
+    fn test_generalized_cross_product_combinations(
+        #[values(1.0, -2.5, 4.0)] r1: f64,
+        #[values(1.0, 3.0, -5.1)] r2: f64,
+        #[values(2.0, -1.5, 0.0)] r3: f64,
+        #[values(0.0, 33.0, -12.5, 0.04)] x: f64,
+        #[values(0.0, 1.0, 3.0, -2.6)] y: f64,
+        #[values(0.0, 2.0, -1.5, -0.1)] z: f64,
+    ) {
+        // Construct a lower-triangular matrix of vectors
+        let vecs = [
+            Cartesian::from([r1, 0.0, 0.0, 0.0]),
+            Cartesian::from([x, r2, 0.0, 0.0]),
+            Cartesian::from([y, z, r3, 0.0]),
+        ];
+
+        let cross = Cartesian::<4>::counary_cross(&vecs);
+
+        // Validate the result is perpendicular to all inputs
+        for v in &vecs {
+            assert_relative_eq!(cross.dot(v), 0.0);
+        }
+
+        // Validate the magnitude is exactly the spanned volume
+        // For a triangular matrix, the volume is strictly the product of the diagonals.
+        let expected_volume_sq = (r1 * r2 * r3).powi(2);
+        assert_relative_eq!(cross.norm_squared(), expected_volume_sq);
     }
 }

--- a/hoomd-vector/src/cartesian.rs
+++ b/hoomd-vector/src/cartesian.rs
@@ -18,10 +18,7 @@ use rand::{
 };
 
 use crate::{Cross, Error, InnerProduct, Metric, Rotate, Unit, Vector};
-use hoomd_linear_algebra::{
-    MatMul,
-    matrix::Matrix,
-};
+use hoomd_linear_algebra::{MatMul, matrix::Matrix};
 
 /// A [`Vector`] represented by `N` `f64` coordinates.
 ///
@@ -468,17 +465,26 @@ impl Cartesian<4> {
     #[inline]
     #[must_use]
     pub fn counary_cross(vectors: &[Self; 3]) -> Self {
+        /// Calculate a 2x2 matrix determinant while compensating for errors.
+        /// <https://pharr.org/matt/blog/2019/11/03/difference-of-floats>
+        #[inline(always)]
+        fn diff_of_products(a: f64, b: f64, c: f64, d: f64) -> f64 {
+            let cd = c * d;
+            let err = (-c).mul_add(d, cd);
+            let dop = a.mul_add(b, -cd);
+            dop + err
+        }
         let u = &vectors[0];
         let v = &vectors[1];
         let w = &vectors[2];
 
-        // 2x2 Minors
-        let m01 = v[0] * w[1] - v[1] * w[0];
-        let m02 = v[0] * w[2] - v[2] * w[0];
-        let m03 = v[0] * w[3] - v[3] * w[0];
-        let m12 = v[1] * w[2] - v[2] * w[1];
-        let m13 = v[1] * w[3] - v[3] * w[1];
-        let m23 = v[2] * w[3] - v[3] * w[2];
+        // 2x2 Minors via Kahan's Exact FMA
+        let m01 = diff_of_products(v[0], w[1], v[1], w[0]);
+        let m02 = diff_of_products(v[0], w[2], v[2], w[0]);
+        let m03 = diff_of_products(v[0], w[3], v[3], w[0]);
+        let m12 = diff_of_products(v[1], w[2], v[2], w[1]);
+        let m13 = diff_of_products(v[1], w[3], v[3], w[1]);
+        let m23 = diff_of_products(v[2], w[3], v[3], w[2]);
 
         // Association is important here, as we can accumulate small sign errors if we
         // do not correctly group terms!

--- a/hoomd-vector/src/cartesian.rs
+++ b/hoomd-vector/src/cartesian.rs
@@ -448,6 +448,26 @@ impl Cross for Cartesian<3> {
     }
 }
 
+impl Cartesian<4> {
+    /// Compute the `N-1`-ary ([co-unary]) cross product of a four-dimensional vector.
+    ///
+    /// This function is a generalization of the cross product to general dimension,
+    /// identifying a unique vector perpendicular to `N-1` other vectors. In two
+    /// dimensions, this is [`Cartesian::<2>::perp`], and in three dimensions this is
+    /// simply [`Cross`].
+    ///
+    /// In geometric algebra terms, this is the Hodge dual of the exterior (Wedge)
+    /// product. Geometrically, the dot product of the resulting vector with all inputs
+    /// is zero and the magnitude of the vector is the hypervolume of the
+    /// parallelepiped spanned by the inputs.
+    ///
+    /// [co-unary]: https://ncatlab.org/nlab/show/cross+product#counary
+    #[inline]
+    fn counary_cross(&self, others: &[Self; 2]) -> Self {
+        todo!()
+    }
+}
+
 impl<const N: usize> Distribution<Cartesian<N>> for StandardUniform {
     /// Sample a Cartesian vector from the uniform [-1, 1] hypercube.
     ///

--- a/hoomd-vector/src/cartesian.rs
+++ b/hoomd-vector/src/cartesian.rs
@@ -20,7 +20,7 @@ use rand::{
 use crate::{Cross, Error, InnerProduct, Metric, Rotate, Unit, Vector};
 use hoomd_linear_algebra::{
     MatMul,
-    matrix::{Matrix, Matrix33},
+    matrix::Matrix,
 };
 
 /// A [`Vector`] represented by `N` `f64` coordinates.

--- a/hoomd-vector/src/cartesian.rs
+++ b/hoomd-vector/src/cartesian.rs
@@ -463,7 +463,7 @@ impl Cartesian<4> {
     ///
     /// [co-unary]: https://ncatlab.org/nlab/show/cross+product#counary
     #[inline]
-    fn counary_cross(&self, others: &[Self; 2]) -> Self {
+    fn counary_cross(vectors: &[Self; 3]) -> Self {
         todo!()
     }
 }

--- a/hoomd-vector/src/cartesian.rs
+++ b/hoomd-vector/src/cartesian.rs
@@ -468,16 +468,26 @@ impl Cartesian<4> {
     #[inline]
     #[must_use]
     pub fn counary_cross(vectors: &[Self; 3]) -> Self {
-        std::array::from_fn(|skip| {
-            Matrix33 {
-                rows: std::array::from_fn(|r| {
-                    // Skip the column 'skip' by adding 1 to the index when c >= skip
-                    std::array::from_fn(|c| vectors[r][c + usize::from(c >= skip)])
-                }),
-            }
-            .determinant()
-                * if skip.is_multiple_of(2) { 1.0 } else { -1.0 }
-        })
+        let u = &vectors[0];
+        let v = &vectors[1];
+        let w = &vectors[2];
+
+        // 2x2 Minors
+        let m01 = v[0] * w[1] - v[1] * w[0];
+        let m02 = v[0] * w[2] - v[2] * w[0];
+        let m03 = v[0] * w[3] - v[3] * w[0];
+        let m12 = v[1] * w[2] - v[2] * w[1];
+        let m13 = v[1] * w[3] - v[3] * w[1];
+        let m23 = v[2] * w[3] - v[3] * w[2];
+
+        // Association is important here, as we can accumulate small sign errors if we
+        // do not correctly group terms!
+        [
+            (u[1] * m23 - u[2] * m13 + u[3] * m12),
+            -(u[0] * m23 - u[2] * m03 + u[3] * m02),
+            (u[0] * m13 - u[1] * m03 + u[3] * m01),
+            -(u[0] * m12 - u[1] * m02 + u[2] * m01),
+        ]
         .into()
     }
 }

--- a/hoomd-vector/src/cartesian.rs
+++ b/hoomd-vector/src/cartesian.rs
@@ -1235,7 +1235,7 @@ mod tests {
         }
 
         // Validate the magnitude is exactly the spanned volume
-        // For a triangular matrix, the volume is strictly the product of the diagonals.
+        // For a triangular matrix, the volume is the product of the diagonals.
         let expected_volume_sq = (r1 * r2 * r3).powi(2);
         assert_relative_eq!(cross.norm_squared(), expected_volume_sq);
     }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->

## Motivation and context

This approach generalizes the concept of the cross product to arbitrary dimension, although I have only implemented it for N=4 as most algorithms for this scale exponentially with N. This code is planned to be used in a four-dimensional xenocollide implementation, although I tried to make the implementation as domain-agnostic as possible. It is possible we could rewrite the current Cross trait in terms of this more general feature, but we run into N-1 generic issues.

## How has this been tested?

New tests validate invariants including orthogonality and the volume of the spanned vectors.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**hoomd-rs Contributor Agreement**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/credits.md`) in the pull request source branch.
- [ ] I have summarized these changes in `release-notes.md` following the established format.
