### PR TITLE
Switch back to `rust-toolchain`.

### DIFF
--- a/.github/workflows/interactive-examples.yaml
+++ b/.github/workflows/interactive-examples.yaml
@@ -37,9 +37,10 @@ jobs:
     - name: Remove native build configuration
       run: rm .cargo/config.toml
     - name: Configure Rust
-      run: rustup toolchain install 1.95.0
-    - name: Install wasm32 target
-      run: rustup target add wasm32-unknown-unknown
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+      with:
+        toolchain: 1.96.0
+        targets: wasm32-unknown-unknown
     - name: Check rust installation
       run: rustc -vV
     - name: Install cargo-binstall

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -130,7 +130,9 @@ jobs:
     - name: Remove native build configuration
       run: rm .cargo/config.toml
     - name: Configure Rust
-      run: rustup toolchain install 1.95.0
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+      with:
+        toolchain: 1.96.0
     - name: Authorize with crates.io
       uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
       id: auth

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -31,9 +31,11 @@ jobs:
     - name: Remove native build configuration
       run: rm .cargo/config.toml
     - name: Configure Rust
-      run: rustup toolchain install 1.95.0 --component clippy
-    - name: Install wasm32 target
-      run: rustup target add wasm32-unknown-unknown
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+      with:
+        toolchain: 1.96.0
+        targets: wasm32-unknown-unknown
+        components: clippy
     - name: Cache
       uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       with:
@@ -122,7 +124,10 @@ jobs:
     - name: Remove native build configuration
       run: rm .cargo/config.toml
     - name: Configure Rust
-      run: rustup toolchain install nightly-2025-09-17 --component rustfmt
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+      with:
+        toolchain: nightly-2025-09-17
+        components: rustfmt
     - run: cargo +nightly-2025-09-17 fmt --all --check
 
   prek:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,13 +37,13 @@ jobs:
           - macos-26
           - windows-2025
         rust:
-          - 1.95.0
+          - 1.96.0
         target:
          - ''
 
         include:
         - os: ubuntu-24.04
-          rust: 1.95.0
+          rust: 1.96.0
           target: wasm32-unknown-unknown
 
         # Test MSRV
@@ -59,14 +59,10 @@ jobs:
     - name: Remove native build configuration
       run: rm .cargo/config.toml
     - name: Configure Rust
-      run: rustup toolchain install "${TOOLCHAIN}"
-      env:
-        TOOLCHAIN: ${{ matrix.rust }}
-    - name: Install additional target
-      if: ${{ matrix.target }}
-      run: rustup target add "${TARGET}"
-      env:
-        TARGET: ${{ matrix.target }}
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+      with:
+        toolchain: ${{ matrix.rust }}
+        targets: ${{ matrix.target }}
     - name: Check rust installation
       run: rustc -vV
     # rust-cache already includes a Cargo.lock hash in the key. However, it

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,7 +48,7 @@ jobs:
 
         # Test MSRV
         - os: ubuntu-24.04
-          rust: 1.91.0
+          rust: 1.95.0
           target: ''
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   unit_test:
-    name: Unit test [rust-${{ matrix.rust }}-${{ matrix.os }}-${{ matrix.target || 'native' }}]
+    name: Unit test [${{ matrix.os }}-${{ matrix.target || 'native' }}]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -36,8 +36,6 @@ jobs:
           - ubuntu-24.04
           - macos-26
           - windows-2025
-        rust:
-          - 1.96.0
         target:
          - ''
 
@@ -45,11 +43,6 @@ jobs:
         - os: ubuntu-24.04
           rust: 1.96.0
           target: wasm32-unknown-unknown
-
-        # Test MSRV
-        - os: ubuntu-24.04
-          rust: 1.95.0
-          target: ''
 
     steps:
     - name: Checkout
@@ -61,7 +54,7 @@ jobs:
     - name: Configure Rust
       uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
       with:
-        toolchain: ${{ matrix.rust }}
+        toolchain: 1.96.0
         targets: ${{ matrix.target }}
     - name: Check rust installation
       run: rustc -vV

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ default-members = ["examples",
 [workspace.package]
 version = "1.1.0"
 edition = "2024"
-rust-version = "1.91"
+rust-version = "1.95"
 homepage = "https://glotzerlab.engin.umich.edu"
 documentation = "https://hoomd-rs.readthedocs.io"
 repository = "https://github.com/glotzerlab/hoomd-rs"


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Switch back to `rust-toolchain`. Also test with Rust 1.96.0.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
There are many advantages to using `rust-toolchain`: https://github.com/zizmorcore/zizmor/issues/1817 . One of those is automatic updates of `rust-version` by Renovate.

zizmor now considers `rust-toolchain` a pedantic lint.

<!-- Replace ??? with the issue number that this pull request resolves. -->

## How has this been tested?

CI checks.

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**hoomd-rs Contributor Agreement**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/credits.md`) in the pull request source branch.
- [ ] I have summarized these changes in `release-notes.md` following the established format.
