### PR TITLE
Example: 3d particles on a 2d plane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3061,6 +3061,7 @@ name = "examples"
 version = "1.2.0"
 dependencies = [
  "anyhow",
+ "arrayvec",
  "bevy",
  "bevy_egui",
  "hoomd-bevy",

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -39,6 +39,7 @@
   - [Grandcanonical ensemble simulation of ellipses (2D)](mc-examples/ellipse-gcmc-2d.md)
   - [Melt an ideal hexagonal structure of hexagons](mc-examples/crystal-stability.md)
   - [Multi-site patchy shapes](mc-examples/multi-site-patchy-shapes.md)
+  - [3D shapes confined to a 2D plane](mc-examples/capsules-on-a-plane.md)
 
 # Reference
 

--- a/doc/src/mc-examples/capsules-on-a-plane.md
+++ b/doc/src/mc-examples/capsules-on-a-plane.md
@@ -22,19 +22,20 @@ import init from 'https://glotzerlab.github.io/hoomd-rs/mc-examples/capsules-on-
 
 ## Strategy
 
-1. Bodies with `Cartesian<2>` positions and `Versor` orientations.
-2. Define a custom `SiteProperties` with `Cartesian<3>` position and `Versor` orientation.
-   Transform sites from the body frame to the simulation frame by lifting the body
-   position into 3D: `(body_x, body_y, 0)`.
+1. Represent bodies with `Cartesian<2>` positions and `Versor` orientations.
+2. Define a custom `SiteProperties` with `Cartesian<3>` positions and `Versor`
+   orientations. Transform sites from the body frame to the simulation frame by first
+   lifting the body position into 3D: `(body_x, body_y, 0)` and then transforming
+   as normal.
 3. Define a custom `Boundary` type that wraps `Periodic<Rectangle>`.
    Implement `Wrap<BodyProperties>`, `Volume`, `MapPoint`, `Scale`, and `Distribution`
-   for the custom boundary by calling the same method on the inner type.
+   for the custom boundary by calling the same methods on the inner type.
    Implement `Wrap<SiteProperties>` and `GenerateGhosts` by projecting
-   the 3D site position into 2D, calling the method on the wrapped type,
+   the 3D site position into 2D, calling the same methods on the wrapped type,
    then lift the result back into 3D.
 
 See the example code for details. It implements all of these steps in a general fashion.
-You can copy and paste this code and use it for Monte Carlo simulations of any 3D
+You can copy and paste this code and use it for Monte Carlo simulations with any 3D
 interaction model (including multi-site rigid bodies) where the body centers should
 be confined to the _xy_ plane.
 

--- a/doc/src/mc-examples/capsules-on-a-plane.md
+++ b/doc/src/mc-examples/capsules-on-a-plane.md
@@ -1,0 +1,43 @@
+# 3D shapes confined to a 2D plane
+
+<script type="module">
+import init from 'https://glotzerlab.github.io/hoomd-rs/mc-examples/capsules-on-a-plane.js'
+{{#include ../../scripts/init-wasm-canvas.js}}
+</script>
+{{#include ../../scripts/canvas.html}}
+
+## Overview
+
+* Objective: Self-assemble 3D capsules that are allowed to freely rotate while their
+  center is confined to a 2D plane.
+* File: `hoomd-rs/examples/mc-examples/capsules-on-a-plane.rs`
+* Run (interactively):
+  ```shell
+  cargo run --release --features "bevy" --example capsules-on-a-plane
+  ```
+* Run (in batch mode):
+  ```shell
+  cargo run --release --example capsules-on-a-plane
+  ```
+
+## Strategy
+
+1. Bodies with `Cartesian<2>` positions and `Versor` orientations.
+2. Define a custom `SiteProperties` with `Cartesian<3>` position and `Versor` orientation.
+   Transform sites from the body frame to the simulation frame by lifting the body
+   position into 3D: `(body_x, body_y, 0)`.
+3. Define a custom `Boundary` type that wraps `Periodic<Rectangle>`.
+   Implement `Wrap<BodyProperties>`, `Volume`, `MapPoint`, `Scale`, and `Distribution`
+   for the custom boundary by calling the same method on the inner type.
+   Implement `Wrap<SiteProperties>` and `GenerateGhosts` by projecting
+   the 3D site position into 2D, calling the method on the wrapped type,
+   then lift the result back into 3D.
+
+See the example code for details. It implements all of these steps in a general fashion.
+You can copy and paste this code and use it for Monte Carlo simulations of any 3D
+interaction model (including multi-site rigid bodies) where the body centers should
+be confined to the _xy_ plane.
+
+## Complete Code
+```rust,ignore
+{{#rustdoc_include ../../../examples/mc-examples/capsules-on-a-plane.rs:all}}

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -4,11 +4,11 @@
 
 *Added:*
 
-* `[examples`]: Add "Melt an ideal hexagonal structure of hexagons" example (#393).
-* `[examples`]: Add "Multi-site patchy shapes" example (#395).
-* `[examples`]: Add "3D shapes confined to a 2D plane" example (#397).
-* `[examples`]: Use the mouse wheel to zoom examples with 3D cameras (#397).
-* `[examples`]: Click and drag to orbit the camera in examples with 3D cameras (#397).
+* `[examples]`: Add "Melt an ideal hexagonal structure of hexagons" example (#393).
+* `[examples]`: Add "Multi-site patchy shapes" example (#395).
+* `[examples]`: Add "3D shapes confined to a 2D plane" example (#397).
+* `[examples]`: Use the mouse wheel to zoom examples with 3D cameras (#397).
+* `[examples]`: Click and drag to orbit the camera in examples with 3D cameras (#397).
 * `[hoomd-geometry]`: Add `Hyperparallelepiped`, `Triclinic`, and `Rhomboid` shapes (#88).
 * `[hoomd-linear-algebra]` Add `matrix::qr` module with methods to compute the QR factorization of matrices (#88).
 * `[hoomd-linear-algebra]` Add methods `iter_column_slice`, `iter_column_slice_mut`, `iter_submatrix`, to `Matrix<N, M>` (#88).
@@ -39,8 +39,8 @@
 
 *Fixed:*
 
-* `[examples`]: Properly auto size egui parameter windows (#354).
-* `[examples`]: Reduce the zoom speed (#393).
+* `[examples]`: Properly auto size egui parameter windows (#354).
+* `[examples]`: Reduce the zoom speed (#393).
 * `[hoomd-interaction]`: Fix typos in documentation (#358).
 * `[hoomd-microstate]`: Fix typos in documentation (#358).
 

--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -4,13 +4,18 @@
 
 *Added:*
 
+* `[examples`]: Add "Melt an ideal hexagonal structure of hexagons" example (#393).
+* `[examples`]: Add "Multi-site patchy shapes" example (#395).
+* `[examples`]: Add "3D shapes confined to a 2D plane" example (#397).
+* `[examples`]: Use the mouse wheel to zoom examples with 3D cameras (#397).
+* `[examples`]: Click and drag to orbit the camera in examples with 3D cameras (#397).
 * `[hoomd-geometry]`: Add `Hyperparallelepiped`, `Triclinic`, and `Rhomboid` shapes (#88).
 * `[hoomd-linear-algebra]` Add `matrix::qr` module with methods to compute the QR factorization of matrices (#88).
 * `[hoomd-linear-algebra]` Add methods `iter_column_slice`, `iter_column_slice_mut`, `iter_submatrix`, to `Matrix<N, M>` (#88).
 * `[hoomd-macrostate]`: Add `Fugacity` trait that access the fugacity of a macrostate (#354).
 * `[hoomd-macrostate]`: Add `IsothermoalIsofugacity` type that stores the system's temperature and fugacity (#354).
 * `[hoomd-mc]`: Add `GrandCanonical` trial move type. It inserts and removes bodies and samples from the constant chemical potential, constant volume, constant temperature ensemble (#354).
-* `[hoomd-mc`]: Add `InsertReMoveCount` type that counts the accepted and rejected insertion and removal moves (#354).
+* `[hoomd-mc`]: Add `InsertRemoveCount` type that counts the accepted and rejected insertion and removal moves (#354).
 * `[hoomd-microstate`]: Implement all traits necessary to use `Hyperparallelepiped`, `Triclinic`, and `Rhomboid` as simulation boundaries (#88).
 * `[hoomd-microstate`]: Implement `AppendMicrostate` for microstates with `Triclinic` and `Rhomboid` boundaries (#88).
 * `[hoomd-microstate`]: Add `Microstate::iter_bodies_tag_order` method that iterates over all bodies in tag order (#393).
@@ -19,12 +24,14 @@
 * `[hoomd-vector`]: Implement `Mul<Cartesian<N>> for f64`, `Mul<PositiveReal> for Cartesian<N>`, `Mul<Cartesian<N>> for PositiveReal`, `MulAssign<f64> for Cartesian<N>`, and `MulAssign<PositiveReal> for Cartesian<N>` (#88).
 * `[hoomd-vector`]: Add `Cartesian::basis` method that constructs Cartesian basis vectors (#393).
 * `[hoomd-workspace`]: Add the `hoomd-workspace` crate. Use it to initialize and read state points in a signac workspace (#359).
-* *examples*: Add "Melt an ideal hexagonal structure of hexagons" example (#393).
-* *examples*: Add "Multi-site patchy shapes" example (#395).
 
 *Changed:*
 
 * Build the documentation with mdBook 0.5.4 and KaTeX 0.18.1 (#376).
+* `[hoomd-microstate]`: Relax trait bounds to allow bodie and site positions to
+  have different types (#397).
+* `[hoomd-mc]`: Relax trait bounds to allow bodie and site positions to
+  have different types (#397).
 
 *Deprecated:*
 
@@ -32,10 +39,10 @@
 
 *Fixed:*
 
+* `[examples`]: Properly auto size egui parameter windows (#354).
+* `[examples`]: Reduce the zoom speed (#393).
 * `[hoomd-interaction]`: Fix typos in documentation (#358).
 * `[hoomd-microstate]`: Fix typos in documentation (#358).
-* *examples*: Properly auto size egui parameter windows (#354).
-* *examples*: Reduce the zoom speed (#393).
 
 ## 1.2.0 (2026-07-07)
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -39,6 +39,7 @@ hoomd-spatial.workspace = true
 hoomd-utility.workspace = true
 hoomd-vector.workspace = true
 
+arrayvec.workspace = true
 anyhow.workspace = true
 bevy = { workspace = true, optional = true }
 bevy_egui = { workspace = true, optional = true }
@@ -168,4 +169,11 @@ name = "multi-site-patchy-shapes"
 path = "mc-examples/multi-site-patchy-shapes.rs"
 
 [package.metadata.example.multi-site-patchy-shapes]
+path = "mc-examples"
+
+[[example]]
+name = "capsules-on-a-plane"
+path = "mc-examples/capsules-on-a-plane.rs"
+
+[package.metadata.example.capsules-on-a-plane]
 path = "mc-examples"

--- a/examples/mc-examples/capsules-on-a-plane.rs
+++ b/examples/mc-examples/capsules-on-a-plane.rs
@@ -3,7 +3,8 @@ use anyhow::{Context, anyhow};
 use arrayvec::ArrayVec;
 
 use hoomd_geometry::{
-    Convex, IsPointInside, MapPoint, Scale, Volume, shape::{Capsule, Rectangle}
+    Convex, MapPoint, Scale, Volume,
+    shape::{Capsule, Rectangle},
 };
 use hoomd_interaction::{
     MaximumInteractionRange, PairwiseCutoff,
@@ -11,10 +12,13 @@ use hoomd_interaction::{
     univariate::OverlapPenalty,
 };
 use hoomd_mc::{
-    QuickCompress, QuickInsert, Rotate, Sweep, Translate, Trial, Tune, TuneOptions, UniformIn
+    QuickCompress, QuickInsert, Rotate, Sweep, Translate, Trial, Tune,
+    TuneOptions, UniformIn,
 };
 use hoomd_microstate::{
-    Microstate, SiteKey, Transform, boundary::{GenerateGhosts, MAX_GHOSTS, Periodic, Wrap}, property::{Orientation, OrientedPoint, Position}
+    Microstate, SiteKey, Transform,
+    boundary::{GenerateGhosts, MAX_GHOSTS, Periodic, Wrap},
+    property::{Orientation, OrientedPoint, Point, Position},
 };
 use hoomd_simulation::{Simulation, macrostate::Isothermal};
 use hoomd_spatial::VecCell;
@@ -34,32 +38,43 @@ struct Boundary(Periodic<Rectangle>);
 impl Transform<SiteProperties> for OrientedPoint<Cartesian<2>, Versor> {
     fn transform(&self, site_properties: &SiteProperties) -> SiteProperties {
         SiteProperties {
-            position: Cartesian::from([self.position[0] + site_properties.position[0],
+            position: Cartesian::from([
+                self.position[0] + site_properties.position[0],
                 self.position[1] + site_properties.position[1],
-                site_properties.position[2]]),
+                site_properties.position[2],
+            ]),
             orientation: self.orientation,
         }
     }
 }
 
 impl Wrap<SiteProperties> for Boundary {
-    fn wrap(&self, properties: SiteProperties) -> Result<SiteProperties, hoomd_microstate::boundary::Error> {
-        let mut properties = properties;
-        let r = properties.position_mut();
-
-        for (coordinate, edge_length) in r.coordinates.iter_mut().zip(self.0.shape().edge_lengths).take(2) {
-            let edge_length = edge_length.get();
-            let lambda = *coordinate / edge_length;
-            let lambda = lambda - lambda.round();
-            let lambda = if lambda == 0.5 { -0.5 } else { lambda };
-            *coordinate = lambda * edge_length;
-        }
-        Ok(properties)
+    fn wrap(
+        &self,
+        properties: SiteProperties,
+    ) -> Result<SiteProperties, hoomd_microstate::boundary::Error> {
+        let wrapped_projection = self.0.wrap(Point {
+            position: Cartesian::from([
+                properties.position[0],
+                properties.position[1],
+            ]),
+        })?;
+        Ok(SiteProperties {
+            position: Cartesian::from([
+                wrapped_projection.position[0],
+                wrapped_projection.position[1],
+                properties.position[2],
+            ]),
+            ..properties
+        })
     }
 }
 
 impl Wrap<BodyProperties> for Boundary {
-    fn wrap(&self, properties: BodyProperties) -> Result<BodyProperties, hoomd_microstate::boundary::Error> {
+    fn wrap(
+        &self,
+        properties: BodyProperties,
+    ) -> Result<BodyProperties, hoomd_microstate::boundary::Error> {
         self.0.wrap(properties)
     }
 }
@@ -69,56 +84,28 @@ impl GenerateGhosts<SiteProperties> for Boundary {
         self.0.maximum_interaction_range()
     }
 
-    fn generate_ghosts(&self, site_properties: &SiteProperties) -> ArrayVec<SiteProperties, MAX_GHOSTS> {
-        let mut result = ArrayVec::new();
-
-        let r = site_properties.position();
-        let projected_r = Cartesian::from([r[0], r[1]]);
-        let max = self.0.shape().maximal_extents();
-        let min = self.0.shape().minimal_extents();
-
-        if !self.0.shape().is_point_inside(&projected_r) {
-            return result;
-        }
-
-        let new_site = |x, y| {
-            let mut new_site = *site_properties;
-            new_site.position_mut()[0] += x * self.0.shape().edge_lengths[0].get();
-            new_site.position_mut()[1] += y * self.0.shape().edge_lengths[1].get();
-            new_site
+    fn generate_ghosts(
+        &self,
+        site_properties: &SiteProperties,
+    ) -> ArrayVec<SiteProperties, MAX_GHOSTS> {
+        let projected_site = Point {
+            position: Cartesian::from([
+                site_properties.position[0],
+                site_properties.position[1],
+            ]),
         };
-
-        let near_left = r[0] < min[0] + self.0.maximum_interaction_range();
-        let near_right = r[0] > max[0] - self.0.maximum_interaction_range();
-        let near_top = r[1] > max[1] - self.0.maximum_interaction_range();
-        let near_bottom = r[1] < min[1] + self.0.maximum_interaction_range();
-
-        if near_right {
-            result.push(new_site(-1.0, 0.0));
-        }
-        if near_left {
-            result.push(new_site(1.0, 0.0));
-        }
-        if near_top {
-            result.push(new_site(0.0, -1.0));
-        }
-        if near_bottom {
-            result.push(new_site(0.0, 1.0));
-        }
-        if near_right && near_top {
-            result.push(new_site(-1.0, -1.0));
-        }
-        if near_right && near_bottom {
-            result.push(new_site(-1.0, 1.0));
-        }
-        if near_left && near_top {
-            result.push(new_site(1.0, -1.0));
-        }
-        if near_left && near_bottom {
-            result.push(new_site(1.0, 1.0));
-        }
-
-        result
+        let projected_ghosts = self.0.generate_ghosts(&projected_site);
+        projected_ghosts
+            .iter()
+            .map(|s| SiteProperties {
+                position: Cartesian::from([
+                    s.position[0],
+                    s.position[1],
+                    site_properties.position[2],
+                ]),
+                ..*site_properties
+            })
+            .collect()
     }
 }
 
@@ -129,7 +116,11 @@ impl Volume for Boundary {
 }
 
 impl MapPoint<Cartesian<2>> for Boundary {
-    fn map_point(&self, point: Cartesian<2>, other: &Self) -> Result<Cartesian<2>, hoomd_geometry::Error> {
+    fn map_point(
+        &self,
+        point: Cartesian<2>,
+        other: &Self,
+    ) -> Result<Cartesian<2>, hoomd_geometry::Error> {
         self.0.map_point(point, &other.0)
     }
 }
@@ -153,23 +144,27 @@ impl Distribution<Cartesian<2>> for Boundary {
 impl Quasi2dCapsuleSelfAssembly {
     /// Construct a new hard tetrahedron self-assembly simulation.
     fn new() -> anyhow::Result<Quasi2dCapsuleSelfAssembly> {
-        let initial_number_density = 0.1;
-        let target_number_density = 0.2;
+        let initial_number_density = 0.12;
+        let target_number_density = 0.22;
         let n_bodies = 256;
         let maximum_distance = 0.04;
         let maximum_rotation = 0.04;
         let macrostate = Isothermal { temperature: 1.0 };
 
-        let capsule = Capsule { radius: 1.0.try_into()?, height: 5.0.try_into()?};
+        let capsule = Capsule {
+            radius: 1.0.try_into()?,
+            height: 5.0.try_into()?,
+        };
         let hamiltonian = PairwiseCutoff(HardShape(capsule.clone()));
 
-        let initial_box_volume =
-            n_bodies as f64 / initial_number_density;
+        let initial_box_volume = n_bodies as f64 / initial_number_density;
         let initial_box_edge_length = initial_box_volume.sqrt();
         let rectangle =
             Rectangle::with_equal_edges(initial_box_edge_length.try_into()?);
-        let periodic_rectangle =
-            Boundary(Periodic::new(hamiltonian.maximum_interaction_range(), rectangle)?);
+        let periodic_rectangle = Boundary(Periodic::new(
+            hamiltonian.maximum_interaction_range(),
+            rectangle,
+        )?);
 
         let vec_cell = VecCell::builder()
             .nominal_search_radius(
@@ -195,8 +190,7 @@ impl Quasi2dCapsuleSelfAssembly {
         };
         let quick_insert = QuickInsert::new(distribution, n_bodies);
 
-        let target_box_volume =
-            n_bodies as f64 / target_number_density;
+        let target_box_volume = n_bodies as f64 / target_number_density;
         let quick_compress =
             QuickCompress::with_target_volume(target_box_volume.try_into()?);
 

--- a/examples/mc-examples/capsules-on-a-plane.rs
+++ b/examples/mc-examples/capsules-on-a-plane.rs
@@ -23,7 +23,7 @@ use hoomd_microstate::{
 };
 use hoomd_simulation::{Simulation, macrostate::Isothermal};
 use hoomd_spatial::VecCell;
-use hoomd_vector::{self, Cartesian, Versor};
+use hoomd_vector::{self, Cartesian, Rotate as _, Rotation, Versor};
 
 type BodyProperties = OrientedPoint<Cartesian<2>, Versor>;
 
@@ -38,13 +38,13 @@ struct Boundary(Periodic<Rectangle>);
 
 impl Transform<SiteProperties> for OrientedPoint<Cartesian<2>, Versor> {
     fn transform(&self, site_properties: &SiteProperties) -> SiteProperties {
+        let lifted_body_position =
+            Cartesian::from([self.position[0], self.position[1], 0.0]);
+
         SiteProperties {
-            position: Cartesian::from([
-                self.position[0] + site_properties.position[0],
-                self.position[1] + site_properties.position[1],
-                site_properties.position[2],
-            ]),
-            orientation: self.orientation,
+            position: lifted_body_position
+                + self.orientation.rotate(&site_properties.position),
+            orientation: self.orientation.combine(&site_properties.orientation),
         }
     }
 }

--- a/examples/mc-examples/capsules-on-a-plane.rs
+++ b/examples/mc-examples/capsules-on-a-plane.rs
@@ -17,7 +17,9 @@ use hoomd_mc::{
     TuneOptions, UniformIn,
 };
 use hoomd_microstate::{
-    AppendMicrostate, Microstate, SiteKey, Transform, boundary::{GenerateGhosts, MAX_GHOSTS, Periodic, Wrap}, property::{Orientation, OrientedPoint, Point, Position}
+    AppendMicrostate, Microstate, SiteKey, Transform,
+    boundary::{GenerateGhosts, MAX_GHOSTS, Periodic, Wrap},
+    property::{Orientation, OrientedPoint, Point, Position},
 };
 use hoomd_simulation::{Simulation, macrostate::Isothermal};
 use hoomd_spatial::VecCell;
@@ -356,18 +358,20 @@ impl<X> AppendMicrostate<BodyProperties, SiteProperties, X, Boundary>
     #[inline]
     fn append_microstate(
         &mut self,
-        microstate: &Microstate<
-            BodyProperties,
-            SiteProperties,
-            X,
-            Boundary,
-        >,
+        microstate: &Microstate<BodyProperties, SiteProperties, X, Boundary>,
     ) -> Result<hoomd_gsd::hoomd::Frame<'_>, hoomd_gsd::hoomd::AppendError>
     {
-    let edge_lengths = microstate.boundary().0.shape().edge_lengths;
-    
+        let edge_lengths = microstate.boundary().0.shape().edge_lengths;
+
         self.append_frame(microstate.step())?
-            .configuration_box([edge_lengths[0].get(), edge_lengths[1].get(), 5.0, 0.0, 0.0, 0.0])?
+            .configuration_box([
+                edge_lengths[0].get(),
+                edge_lengths[1].get(),
+                5.0,
+                0.0,
+                0.0,
+                0.0,
+            ])?
             .configuration_dimensions(Dimensions::Three)?
             .particles_orientation(
                 microstate
@@ -389,8 +393,7 @@ fn main() -> anyhow::Result<()> {
     use hoomd_microstate::AppendMicrostate;
 
     let mut simulation = Quasi2dCapsuleSelfAssembly::new()?;
-    let mut hoomd_gsd_file =
-        HoomdGsdFile::create("capsules-on-a-plane.gsd")?;
+    let mut hoomd_gsd_file = HoomdGsdFile::create("capsules-on-a-plane.gsd")?;
 
     for _ in 0..40_000 {
         simulation.advance()?;

--- a/examples/mc-examples/capsules-on-a-plane.rs
+++ b/examples/mc-examples/capsules-on-a-plane.rs
@@ -6,6 +6,7 @@ use hoomd_geometry::{
     Convex, MapPoint, Scale, Volume,
     shape::{Capsule, Rectangle},
 };
+use hoomd_gsd::hoomd::{Dimensions, HoomdGsdFile};
 use hoomd_interaction::{
     MaximumInteractionRange, PairwiseCutoff,
     pairwise::{Anisotropic, ApproximateShapeOverlap, HardShape},
@@ -16,9 +17,7 @@ use hoomd_mc::{
     TuneOptions, UniformIn,
 };
 use hoomd_microstate::{
-    Microstate, SiteKey, Transform,
-    boundary::{GenerateGhosts, MAX_GHOSTS, Periodic, Wrap},
-    property::{Orientation, OrientedPoint, Point, Position},
+    AppendMicrostate, Microstate, SiteKey, Transform, boundary::{GenerateGhosts, MAX_GHOSTS, Periodic, Wrap}, property::{Orientation, OrientedPoint, Point, Position}
 };
 use hoomd_simulation::{Simulation, macrostate::Isothermal};
 use hoomd_spatial::VecCell;
@@ -351,6 +350,38 @@ impl Quasi2dCapsuleSelfAssembly {
     }
 }
 
+impl<X> AppendMicrostate<BodyProperties, SiteProperties, X, Boundary>
+    for HoomdGsdFile
+{
+    #[inline]
+    fn append_microstate(
+        &mut self,
+        microstate: &Microstate<
+            BodyProperties,
+            SiteProperties,
+            X,
+            Boundary,
+        >,
+    ) -> Result<hoomd_gsd::hoomd::Frame<'_>, hoomd_gsd::hoomd::AppendError>
+    {
+    let edge_lengths = microstate.boundary().0.shape().edge_lengths;
+    
+        self.append_frame(microstate.step())?
+            .configuration_box([edge_lengths[0].get(), edge_lengths[1].get(), 5.0, 0.0, 0.0, 0.0])?
+            .configuration_dimensions(Dimensions::Three)?
+            .particles_orientation(
+                microstate
+                    .iter_sites_tag_order()
+                    .map(|s| s.properties.orientation),
+            )?
+            .particles_position(
+                microstate
+                    .iter_sites_tag_order()
+                    .map(|s| s.properties.position),
+            )
+    }
+}
+
 // Remove the cfg(not(...)) line when using this code outside the hoomd-rs/examples directory.
 #[cfg(not(feature = "bevy"))]
 fn main() -> anyhow::Result<()> {
@@ -359,7 +390,7 @@ fn main() -> anyhow::Result<()> {
 
     let mut simulation = Quasi2dCapsuleSelfAssembly::new()?;
     let mut hoomd_gsd_file =
-        HoomdGsdFile::create("hard-tetrahedron-self-assembly.gsd")?;
+        HoomdGsdFile::create("capsules-on-a-plane.gsd")?;
 
     for _ in 0..40_000 {
         simulation.advance()?;

--- a/examples/mc-examples/capsules-on-a-plane.rs
+++ b/examples/mc-examples/capsules-on-a-plane.rs
@@ -1,0 +1,390 @@
+// ANCHOR: all
+use anyhow::{Context, anyhow};
+use arrayvec::ArrayVec;
+
+use hoomd_geometry::{
+    Convex, IsPointInside, MapPoint, Scale, Volume, shape::{Capsule, Rectangle}
+};
+use hoomd_interaction::{
+    MaximumInteractionRange, PairwiseCutoff,
+    pairwise::{Anisotropic, ApproximateShapeOverlap, HardShape},
+    univariate::OverlapPenalty,
+};
+use hoomd_mc::{
+    QuickCompress, QuickInsert, Rotate, Sweep, Translate, Trial, Tune, TuneOptions, UniformIn
+};
+use hoomd_microstate::{
+    Microstate, SiteKey, Transform, boundary::{GenerateGhosts, MAX_GHOSTS, Periodic, Wrap}, property::{Orientation, OrientedPoint, Position}
+};
+use hoomd_simulation::{Simulation, macrostate::Isothermal};
+use hoomd_spatial::VecCell;
+use hoomd_vector::{self, Cartesian, Versor};
+
+type BodyProperties = OrientedPoint<Cartesian<2>, Versor>;
+
+#[derive(Clone, Copy, Default, Position, Orientation)]
+struct SiteProperties {
+    position: Cartesian<3>,
+    orientation: Versor,
+}
+
+#[derive(Clone, PartialEq)]
+struct Boundary(Periodic<Rectangle>);
+
+impl Transform<SiteProperties> for OrientedPoint<Cartesian<2>, Versor> {
+    fn transform(&self, site_properties: &SiteProperties) -> SiteProperties {
+        SiteProperties {
+            position: Cartesian::from([self.position[0] + site_properties.position[0],
+                self.position[1] + site_properties.position[1],
+                site_properties.position[2]]),
+            orientation: self.orientation,
+        }
+    }
+}
+
+impl Wrap<SiteProperties> for Boundary {
+    fn wrap(&self, properties: SiteProperties) -> Result<SiteProperties, hoomd_microstate::boundary::Error> {
+        let mut properties = properties;
+        let r = properties.position_mut();
+
+        for (coordinate, edge_length) in r.coordinates.iter_mut().zip(self.0.shape().edge_lengths).take(2) {
+            let edge_length = edge_length.get();
+            let lambda = *coordinate / edge_length;
+            let lambda = lambda - lambda.round();
+            let lambda = if lambda == 0.5 { -0.5 } else { lambda };
+            *coordinate = lambda * edge_length;
+        }
+        Ok(properties)
+    }
+}
+
+impl Wrap<BodyProperties> for Boundary {
+    fn wrap(&self, properties: BodyProperties) -> Result<BodyProperties, hoomd_microstate::boundary::Error> {
+        self.0.wrap(properties)
+    }
+}
+
+impl GenerateGhosts<SiteProperties> for Boundary {
+    fn maximum_interaction_range(&self) -> f64 {
+        self.0.maximum_interaction_range()
+    }
+
+    fn generate_ghosts(&self, site_properties: &SiteProperties) -> ArrayVec<SiteProperties, MAX_GHOSTS> {
+        let mut result = ArrayVec::new();
+
+        let r = site_properties.position();
+        let projected_r = Cartesian::from([r[0], r[1]]);
+        let max = self.0.shape().maximal_extents();
+        let min = self.0.shape().minimal_extents();
+
+        if !self.0.shape().is_point_inside(&projected_r) {
+            return result;
+        }
+
+        let new_site = |x, y| {
+            let mut new_site = *site_properties;
+            new_site.position_mut()[0] += x * self.0.shape().edge_lengths[0].get();
+            new_site.position_mut()[1] += y * self.0.shape().edge_lengths[1].get();
+            new_site
+        };
+
+        let near_left = r[0] < min[0] + self.0.maximum_interaction_range();
+        let near_right = r[0] > max[0] - self.0.maximum_interaction_range();
+        let near_top = r[1] > max[1] - self.0.maximum_interaction_range();
+        let near_bottom = r[1] < min[1] + self.0.maximum_interaction_range();
+
+        if near_right {
+            result.push(new_site(-1.0, 0.0));
+        }
+        if near_left {
+            result.push(new_site(1.0, 0.0));
+        }
+        if near_top {
+            result.push(new_site(0.0, -1.0));
+        }
+        if near_bottom {
+            result.push(new_site(0.0, 1.0));
+        }
+        if near_right && near_top {
+            result.push(new_site(-1.0, -1.0));
+        }
+        if near_right && near_bottom {
+            result.push(new_site(-1.0, 1.0));
+        }
+        if near_left && near_top {
+            result.push(new_site(1.0, -1.0));
+        }
+        if near_left && near_bottom {
+            result.push(new_site(1.0, 1.0));
+        }
+
+        result
+    }
+}
+
+impl Volume for Boundary {
+    fn volume(&self) -> f64 {
+        self.0.volume()
+    }
+}
+
+impl MapPoint<Cartesian<2>> for Boundary {
+    fn map_point(&self, point: Cartesian<2>, other: &Self) -> Result<Cartesian<2>, hoomd_geometry::Error> {
+        self.0.map_point(point, &other.0)
+    }
+}
+
+impl Scale for Boundary {
+    fn scale_length(&self, v: hoomd_utility::valid::PositiveReal) -> Self {
+        Boundary(self.0.scale_length(v))
+    }
+
+    fn scale_volume(&self, v: hoomd_utility::valid::PositiveReal) -> Self {
+        Boundary(self.0.scale_volume(v))
+    }
+}
+
+impl Distribution<Cartesian<2>> for Boundary {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Cartesian<2> {
+        self.0.sample(rng)
+    }
+}
+
+impl Quasi2dCapsuleSelfAssembly {
+    /// Construct a new hard tetrahedron self-assembly simulation.
+    fn new() -> anyhow::Result<Quasi2dCapsuleSelfAssembly> {
+        let initial_number_density = 0.1;
+        let target_number_density = 0.2;
+        let n_bodies = 256;
+        let maximum_distance = 0.04;
+        let maximum_rotation = 0.04;
+        let macrostate = Isothermal { temperature: 1.0 };
+
+        let capsule = Capsule { radius: 1.0.try_into()?, height: 5.0.try_into()?};
+        let hamiltonian = PairwiseCutoff(HardShape(capsule.clone()));
+
+        let initial_box_volume =
+            n_bodies as f64 / initial_number_density;
+        let initial_box_edge_length = initial_box_volume.sqrt();
+        let rectangle =
+            Rectangle::with_equal_edges(initial_box_edge_length.try_into()?);
+        let periodic_rectangle =
+            Boundary(Periodic::new(hamiltonian.maximum_interaction_range(), rectangle)?);
+
+        let vec_cell = VecCell::builder()
+            .nominal_search_radius(
+                hamiltonian.maximum_interaction_range().try_into()?,
+            )
+            .build();
+        let microstate = Microstate::builder()
+            .boundary(periodic_rectangle)
+            .spatial_data(vec_cell)
+            .try_build()?;
+
+        let translate =
+            Translate::with_maximum_distance(maximum_distance.try_into()?);
+        let translate_sweep = Sweep(translate);
+
+        let rotate =
+            Rotate::with_maximum_rotation(maximum_rotation.try_into()?);
+        let rotate_sweep = Sweep(rotate);
+
+        let distribution = UniformIn {
+            boundary: microstate.boundary().clone(),
+            template_sites: vec![SiteProperties::default()],
+        };
+        let quick_insert = QuickInsert::new(distribution, n_bodies);
+
+        let target_box_volume =
+            n_bodies as f64 / target_number_density;
+        let quick_compress =
+            QuickCompress::with_target_volume(target_box_volume.try_into()?);
+
+        let approximate_shape_overlap = Anisotropic {
+            interaction: ApproximateShapeOverlap::new(
+                Convex(capsule),
+                OverlapPenalty::default(),
+                0.01.try_into()?,
+            ),
+            r_cut: hamiltonian.maximum_interaction_range(),
+        };
+
+        let overlap_penalty_hamiltonian =
+            PairwiseCutoff(approximate_shape_overlap);
+
+        Ok(Quasi2dCapsuleSelfAssembly {
+            microstate,
+            overlap_penalty_hamiltonian,
+            hamiltonian,
+            translate_sweep,
+            rotate_sweep,
+            quick_compress,
+            quick_insert,
+            macrostate,
+            phase: Phase::Initialize,
+        })
+    }
+}
+
+#[cfg_attr(feature = "bevy", derive(Resource))]
+struct Quasi2dCapsuleSelfAssembly {
+    /// Positions and orientations of all the bodies in the simulation.
+    microstate: Microstate<
+        BodyProperties,
+        SiteProperties,
+        VecCell<SiteKey, 3>,
+        Boundary,
+    >,
+    /// How sites interact with other sites and fields.
+    hamiltonian: PairwiseCutoff<HardShape<Capsule<3>>>,
+    /// Trial moves to apply.
+    translate_sweep: Sweep<Translate<Cartesian<2>>>,
+    /// Trial moves to apply.
+    rotate_sweep: Sweep<Rotate<Versor>>,
+    /// Temperature set point.
+    macrostate: Isothermal,
+    /// Quick compress algorithm.
+    quick_compress: QuickCompress<Boundary>,
+    /// Quick insert algorithm.
+    quick_insert: QuickInsert<UniformIn<SiteProperties, Boundary>>,
+    /// How sites interact when inserted and compressed.
+    overlap_penalty_hamiltonian: PairwiseCutoff<
+        Anisotropic<
+            ApproximateShapeOverlap<OverlapPenalty, Convex<Capsule<3>>>,
+        >,
+    >,
+    /// The current phase of the simulation.
+    phase: Phase,
+}
+
+enum Phase {
+    Initialize,
+    Equilibrate,
+}
+
+impl Simulation for Quasi2dCapsuleSelfAssembly {
+    /// Advance the simulation forward one step.
+    fn advance(&mut self) -> anyhow::Result<()> {
+        match self.phase {
+            Phase::Initialize => {
+                self.initialize().context("failed to initialize")?
+            }
+            Phase::Equilibrate => self.equilibrate(),
+        }
+
+        self.microstate.increment_step();
+
+        Ok(())
+    }
+
+    /// Get the current simulation step.
+    fn step(&self) -> u64 {
+        self.microstate.step()
+    }
+}
+
+impl Quasi2dCapsuleSelfAssembly {
+    fn initialize(&mut self) -> anyhow::Result<()> {
+        if self.quick_insert.is_complete() {
+            self.quick_compress.apply(
+                &mut self.microstate,
+                &self.overlap_penalty_hamiltonian,
+                |_| true,
+            );
+        } else {
+            self.quick_insert
+                .apply(&mut self.microstate, &self.overlap_penalty_hamiltonian);
+        }
+
+        self.translate_sweep.apply(
+            &mut self.microstate,
+            &self.overlap_penalty_hamiltonian,
+            &Isothermal { temperature: 1.0 },
+        );
+
+        self.rotate_sweep.apply(
+            &mut self.microstate,
+            &self.overlap_penalty_hamiltonian,
+            &Isothermal { temperature: 1.0 },
+        );
+
+        if self.quick_compress.is_complete() {
+            self.translate_sweep.tune_with_options(
+                &self.microstate,
+                &self.hamiltonian,
+                &self.macrostate,
+                &TuneOptions::default(),
+            );
+            self.rotate_sweep.tune_with_options(
+                &self.microstate,
+                &self.hamiltonian,
+                &self.macrostate,
+                &TuneOptions::default(),
+            );
+
+            self.phase = Phase::Equilibrate;
+            println!(
+                "Initialization complete at step {}.",
+                self.microstate.step()
+            );
+        }
+
+        if self.step() >= 20_000 {
+            let n = self.microstate.bodies().len();
+            let target_n = self.quick_insert.target();
+            let volume = self.microstate.boundary().0.volume();
+            let target_volume = self.quick_compress.target_volume();
+            return Err(anyhow!(
+                "inserted {n}/{target_n} bodies and compressed to {volume} / {target_volume}"
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn equilibrate(&mut self) {
+        self.translate_sweep.apply(
+            &mut self.microstate,
+            &self.hamiltonian,
+            &self.macrostate,
+        );
+
+        self.rotate_sweep.apply(
+            &mut self.microstate,
+            &self.hamiltonian,
+            &self.macrostate,
+        );
+    }
+}
+
+// Remove the cfg(not(...)) line when using this code outside the hoomd-rs/examples directory.
+#[cfg(not(feature = "bevy"))]
+fn main() -> anyhow::Result<()> {
+    use hoomd_gsd::hoomd::HoomdGsdFile;
+    use hoomd_microstate::AppendMicrostate;
+
+    let mut simulation = Quasi2dCapsuleSelfAssembly::new()?;
+    let mut hoomd_gsd_file =
+        HoomdGsdFile::create("hard-tetrahedron-self-assembly.gsd")?;
+
+    for _ in 0..40_000 {
+        simulation.advance()?;
+
+        if simulation.step().is_multiple_of(10_000) {
+            hoomd_gsd_file
+                .append_microstate(&simulation.microstate)?
+                .end()?;
+        }
+    }
+
+    Ok(())
+}
+// ANCHOR_END: all
+
+#[cfg(feature = "bevy")]
+mod capsules_on_a_plane_interactive;
+#[cfg(feature = "bevy")]
+use bevy::prelude::Resource;
+#[cfg(feature = "bevy")]
+use capsules_on_a_plane_interactive::main;
+use rand::{Rng, distr::Distribution};

--- a/examples/mc-examples/capsules_on_a_plane_interactive.rs
+++ b/examples/mc-examples/capsules_on_a_plane_interactive.rs
@@ -39,20 +39,15 @@ pub(crate) fn main() -> anyhow::Result<()> {
         half_length: 2.5,
     };
     let capsule_material = StandardMaterial {
-                    base_color: PRIMARY_COLOR_3D,
-                    perceptual_roughness: 0.2,
-                    ..default()
-                };
+        base_color: PRIMARY_COLOR_3D,
+        perceptual_roughness: 0.2,
+        ..default()
+    };
 
     app.add_systems(
         Startup,
-        (move || {
-            (
-                capsule.mesh().build(),
-                capsule_material.clone(),
-            )
-        })
-        .pipe(surface_mesh::SurfaceMesh::<A>::setup),
+        (move || (capsule.mesh().build(), capsule_material.clone()))
+            .pipe(surface_mesh::SurfaceMesh::<A>::setup),
     );
 
     app.add_systems(
@@ -86,16 +81,19 @@ fn sync_sites(
         sites.iter().map(|site| {
             let orientation = site.properties.orientation;
             let rotation = Versor::from_axis_angle(
-                [1.0, 0.0, 0.0].try_into().expect("hard-coded vector should be non-zero length"),
-                PI/2.0);
+                [1.0, 0.0, 0.0]
+                    .try_into()
+                    .expect("hard-coded vector should be non-zero length"),
+                PI / 2.0,
+            );
             let orientation = orientation.combine(&rotation);
-        
+
             (
                 Vec3::new(
                     site.properties.position[0] as f32,
                     site.properties.position[1] as f32,
                     site.properties.position[2] as f32,
-                ),                                
+                ),
                 Quat::from_xyzw(
                     orientation.get().vector[0] as f32,
                     orientation.get().vector[1] as f32,

--- a/examples/mc-examples/capsules_on_a_plane_interactive.rs
+++ b/examples/mc-examples/capsules_on_a_plane_interactive.rs
@@ -1,0 +1,108 @@
+use std::f64::consts::PI;
+
+use hoomd_bevy::{
+    AdvanceSet, HoomdBevyPlugin, InitialCamera, PRIMARY_COLOR_3D, Settings,
+    representation::surface_mesh,
+};
+
+use anyhow::Context;
+use bevy::prelude::*;
+use bevy_egui::EguiPlugin;
+use hoomd_vector::{Rotate, Rotation, Versor};
+
+use super::Quasi2dCapsuleSelfAssembly;
+
+/// Mark the tetrahedron representation type.
+struct A;
+
+pub(crate) fn main() -> anyhow::Result<()> {
+    let simulation = Quasi2dCapsuleSelfAssembly::new()
+        .context("failed to setup simulation")?;
+
+    let l =
+        simulation.microstate.boundary().0.shape().edge_lengths[1].get() as f32;
+    let hoomd_bevy_plugin = HoomdBevyPlugin {
+        initial_settings: Settings {
+            camera: InitialCamera::Orthographic3d(l + 1.0),
+            ..default()
+        },
+        simulation,
+    };
+
+    let mut app = App::new();
+    hoomd_bevy::add_default_plugins(&mut app);
+    app.add_plugins(EguiPlugin::default());
+    hoomd_bevy_plugin.build(&mut app);
+
+    let capsule = Capsule3d {
+        radius: 1.0,
+        half_length: 2.5,
+    };
+    let capsule_material = StandardMaterial {
+                    base_color: PRIMARY_COLOR_3D,
+                    perceptual_roughness: 0.2,
+                    ..default()
+                };
+
+    app.add_systems(
+        Startup,
+        (move || {
+            (
+                capsule.mesh().build(),
+                capsule_material.clone(),
+            )
+        })
+        .pipe(surface_mesh::SurfaceMesh::<A>::setup),
+    );
+
+    app.add_systems(
+        Update,
+        (sync_sites,)
+            .run_if(resource_changed::<Quasi2dCapsuleSelfAssembly>)
+            .after(AdvanceSet),
+    );
+
+    app.run();
+
+    Ok(())
+}
+
+/// Copy the current positions of simulation sites to bevy entities.
+fn sync_sites(
+    mut commands: Commands,
+    site_representation: Res<surface_mesh::Representation<A>>,
+    site_query: Query<
+        (Entity, &mut Transform),
+        With<surface_mesh::SurfaceMesh<A>>,
+    >,
+    simulation: Res<Quasi2dCapsuleSelfAssembly>,
+) {
+    let sites = simulation.microstate.sites();
+
+    surface_mesh::SurfaceMesh::sync(
+        &mut commands,
+        site_representation,
+        site_query,
+        sites.iter().map(|site| {
+            let orientation = site.properties.orientation;
+            let rotation = Versor::from_axis_angle(
+                [1.0, 0.0, 0.0].try_into().expect("hard-coded vector should be non-zero length"),
+                PI/2.0);
+            let orientation = orientation.combine(&rotation);
+        
+            (
+                Vec3::new(
+                    site.properties.position[0] as f32,
+                    site.properties.position[1] as f32,
+                    site.properties.position[2] as f32,
+                ),                                
+                Quat::from_xyzw(
+                    orientation.get().vector[0] as f32,
+                    orientation.get().vector[1] as f32,
+                    orientation.get().vector[2] as f32,
+                    orientation.get().scalar as f32,
+                ),
+            )
+        }),
+    );
+}

--- a/examples/mc-examples/capsules_on_a_plane_interactive.rs
+++ b/examples/mc-examples/capsules_on_a_plane_interactive.rs
@@ -8,7 +8,7 @@ use hoomd_bevy::{
 use anyhow::Context;
 use bevy::prelude::*;
 use bevy_egui::EguiPlugin;
-use hoomd_vector::{Rotate, Rotation, Versor};
+use hoomd_vector::{Rotation, Versor};
 
 use super::Quasi2dCapsuleSelfAssembly;
 

--- a/examples/mc-tutorial/hard_tetrahedron_self_assembly_interactive.rs
+++ b/examples/mc-tutorial/hard_tetrahedron_self_assembly_interactive.rs
@@ -56,7 +56,11 @@ pub(crate) fn main() -> anyhow::Result<()> {
             ),
         ],
     };
-    let tetrahedron_material = StandardMaterial::from(PRIMARY_COLOR_3D);
+    let tetrahedron_material = StandardMaterial {
+                    base_color: PRIMARY_COLOR_3D,
+                    perceptual_roughness: 0.2,
+                    ..default()
+                };
 
     app.add_systems(
         Startup,

--- a/examples/mc-tutorial/hard_tetrahedron_self_assembly_interactive.rs
+++ b/examples/mc-tutorial/hard_tetrahedron_self_assembly_interactive.rs
@@ -57,10 +57,10 @@ pub(crate) fn main() -> anyhow::Result<()> {
         ],
     };
     let tetrahedron_material = StandardMaterial {
-                    base_color: PRIMARY_COLOR_3D,
-                    perceptual_roughness: 0.2,
-                    ..default()
-                };
+        base_color: PRIMARY_COLOR_3D,
+        perceptual_roughness: 0.2,
+        ..default()
+    };
 
     app.add_systems(
         Startup,

--- a/hoomd-bevy/src/lib.rs
+++ b/hoomd-bevy/src/lib.rs
@@ -205,7 +205,8 @@ pub enum InitialCamera {
     /// automatically based on the window dimensions.
     ///
     /// Controls:
-    /// * TODO
+    /// * Left click and drag to rotate.
+    /// * Scroll to zoom.
     Orthographic3d(f32),
 }
 
@@ -249,6 +250,22 @@ struct FrameBudget(Duration);
 pub struct CameraControl2d {
     /// Coordinates clicked in the world frame.
     world_position: Vec2,
+
+    /// Track whether the user is dragging the view.
+    dragging: bool,
+}
+
+/// Settings used by the 3d camera controls.
+#[derive(Debug, Default, Resource)]
+pub struct CameraControl3d {
+    /// Coordinates clicked in the window.
+    initial_click_position: Vec2,
+
+    /// Initial camera transform when clicked
+    initial_camera_transform: Transform,
+
+    /// Initial light transform when clicked
+    initial_light_transform: Transform,
 
     /// Track whether the user is dragging the view.
     dragging: bool,
@@ -575,10 +592,6 @@ where
     }
 
     /// Left click and drag to pan the 2D camera.
-    ///
-    /// # Panics
-    ///
-    /// Panics when the 2D camera viewport is invalid.
     fn camera_mouse_pan_control_2d(
         camera: Single<
             (&Camera, &GlobalTransform, &mut Transform, &mut Projection),
@@ -679,6 +692,93 @@ where
         }
     }
 
+    /// Zoom the 3d camera using the mouse wheel or trackpad scroll gesture.
+    fn camera_mouse_zoom_control_3d(
+        time: Res<Time>,
+        camera: Single<&mut Projection, With<Camera3d>>,
+        settings: Res<Settings>,
+        mut scroll: MessageReader<MouseWheel>,
+    ) {
+        let projection = camera.into_inner();
+
+        if let Projection::Orthographic(ref mut orthographic) = *projection.into_inner() {
+            let scroll = scroll.read().map(|e| e.y).fold(0.0, |total, y| total + y);
+
+            // The scroll events distinguish between line (mouse wheel) and pixel
+            // (trackpad) events. However, In wasm builds all major browsers report
+            // only pixel events. Tested on macOS, scrolling with the trackpad gave
+            // consistent values across all browsers and native. However, scrolling
+            // with the mouse wheel gave different scales between native and browser
+            // and from browser to browser (a factor of 100 from the smallest to
+            // the largest). Therefore, the best we can do is check the sign of the
+            // scroll event and act scale the camera in the appropriate direction.
+            let zoom_speed = settings.camera_sensitivity * CAMERA_ZOOM_SPEED * time.delta_secs();
+            let delta_zoom = -zoom_speed.copysign(scroll);
+            let new_scale = (orthographic.scale * (1.0 + delta_zoom)).clamp(
+                1.0 / settings.zoom_range.end,
+                1.0 / settings.zoom_range.start,
+            );
+
+            orthographic.scale = new_scale;
+        }
+    }
+
+    /// Left click and drag to pan the 3D camera.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the 3D camera viewport is invalid.
+    fn camera_mouse_rotate_control_3d(
+        camera: Single<&mut Transform, (With<Camera3d>, Without<DirectionalLight>)>,
+        directional_light: Single<&mut Transform, (With<DirectionalLight>, Without<Camera3d>)>,
+        mut control: ResMut<CameraControl3d>,
+        buttons: Res<ButtonInput<MouseButton>>,
+        window: Single<&Window, With<PrimaryWindow>>,
+        settings: Res<Settings>,
+    ) {
+        // Firefox wasm builds do not behave well using AccumulatedMouseMotion. Use
+        // absolute window coordinates and a state machine to provide consistent
+        // panning behavior across all platforms.
+
+        let mut camera_transform = camera.into_inner();
+        let mut light_transform = directional_light.into_inner();
+
+        if buttons.just_pressed(MouseButton::Left)
+            && let Some(initial_click_position) = window.cursor_position()
+        {
+            control.initial_click_position = initial_click_position;
+            control.initial_camera_transform = *camera_transform;
+            control.initial_light_transform = *light_transform;
+            control.dragging = true;
+            return;
+        }
+
+        if !buttons.pressed(MouseButton::Left) {
+            control.dragging = false;
+            return;
+        }
+
+        if control.dragging
+            && let Some(current_cursor_position) = window.cursor_position()
+        {
+            let offset = current_cursor_position - control.initial_click_position;
+            let q_y = Quat::from_axis_angle(
+                control.initial_camera_transform.local_y().into(),
+                -offset.x / 100.0 * settings.camera_sensitivity,
+            );
+            let q_x = Quat::from_axis_angle(
+                control.initial_camera_transform.local_x().into(),
+                -offset.y / 100.0 * settings.camera_sensitivity,
+            );
+            camera_transform.translation = q_x * q_y * control.initial_camera_transform.translation;
+
+            let up = camera_transform.local_y();
+            camera_transform.look_at(Vec3::default(), up);
+
+            light_transform.translation = q_x * q_y * control.initial_light_transform.translation;
+            light_transform.look_at(Vec3::default(), up);
+        }
+    }
     /// Build the plugin.
     ///
     /// [`HoomdBevyPlugin`] does not implement [`Plugin`] and cannot be used with
@@ -760,6 +860,22 @@ where
                 app.add_systems(Startup, move |commands: Commands| {
                     Self::setup_camera_3d(commands, initial_viewport_height);
                 })
+                .insert_resource(CameraControl3d::default())
+                .add_systems(
+                    Update,
+                    Self::camera_mouse_rotate_control_3d
+                        .run_if(
+                            input_pressed(MouseButton::Left)
+                                .or_else(input_just_released(MouseButton::Left)),
+                        )
+                        .in_set(MouseInputSet),
+                )
+                .add_systems(
+                    Update,
+                    Self::camera_mouse_zoom_control_3d
+                        .run_if(on_message::<MouseWheel>)
+                        .in_set(MouseInputSet),
+                )
                 .add_systems(Startup, Self::setup_ambient_light);
             }
         }
@@ -862,8 +978,8 @@ where
                         ui.label("Scroll to zoom.");
                     }
                     InitialCamera::Orthographic3d(_) => {
-                        ui.label("TODO.");
-                        ui.label("TODO.");
+                        ui.label("Click and drag to rotate the camera.");
+                        ui.label("Scroll to zoom.");
                     }
                 }
 

--- a/hoomd-bevy/src/lib.rs
+++ b/hoomd-bevy/src/lib.rs
@@ -259,13 +259,13 @@ pub struct CameraControl2d {
 #[derive(Debug, Default, Resource)]
 pub struct CameraControl3d {
     /// Coordinates clicked in the window.
-    initial_click_position: Vec2,
+    last_click_position: Vec2,
 
     /// Initial camera transform when clicked
-    initial_camera_transform: Transform,
+    last_camera_transform: Transform,
 
     /// Initial light transform when clicked
-    initial_light_transform: Transform,
+    last_light_transform: Transform,
 
     /// Track whether the user is dragging the view.
     dragging: bool,
@@ -746,9 +746,9 @@ where
         if buttons.just_pressed(MouseButton::Left)
             && let Some(initial_click_position) = window.cursor_position()
         {
-            control.initial_click_position = initial_click_position;
-            control.initial_camera_transform = *camera_transform;
-            control.initial_light_transform = *light_transform;
+            control.last_click_position = initial_click_position;
+            control.last_camera_transform = *camera_transform;
+            control.last_light_transform = *light_transform;
             control.dragging = true;
             return;
         }
@@ -761,22 +761,26 @@ where
         if control.dragging
             && let Some(current_cursor_position) = window.cursor_position()
         {
-            let offset = current_cursor_position - control.initial_click_position;
+            let offset = current_cursor_position - control.last_click_position;
             let q_y = Quat::from_axis_angle(
-                control.initial_camera_transform.local_y().into(),
+                control.last_camera_transform.local_y().into(),
                 -offset.x / 100.0 * settings.camera_sensitivity,
             );
             let q_x = Quat::from_axis_angle(
-                control.initial_camera_transform.local_x().into(),
+                control.last_camera_transform.local_x().into(),
                 -offset.y / 100.0 * settings.camera_sensitivity,
             );
-            camera_transform.translation = q_x * q_y * control.initial_camera_transform.translation;
+            camera_transform.translation = q_x * q_y * control.last_camera_transform.translation;
 
             let up = camera_transform.local_y();
             camera_transform.look_at(Vec3::default(), up);
 
-            light_transform.translation = q_x * q_y * control.initial_light_transform.translation;
+            light_transform.translation = q_x * q_y * control.last_light_transform.translation;
             light_transform.look_at(Vec3::default(), up);
+
+            control.last_click_position = current_cursor_position;
+            control.last_camera_transform = *camera_transform;
+            control.last_light_transform = *light_transform;
         }
     }
     /// Build the plugin.

--- a/hoomd-mc/src/grand_canonical.rs
+++ b/hoomd-mc/src/grand_canonical.rs
@@ -61,13 +61,14 @@ pub struct InsertRemoveCount {
     pub remove_rejected: u64,
 }
 
-impl<D, P, B, S, X, C, H, MA> Trial<Microstate<B, S, X, C>, H, MA> for GrandCanonical<D>
+impl<D, P1, P2, B, S, X, C, H, MA> Trial<Microstate<B, S, X, C>, H, MA> for GrandCanonical<D>
 where
     D: BodyDistribution<Body<B, S>>,
-    P: Copy,
-    B: Copy + Default + Transform<S> + Position<Position = P>,
-    S: Copy + Default + Position<Position = P>,
-    X: PointUpdate<P, SiteKey>,
+    P1: Copy,
+    P2: Copy,
+    B: Copy + Default + Transform<S> + Position<Position = P1>,
+    S: Copy + Default + Position<Position = P2>,
+    X: PointUpdate<P2, SiteKey>,
     H: DeltaEnergyInsert<B, S, X, C> + DeltaEnergyRemove<B, S, X, C>,
     C: Wrap<B> + Wrap<S> + GenerateGhosts<S> + Volume,
     MA: Temperature + Fugacity,

--- a/hoomd-mc/src/parallel_sweep.rs
+++ b/hoomd-mc/src/parallel_sweep.rs
@@ -206,7 +206,7 @@ impl<L, K, B, S> ParallelSweep<L, K, B, S> {
         reason = "many arguments must be passed to avoid too many lines of code in other methods"
     )]
     #[inline(always)]
-    fn generate_trial_moves<P, X, C, H>(
+    fn generate_trial_moves<P1, P2, X, C, H>(
         local_trial: &L,
         body_trials: &mut Vec<BodyTrial<B, S>>,
         microstate: &Microstate<B, S, X, C>,
@@ -216,13 +216,14 @@ impl<L, K, B, S> ParallelSweep<L, K, B, S> {
         spaces: &[Vec<usize>],
         space_indices: &Vec<usize>,
     ) where
-        P: Copy,
-        B: Copy + Default + Transform<S> + Position<Position = P> + Send + Sync,
-        S: Copy + Default + Position<Position = P> + Send + Sync,
+        P1: Copy,
+        P2: Copy,
+        B: Copy + Default + Transform<S> + Position<Position = P1> + Send + Sync,
+        S: Copy + Default + Position<Position = P2> + Send + Sync,
         L: LocalTrial<B> + Sync,
         H: DeltaEnergyOne<B, S, X, C> + Sync,
         C: Wrap<B> + Wrap<S> + GenerateGhosts<S> + Sync,
-        K: Checkerboard<P> + Sync,
+        K: Checkerboard<P1> + Sync,
         X: Sync,
     {
         body_trials.resize_with(space_indices.len(), Default::default);
@@ -277,15 +278,16 @@ impl<L, K, B, S> ParallelSweep<L, K, B, S> {
 
     /// Update the properties of bodies with accepted moves.
     #[inline(always)]
-    fn update_bodies<P, X, C>(
+    fn update_bodies<P1, P2, X, C>(
         microstate: &mut Microstate<B, S, X, C>,
         body_trials: &Vec<BodyTrial<B, S>>,
     ) -> Count
     where
-        P: Copy,
-        B: Copy + Default + Transform<S> + Position<Position = P>,
-        S: Copy + Default + Position<Position = P>,
-        X: PointUpdate<P, SiteKey>,
+        P1: Copy,
+        P2: Copy,
+        B: Copy + Default + Transform<S> + Position<Position = P1>,
+        S: Copy + Default + Position<Position = P2>,
+        X: PointUpdate<P2, SiteKey>,
         C: Wrap<B> + Wrap<S> + GenerateGhosts<S>,
     {
         let mut count = Count::default();
@@ -310,17 +312,18 @@ impl<L, K, B, S> ParallelSweep<L, K, B, S> {
     }
 }
 
-impl<P, B, S, X, C, L, H, MA, K> Trial<Microstate<B, S, X, C>, H, MA> for ParallelSweep<L, K, B, S>
+impl<P1, P2, B, S, X, C, L, H, MA, K> Trial<Microstate<B, S, X, C>, H, MA> for ParallelSweep<L, K, B, S>
 where
-    P: Copy,
-    B: Copy + Default + Transform<S> + Position<Position = P> + Send + Sync,
-    S: Copy + Default + Position<Position = P> + Send + Sync,
-    X: PointUpdate<P, SiteKey> + Sync,
+    P1: Copy,
+    P2: Copy,
+    B: Copy + Default + Transform<S> + Position<Position = P1> + Send + Sync,
+    S: Copy + Default + Position<Position = P2> + Send + Sync,
+    X: PointUpdate<P2, SiteKey> + Sync,
     L: LocalTrial<B> + Sync,
     H: DeltaEnergyOne<B, S, X, C> + Sync,
-    C: Wrap<B> + Wrap<S> + GenerateGhosts<S> + Cover<P, Checkerboard = K> + Sync,
+    C: Wrap<B> + Wrap<S> + GenerateGhosts<S> + Cover<P1, Checkerboard = K> + Sync,
     MA: Temperature,
-    K: Checkerboard<P> + Sync,
+    K: Checkerboard<P1> + Sync,
 {
     type Count = Count;
 
@@ -415,12 +418,13 @@ where
     }
 }
 
-impl<P, B, S, X, C, L, H, MA, K> Tune<P, B, S, X, C, L, H, MA> for ParallelSweep<L, K, B, S>
+impl<P1, P2, B, S, X, C, L, H, MA, K> Tune<P1, B, S, X, C, L, H, MA> for ParallelSweep<L, K, B, S>
 where
-    P: Copy,
-    B: Copy + Default + Transform<S> + Position<Position = P>,
-    S: Copy + Default + Position<Position = P>,
-    X: PointUpdate<P, SiteKey>,
+    P1: Copy,
+    P2: Copy,
+    B: Copy + Default + Transform<S> + Position<Position = P1>,
+    S: Copy + Default + Position<Position = P2>,
+    X: PointUpdate<P2, SiteKey>,
     L: LocalTrial<B> + Adjust + Display,
     H: DeltaEnergyOne<B, S, X, C>,
     C: Wrap<B> + Wrap<S> + GenerateGhosts<S>,

--- a/hoomd-mc/src/parallel_sweep.rs
+++ b/hoomd-mc/src/parallel_sweep.rs
@@ -312,7 +312,8 @@ impl<L, K, B, S> ParallelSweep<L, K, B, S> {
     }
 }
 
-impl<P1, P2, B, S, X, C, L, H, MA, K> Trial<Microstate<B, S, X, C>, H, MA> for ParallelSweep<L, K, B, S>
+impl<P1, P2, B, S, X, C, L, H, MA, K> Trial<Microstate<B, S, X, C>, H, MA>
+    for ParallelSweep<L, K, B, S>
 where
     P1: Copy,
     P2: Copy,

--- a/hoomd-mc/src/quick_compress.rs
+++ b/hoomd-mc/src/quick_compress.rs
@@ -441,18 +441,19 @@ impl<C> QuickCompress<C> {
         reason = "Panic would occur due to a bug in hoomd-rs."
     )]
     #[inline]
-    pub fn apply<P, B, S, X, H, F>(
+    pub fn apply<P1, P2, B, S, X, H, F>(
         &mut self,
         microstate: &mut Microstate<B, S, X, C>,
         hamiltonian: &H,
         should_map_body: F,
     ) where
-        P: Copy,
-        B: Clone + Position<Position = P> + Transform<S>,
-        S: Clone + Position<Position = P> + Default,
-        X: Clone + PointUpdate<P, SiteKey>,
+        P1: Copy,
+        P2: Copy,
+        B: Clone + Position<Position = P1> + Transform<S>,
+        S: Clone + Position<Position = P2> + Default,
+        X: Clone + PointUpdate<P2, SiteKey>,
         H: TotalEnergy<Microstate<B, S, X, C>>,
-        C: Clone + MapPoint<P> + Wrap<B> + Wrap<S> + GenerateGhosts<S> + Volume + Scale + PartialEq,
+        C: Clone + MapPoint<P1> + Wrap<B> + Wrap<S> + GenerateGhosts<S> + Volume + Scale + PartialEq,
         Microstate<B, S, X, C>: Clone,
         F: Fn(&Tagged<Body<B, S>>) -> bool,
     {

--- a/hoomd-mc/src/quick_compress.rs
+++ b/hoomd-mc/src/quick_compress.rs
@@ -453,7 +453,14 @@ impl<C> QuickCompress<C> {
         S: Clone + Position<Position = P2> + Default,
         X: Clone + PointUpdate<P2, SiteKey>,
         H: TotalEnergy<Microstate<B, S, X, C>>,
-        C: Clone + MapPoint<P1> + Wrap<B> + Wrap<S> + GenerateGhosts<S> + Volume + Scale + PartialEq,
+        C: Clone
+            + MapPoint<P1>
+            + Wrap<B>
+            + Wrap<S>
+            + GenerateGhosts<S>
+            + Volume
+            + Scale
+            + PartialEq,
         Microstate<B, S, X, C>: Clone,
         F: Fn(&Tagged<Body<B, S>>) -> bool,
     {

--- a/hoomd-mc/src/quick_insert.rs
+++ b/hoomd-mc/src/quick_insert.rs
@@ -267,16 +267,17 @@ impl<D> QuickInsert<D> {
     /// # }
     /// ```
     #[inline]
-    pub fn apply<P, B, S, X, C, H>(
+    pub fn apply<P1, P2, B, S, X, C, H>(
         &mut self,
         microstate: &mut Microstate<B, S, X, C>,
         hamiltonian: &H,
     ) -> Count
     where
-        P: Copy,
-        B: Position<Position = P> + Transform<S>,
-        S: Position<Position = P> + Default,
-        X: PointUpdate<P, SiteKey>,
+        P1: Copy,
+        P2: Copy,
+        B: Position<Position = P1> + Transform<S>,
+        S: Position<Position = P2> + Default,
+        X: PointUpdate<P2, SiteKey>,
         D: BodyDistribution<Body<B, S>>,
         H: DeltaEnergyInsert<B, S, X, C> + TotalEnergy<Microstate<B, S, X, C>>,
         C: Wrap<B> + Wrap<S> + GenerateGhosts<S>,

--- a/hoomd-mc/src/sweep.rs
+++ b/hoomd-mc/src/sweep.rs
@@ -42,12 +42,13 @@ use super::{Adjust, Count, LocalTrial, Trial, Tune, TuneOptions, tune_local::tun
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Sweep<L>(pub L);
 
-impl<P, B, S, X, C, L, H, MA> Trial<Microstate<B, S, X, C>, H, MA> for Sweep<L>
+impl<P1, P2, B, S, X, C, L, H, MA> Trial<Microstate<B, S, X, C>, H, MA> for Sweep<L>
 where
-    P: Copy,
-    B: Copy + Default + Transform<S> + Position<Position = P>,
-    S: Copy + Default + Position<Position = P>,
-    X: PointUpdate<P, SiteKey>,
+    P1: Copy,
+    P2: Copy,
+    B: Copy + Default + Transform<S> + Position<Position = P1>,
+    S: Copy + Default + Position<Position = P2>,
+    X: PointUpdate<P2, SiteKey>,
     L: LocalTrial<B>,
     H: DeltaEnergyOne<B, S, X, C>,
     C: Wrap<B> + Wrap<S> + GenerateGhosts<S>,
@@ -155,7 +156,7 @@ impl<L> Sweep<L> {
     /// # }
     /// ```
     #[inline]
-    pub fn apply_with_filter<P, B, S, X, C, H, MA, F>(
+    pub fn apply_with_filter<P1, P2, B, S, X, C, H, MA, F>(
         &self,
         microstate: &mut Microstate<B, S, X, C>,
         hamiltonian: &H,
@@ -163,10 +164,11 @@ impl<L> Sweep<L> {
         should_move_body: F,
     ) -> Count
     where
-        P: Copy,
-        B: Copy + Default + Transform<S> + Position<Position = P>,
-        S: Copy + Default + Position<Position = P>,
-        X: PointUpdate<P, SiteKey>,
+        P1: Copy,
+        P2: Copy,
+        B: Copy + Default + Transform<S> + Position<Position = P1>,
+        S: Copy + Default + Position<Position = P2>,
+        X: PointUpdate<P2, SiteKey>,
         L: LocalTrial<B>,
         H: DeltaEnergyOne<B, S, X, C>,
         C: Wrap<B> + Wrap<S> + GenerateGhosts<S>,
@@ -268,7 +270,7 @@ impl<L> Sweep<L> {
     /// # }
     /// ```
     #[inline]
-    pub fn tune_with_options_and_filter<P, B, S, X, C, H, MA, F>(
+    pub fn tune_with_options_and_filter<P1, P2, B, S, X, C, H, MA, F>(
         &mut self,
         microstate: &Microstate<B, S, X, C>,
         hamiltonian: &H,
@@ -276,10 +278,11 @@ impl<L> Sweep<L> {
         options: &TuneOptions,
         should_move_body: F,
     ) where
-        P: Copy,
-        B: Copy + Default + Transform<S> + Position<Position = P>,
-        S: Copy + Default + Position<Position = P>,
-        X: PointUpdate<P, SiteKey>,
+        P1: Copy,
+        P2: Copy,
+        B: Copy + Default + Transform<S> + Position<Position = P1>,
+        S: Copy + Default + Position<Position = P2>,
+        X: PointUpdate<P2, SiteKey>,
         L: LocalTrial<B> + Adjust + Display,
         H: DeltaEnergyOne<B, S, X, C>,
         C: Wrap<B> + Wrap<S> + GenerateGhosts<S>,
@@ -297,12 +300,13 @@ impl<L> Sweep<L> {
     }
 }
 
-impl<P, B, S, X, C, L, H, MA> Tune<P, B, S, X, C, L, H, MA> for Sweep<L>
+impl<P1, P2, B, S, X, C, L, H, MA> Tune<P1, B, S, X, C, L, H, MA> for Sweep<L>
 where
-    P: Copy,
-    B: Copy + Default + Transform<S> + Position<Position = P>,
-    S: Copy + Default + Position<Position = P>,
-    X: PointUpdate<P, SiteKey>,
+    P1: Copy,
+    P2: Copy,
+    B: Copy + Default + Transform<S> + Position<Position = P1>,
+    S: Copy + Default + Position<Position = P2>,
+    X: PointUpdate<P2, SiteKey>,
     L: LocalTrial<B> + Adjust + Display,
     H: DeltaEnergyOne<B, S, X, C>,
     C: Wrap<B> + Wrap<S> + GenerateGhosts<S>,

--- a/hoomd-mc/src/tune_local.rs
+++ b/hoomd-mc/src/tune_local.rs
@@ -18,7 +18,7 @@ use hoomd_simulation::macrostate::Temperature;
 use hoomd_spatial::PointUpdate;
 
 /// Tune local trial moves.
-pub(crate) fn tune_local_trial<P, B, S, X, C, L, H, MA, F>(
+pub(crate) fn tune_local_trial<P1, P2, B, S, X, C, L, H, MA, F>(
     local_trial: &mut L,
     microstate: &Microstate<B, S, X, C>,
     hamiltonian: &H,
@@ -26,10 +26,11 @@ pub(crate) fn tune_local_trial<P, B, S, X, C, L, H, MA, F>(
     options: &TuneOptions,
     should_move_body: F,
 ) where
-    P: Copy,
-    B: Copy + Default + Transform<S> + Position<Position = P>,
-    S: Copy + Default + Position<Position = P>,
-    X: PointUpdate<P, SiteKey>,
+    P1: Copy,
+    P2: Copy,
+    B: Copy + Default + Transform<S> + Position<Position = P1>,
+    S: Copy + Default + Position<Position = P2>,
+    X: PointUpdate<P2, SiteKey>,
     L: LocalTrial<B> + Adjust + Display,
     H: DeltaEnergyOne<B, S, X, C>,
     C: Wrap<B> + Wrap<S> + GenerateGhosts<S>,

--- a/hoomd-microstate/src/boundary.rs
+++ b/hoomd-microstate/src/boundary.rs
@@ -44,7 +44,7 @@ pub enum Error {
 }
 
 /// The maximum number of possible ghosts.
-pub(crate) const MAX_GHOSTS: usize = 12;
+pub const MAX_GHOSTS: usize = 12;
 
 // Ideally, MAX_GHOSTS would be associated with the boundary type, but that is
 // not currently possible in Rust.

--- a/hoomd-microstate/src/boundary/periodic/cuboid.rs
+++ b/hoomd-microstate/src/boundary/periodic/cuboid.rs
@@ -289,14 +289,15 @@ where
     }
 }
 
-impl<const N: usize, B, S, X> Replicate<N, B, S, X, Periodic<Hypercuboid<N>>>
+impl<const N: usize, P, B, S, X> Replicate<N, B, S, X, Periodic<Hypercuboid<N>>>
     for Microstate<B, S, X, Periodic<Hypercuboid<N>>>
 where
+    P: Copy,
     B: Transform<S> + Position<Position = Cartesian<N>>,
-    S: Position<Position = Cartesian<N>> + Default,
+    S: Position<Position = P> + Default,
     Body<B, S>: Clone,
     Periodic<Hypercuboid<N>>: Wrap<B> + Wrap<S> + GenerateGhosts<S>,
-    X: PointUpdate<Cartesian<N>, SiteKey> + Clone,
+    X: PointUpdate<P, SiteKey> + Clone,
 {
     /// Replicate the bodies in self `counts[0]` x `counts[1]` x ... `counts[N-1]` times and
     /// expand the periodic boundary accordingly.

--- a/hoomd-microstate/src/boundary/periodic/rhomboid.rs
+++ b/hoomd-microstate/src/boundary/periodic/rhomboid.rs
@@ -204,13 +204,14 @@ where
     }
 }
 
-impl<B, S, X> Replicate<2, B, S, X, Periodic<Rhomboid>> for Microstate<B, S, X, Periodic<Rhomboid>>
+impl<P, B, S, X> Replicate<2, B, S, X, Periodic<Rhomboid>> for Microstate<B, S, X, Periodic<Rhomboid>>
 where
+    P: Copy,
     B: Transform<S> + Position<Position = Cartesian<2>>,
-    S: Position<Position = Cartesian<2>> + Default,
+    S: Position<Position = P> + Default,
     Body<B, S>: Clone,
     Periodic<Rhomboid>: Wrap<B> + Wrap<S> + GenerateGhosts<S>,
-    X: PointUpdate<Cartesian<2>, SiteKey> + Clone,
+    X: PointUpdate<P, SiteKey> + Clone,
 {
     /// Replicate the bodies in self `counts[0]` x `counts[1]` times and
     /// expand the periodic boundary accordingly.

--- a/hoomd-microstate/src/boundary/periodic/rhomboid.rs
+++ b/hoomd-microstate/src/boundary/periodic/rhomboid.rs
@@ -204,7 +204,8 @@ where
     }
 }
 
-impl<P, B, S, X> Replicate<2, B, S, X, Periodic<Rhomboid>> for Microstate<B, S, X, Periodic<Rhomboid>>
+impl<P, B, S, X> Replicate<2, B, S, X, Periodic<Rhomboid>>
+    for Microstate<B, S, X, Periodic<Rhomboid>>
 where
     P: Copy,
     B: Transform<S> + Position<Position = Cartesian<2>>,

--- a/hoomd-microstate/src/boundary/periodic/triclinic.rs
+++ b/hoomd-microstate/src/boundary/periodic/triclinic.rs
@@ -283,14 +283,15 @@ where
     }
 }
 
-impl<B, S, X> Replicate<3, B, S, X, Periodic<Triclinic>>
+impl<P, B, S, X> Replicate<3, B, S, X, Periodic<Triclinic>>
     for Microstate<B, S, X, Periodic<Triclinic>>
 where
+    P: Copy,
     B: Transform<S> + Position<Position = Cartesian<3>>,
-    S: Position<Position = Cartesian<3>> + Default,
+    S: Position<Position = P> + Default,
     Body<B, S>: Clone,
     Periodic<Triclinic>: Wrap<B> + Wrap<S> + GenerateGhosts<S>,
-    X: PointUpdate<Cartesian<3>, SiteKey> + Clone,
+    X: PointUpdate<P, SiteKey> + Clone,
 {
     /// Replicate the bodies in self `counts[0]` x `counts[1]` x `counts[2]` times and
     /// expand the periodic boundary accordingly.

--- a/hoomd-microstate/src/microstate.rs
+++ b/hoomd-microstate/src/microstate.rs
@@ -606,20 +606,21 @@ impl<B, S, X, C> Microstate<B, S, X, C> {
     ///
     /// This helper method is used in the various `Replicate` implementations.
     #[inline]
-    pub(crate) fn build_replicate<const N: usize, V>(
+    pub(crate) fn build_replicate<const N: usize, V1, V2>(
         &self,
         counts: [usize; N],
         new_boundary: C,
-        basis_vectors: [V; N],
-        base_offset: V,
+        basis_vectors: [V1; N],
+        base_offset: V1,
     ) -> Result<Microstate<B, S, X, C>, crate::Error>
     where
-        V: Vector,
-        B: Transform<S> + Position<Position = V>,
-        S: Position<Position = V> + Default,
+        V1: Vector,
+        V2: Copy,
+        B: Transform<S> + Position<Position = V1>,
+        S: Position<Position = V2> + Default,
         Body<B, S>: Clone,
         C: Wrap<B> + Wrap<S> + GenerateGhosts<S>,
-        X: PointUpdate<V, SiteKey> + Clone,
+        X: PointUpdate<V2, SiteKey> + Clone,
     {
         let mut microstate = Microstate::builder()
             .step(self.step())
@@ -648,7 +649,7 @@ impl<B, S, X, C> Microstate<B, S, X, C> {
 impl<P, B, S, X, C> Microstate<B, S, X, C>
 where
     P: Copy,
-    B: Transform<S> + Position<Position = P>,
+    B: Transform<S>,
     S: Position<Position = P> + Default,
     C: Wrap<B> + Wrap<S> + GenerateGhosts<S>,
     X: PointUpdate<P, SiteKey>,
@@ -983,7 +984,7 @@ where
     )]
     pub fn update_body_properties(&mut self, body_index: usize, properties: B) -> Result<(), Error>
     where
-        B: Transform<S> + Position<Position = P>,
+        B: Transform<S>,
         S: Position<Position = P>,
         C: Wrap<B> + Wrap<S>,
     {
@@ -1456,13 +1457,14 @@ where
 }
 
 /// Manipulate the microstate as a whole.
-impl<P, B, S, X, C> Microstate<B, S, X, C>
+impl<P1, P2, B, S, X, C> Microstate<B, S, X, C>
 where
-    P: Copy,
-    B: Clone + Transform<S> + Position<Position = P>,
-    S: Clone + Position<Position = P> + Default,
-    C: Clone + Wrap<B> + Wrap<S> + GenerateGhosts<S> + MapPoint<P>,
-    X: Clone + PointUpdate<P, SiteKey>,
+    P1: Copy,
+    P2: Copy,
+    B: Clone + Transform<S> + Position<Position = P1>,
+    S: Clone + Position<Position = P2> + Default,
+    C: Clone + Wrap<B> + Wrap<S> + GenerateGhosts<S> + MapPoint<P1>,
+    X: Clone + PointUpdate<P2, SiteKey>,
 {
     /// Clone the microstate, mapping or wrapping bodies into a new boundary.
     ///
@@ -1847,7 +1849,7 @@ impl<B, S, X, C> MicrostateBuilder<B, S, X, C> {
     pub fn try_build<P>(self) -> Result<Microstate<B, S, X, C>, Error>
     where
         P: Copy,
-        B: Transform<S> + Position<Position = P>,
+        B: Transform<S>,
         S: Position<Position = P> + Default,
         C: Wrap<B> + Wrap<S> + GenerateGhosts<S>,
         X: PointUpdate<P, SiteKey>,


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Add a new example that demonstrates 3D interaction models (in this case, hard capsules) where the body centers are confined to a 2D plane.

To achieve this example, I needed to relax many `Microstate` trait bounds so that `B` and `P` could hold positions in different vector spaces.

I also added 3D orbit camera controls to `hoomd-bevy`.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Give users a starting point for quasi-2D simulations.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #234
Resolves #331

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
I ran the new example locally, and it behaved as expected. The GSD output renders as expected in OVITO, which has native support to render capsules.

<!--- Please build the documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**hoomd-rs Contributor Agreement**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/credits.md`) in the pull request source branch.
- [x] I have summarized these changes in `release-notes.md` following the established format.
