### PR TITLE
Improve performance of ConvexPolytope::support_mapping

### DIFF
--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -13,6 +13,7 @@
 *Changed:*
 
 * `[hoomd-mc]`: Improve the numerical stability of translation moves for `Point<Spherical<3>>` (#287).
+* `[hoomd-geometry`]: Improve performance `ConvexPolytope` intersection tests (#332).
 * Build the documentation with mdBook 0.5.3 (#295).
 
 *Deprecated:*

--- a/hoomd-geometry/benches/overlaps.rs
+++ b/hoomd-geometry/benches/overlaps.rs
@@ -378,3 +378,38 @@ mod capsule {
             .bench_local_values(|((c0, c1), (t, r))| black_box(c0.intersects_at(&c1, &t, &r)));
     }
 }
+
+#[divan::bench_group]
+mod support_mapping {
+    use super::*;
+    use hoomd_geometry::SupportMapping;
+
+    const VERTICES: &[usize] = &[6, 16, 32];
+
+    fn random_directions<const N: usize>(count: usize, seed: u64) -> Vec<Cartesian<N>> {
+        let mut rng = StdRng::seed_from_u64(seed);
+        (0..count).map(|_| rng.random::<Cartesian<N>>()).collect()
+    }
+
+    #[divan::bench(consts = VERTICES)]
+    fn dipyramid<const N: usize>(bencher: Bencher) {
+        let base = ConvexPolytope::<2>::regular(N);
+        let shape = ConvexPolytope::<3>::with_vertices(
+            base.vertices()
+                .iter()
+                .map(|x| Cartesian::from([x[0], x[1], 0.0]))
+                .chain([[0.0, 0.0, 0.5].into(), [0.0, 0.0, -0.5].into()]),
+        )
+        .expect("constructed polytope should be valid");
+        let directions = random_directions::<3>(1024, 1);
+
+        bencher
+            .counter(ItemsCount::from(1024_u32))
+            .with_inputs(|| directions.clone())
+            .bench_local_values(|dirs| {
+                for d in black_box(dirs) {
+                    black_box(shape.support_mapping(&d));
+                }
+            });
+    }
+}

--- a/hoomd-geometry/benches/overlaps.rs
+++ b/hoomd-geometry/benches/overlaps.rs
@@ -384,24 +384,11 @@ mod support_mapping {
     use super::*;
     use hoomd_geometry::SupportMapping;
 
-    const VERTICES: &[usize] = &[6, 16, 32];
-
-    fn random_directions<const N: usize>(count: usize, seed: u64) -> Vec<Cartesian<N>> {
-        let mut rng = StdRng::seed_from_u64(seed);
-        (0..count).map(|_| rng.random::<Cartesian<N>>()).collect()
-    }
-
-    #[divan::bench(consts = VERTICES)]
+    #[divan::bench(consts = DIPYRAMID_VERTICES)]
     fn dipyramid<const N: usize>(bencher: Bencher) {
-        let base = ConvexPolytope::<2>::regular(N);
-        let shape = ConvexPolytope::<3>::with_vertices(
-            base.vertices()
-                .iter()
-                .map(|x| Cartesian::from([x[0], x[1], 0.0]))
-                .chain([[0.0, 0.0, 0.5].into(), [0.0, 0.0, -0.5].into()]),
-        )
-        .expect("constructed polytope should be valid");
-        let directions = random_directions::<3>(1024, 1);
+        let shape = create_dipyramid(N);
+        let mut rng = StdRng::seed_from_u64(1);
+        let directions: Vec<Cartesian<3>> = (0..1024).map(|_| rng.random()).collect();
 
         bencher
             .counter(ItemsCount::from(1024_u32))

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -211,7 +211,7 @@ impl<const N: usize, const MAX_VERTICES: usize> ConvexPolytope<N, MAX_VERTICES> 
 ///
 /// This returns an `ExactSizeIterator` of f64 values with `lhs.len()` elements.
 #[inline(always)]
-fn gemv<const MAX_VERTICES: usize, const N: usize>(
+fn matrix_vector_multiply<const MAX_VERTICES: usize, const N: usize>(
     lhs: &ArrayVec<Cartesian<N>, MAX_VERTICES>,
     rhs: Cartesian<N>, // Copy appears to be compiled out, and this lets us elide '_
 ) -> impl ExactSizeIterator<Item = f64> + '_ {
@@ -228,7 +228,7 @@ impl<const N: usize, const MAX_VERTICES: usize> SupportMapping<Cartesian<N>>
             0 => Cartesian::<N>::default(),
             1 => self.vertices[0],
             _ => {
-                let scalars = gemv(&self.vertices, *n);
+                let scalars = matrix_vector_multiply(&self.vertices, *n);
 
                 let (mut argmax, mut max_val) = (0, f64::NEG_INFINITY);
                 scalars.enumerate().for_each(|(i, x)| {

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -207,6 +207,18 @@ impl<const N: usize, const MAX_VERTICES: usize> ConvexPolytope<N, MAX_VERTICES> 
     }
 }
 
+/// Compute the matrix-vector multiplication of an `ArrayVec` against a `Cartesian<N>`.
+///
+/// This returns an `ExactSizeIterator` of f64 values with `lhs.len()` elements.
+#[inline(always)]
+fn gemv<const MAX_VERTICES: usize, const N: usize>(
+    lhs: &ArrayVec<Cartesian<N>, MAX_VERTICES>,
+    rhs: Cartesian<N>, // Copy appears to be compiled out, and this lets us elide '_
+) -> impl ExactSizeIterator<Item = f64> + '_ {
+    lhs.iter()
+        .map(move |vertex| (0..N).map(|m| vertex[m] * rhs[m]).sum())
+}
+
 impl<const N: usize, const MAX_VERTICES: usize> SupportMapping<Cartesian<N>>
     for ConvexPolytope<N, MAX_VERTICES>
 {
@@ -216,16 +228,16 @@ impl<const N: usize, const MAX_VERTICES: usize> SupportMapping<Cartesian<N>>
             0 => Cartesian::<N>::default(),
             1 => self.vertices[0],
             _ => {
-                let mut best = self.vertices[0];
-                let mut best_dot = best.dot(n);
-                for v in self.vertices.iter().skip(1) {
-                    let d = v.dot(n);
-                    if d > best_dot {
-                        best_dot = d;
-                        best = *v;
+                let scalars = gemv(&self.vertices, *n);
+
+                let (mut argmax, mut max_val) = (0, f64::NEG_INFINITY);
+                scalars.enumerate().for_each(|(i, x)| {
+                    if x > max_val {
+                        argmax = i;
+                        max_val = x;
                     }
-                }
-                best
+                });
+                self.vertices[argmax]
             }
         }
     }

--- a/hoomd-geometry/src/shape/convex_polytope.rs
+++ b/hoomd-geometry/src/shape/convex_polytope.rs
@@ -215,15 +215,18 @@ impl<const N: usize, const MAX_VERTICES: usize> SupportMapping<Cartesian<N>>
         match N {
             0 => Cartesian::<N>::default(),
             1 => self.vertices[0],
-            _ => *self
-                .vertices
-                .iter()
-                .max_by(|a, b| {
-                    a.dot(n)
-                        .partial_cmp(&b.dot(n))
-                        .unwrap_or(std::cmp::Ordering::Equal)
-                })
-                .expect("the 0 match statement should handle empty vectors"),
+            _ => {
+                let mut best = self.vertices[0];
+                let mut best_dot = best.dot(n);
+                for v in self.vertices.iter().skip(1) {
+                    let d = v.dot(n);
+                    if d > best_dot {
+                        best_dot = d;
+                        best = *v;
+                    }
+                }
+                best
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Calculating the support mapping is a large cost of the Xenocollide algorithm for faceted bodies. This code accelerates that, doing slightly less work than a previous implementation and getting compiled to better asm. This is especially significant for shapes with many vertices.

### mc_3d_octahedron benches

| Architecture  | `trunk` | `feat/support-fewer-dots` |
|-------|-----|------------|
|M1|95.792|130.645|
| M1 Pro | 150.441 steps/s | 187.155 steps/s |
| AMD Ryzen Threadripper 3960X | 152.695 steps/s  | 197.516 steps/s |


## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #317 

## How has this been tested?

Existing tests pass.

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**hoomd-rs Contributor Agreement**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/credits.md`) in the pull request source branch.
- [x] I have summarized these changes in `release-notes.md` following the established format.
