### PR TITLE
Ignore nightly Rust releases.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,11 @@
       "matchManagers": ["cargo"],
       "matchPackageNames": ["wayland-*"],
       "groupName": "wayland"
+    },
+    {
+      "matchPackageNames": ["rust"],
+      "matchCurrentVersion": "/nightly/",
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Ignore nightly Rust releases in Renovate configuration.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
There is no need to update the version of cargo fmt we use every day.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #???

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Please build the sphinx documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**hoomd-rs Contributor Agreement**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/credits.md`) in the pull request source branch.
- [x] I have summarized these changes in `release-notes.md` following the established format.
