### PR TITLE
Test out single-precision support mapping

### DIFF
--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -3,6 +3,8 @@
 
 //! N-Dimensional generalization of a convex polyhedron.
 
+use std::iter::zip;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{BoundingSphereRadius, Error, SupportMapping};
@@ -207,23 +209,56 @@ impl<const N: usize, const MAX_VERTICES: usize> ConvexPolytope<N, MAX_VERTICES> 
     }
 }
 
+/// Single-precision cartesian vector type.
+#[derive(Clone, Copy)]
+struct CartesianF32<const N: usize> {
+    /// Coordinates of the vector in R^N
+    coordinates: [f32; N],
+}
+impl<const N: usize> CartesianF32<N> {
+    /// Take the dot product of two `CartesianF32` types
+    #[inline(always)]
+    fn dot(&self, other: &Self) -> f32 {
+        zip(self.coordinates.iter(), other.coordinates.iter())
+            .fold(0.0, |product, (&x, &y)| x.mul_add(y, product))
+    }
+    /// Return the `CartesianF32` as a double-precision `Cartesian<N>`
+    #[inline]
+    fn as_double(&self) -> Cartesian<N> {
+        self.coordinates.map(f64::from).into()
+    }
+}
+
+impl<const N: usize> From<Cartesian<N>> for CartesianF32<N> {
+    #[inline]
+    #[expect(clippy::cast_possible_truncation, reason = "Truncation is valid")]
+    fn from(value: Cartesian<N>) -> Self {
+        Self {
+            coordinates: value.coordinates.map(|x| x as f32),
+        }
+    }
+}
+
 impl<const N: usize, const MAX_VERTICES: usize> SupportMapping<Cartesian<N>>
     for ConvexPolytope<N, MAX_VERTICES>
 {
     #[inline]
     fn support_mapping(&self, n: &Cartesian<N>) -> Cartesian<N> {
+        let n = &CartesianF32::from(*n);
         match N {
             0 => Cartesian::<N>::default(),
             1 => self.vertices[0],
-            _ => *self
+            _ => self
                 .vertices
                 .iter()
+                .map(|&v| CartesianF32::from(v))
                 .max_by(|a, b| {
                     a.dot(n)
                         .partial_cmp(&b.dot(n))
                         .unwrap_or(std::cmp::Ordering::Equal)
                 })
-                .expect("the 0 match statement should handle empty vectors"),
+                .expect("the 0 match statement should handle empty vectors")
+                .as_double(),
         }
     }
 }


### PR DESCRIPTION
## Description

Improve performance of composite support mapping.

NOTE: this code is not of a sufficient quality to be incorporated, and the finding needs significant further review -- however, the performance delta running SupportMapping for ConvexPolyhedron in single precision is almost 50% on osx-arm64. 

## Motivation and context

```
# f64

> ./target/release/benchmark -b mc_3d_octahedron
[INFO  benchmark] mc_3d_octahedron: 4096 bodies
[INFO  benchmark] 1 threads
[INFO  benchmarks::benchmark] Average: 90.90262056771684 sweep/s
mc_3d_octahedron    :    90.903 steps/s

# f32

> ./target/release/benchmark -b mc_3d_octahedron
[INFO  benchmark] mc_3d_octahedron: 4096 bodies
[INFO  benchmark] 1 threads
[INFO  benchmarks::benchmark] Average: 139.90105206632083 sweep/s
mc_3d_octahedron    :   139.901 steps/s


```

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [ ] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/CONTRIBUTING.md).
- [ ] I agree with the terms of the [**hoomd-rs Contributor Agreement**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/ContributorAgreement.md).
- [ ] My name is on the list of contributors (`doc/src/credits.md`) in the pull request source branch.
- [ ] I have summarized these changes in `release-notes.md` following the established format.
