### PR TITLE
Use hoomd-workspace in the workflow tutorial.

### DIFF
--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -6,6 +6,8 @@
 
 *Changed:*
 
+`[tutorials]`:  The workflow tutorial now uses `hoomd-workspace` (#403).
+
 *Deprecated:*
 
 *Removed:*

--- a/doc/src/workflow-tutorial/action-binary.md
+++ b/doc/src/workflow-tutorial/action-binary.md
@@ -79,12 +79,9 @@ env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(log_l
 
 ## Execute the Chosen Action
 
-Next, `action` switches to the `workspace` directory ([row] names directories
-relative to `workspace/`) and calls `simulate_one`:
+Next, `action` calls `simulate_one`:
 
 ```rust,ignore
-    set_current_dir("workspace").context("error switching to directory `workspace`")?;
-
     match &options.command {
         Commands::Simulate { directory } => simulate_one(directory)?,
     }
@@ -103,6 +100,7 @@ You should see:
 [INFO  hoomd_workflow::simulate] Step 0 / 100000 (0%)
 [INFO  hoomd_workflow::simulate] Step 1000 / 100000 (1%)
 [INFO  hoomd_workflow::simulate] Step 2000 / 100000 (2%)
+...
 ```
 
 Try adding `-v`, `-vv`, or `-q` to the command and see how the output changes.
@@ -126,14 +124,15 @@ $ target/release/action simulate not-a-directory
 
 You should see:
 ```
-Error: error switching to job directory `not-a-directory`
+Error: error initializing model in `not-a-directory`
 
 Caused by:
-    No such file or directory (os error 2)
+    state point not found
 ```
 
-The `error switching to job directory` came from a call to `.context`.
-`anyhow` lists the original error message(s) under `Caused by`.
+The `error initializing model` came from a call to `.with_context`.
+`anyhow` lists the original error message(s) under `Caused by`. In this case,
+the state point with identifier `not-a-directory` is not found.
 
 ## Troubleshooting Difficult Errors
 
@@ -162,7 +161,7 @@ as well. Furthermore, you must build in a development mode (omit the `--release`
 option) or else you will not see file names or line numbers. With
 the same code modification as above, the command:
 ```shell
-$ RUST_BACKTRACE=1 cargo run -- simulate 524ac2c93c6db72af79821edd021696b
+$ RUST_BACKTRACE=1 cargo run --bin action -- simulate 524ac2c93c6db72af79821edd021696b
 ```
 produces the output:
 ```

--- a/doc/src/workflow-tutorial/action-binary.md
+++ b/doc/src/workflow-tutorial/action-binary.md
@@ -44,22 +44,22 @@ one action. The template uses it so that you can easily add more actions
 (subcommands) as needed (e.g. `analyze`, `render`, ...).
 
 > [!TIP]
-> [row] of course allows you to implement these other actions in another
-> language of your preference. You do not have to write all your workflow
-> actions in Rust.
+> [row] allows you to implement these other actions in another language of your
+> preference. You do not have to write all your workflow actions in Rust.
 
 ## Configure `env_logger`
 
-Did you notice all the `info!` and `debug!` messages throughout the code?
-These macros pass messages to the [log] crate, which does nothing by itself.
-Once you configure a logging backend, the messages will print to `stdout` (or
-wherever the backend delivers them). The [env_logger] crate a backend
+Did you notice all the `info!` and `debug!` messages throughout the code? These
+macros pass messages to the [log] crate, which does nothing by itself. Once
+you configure a logging backend, the messages will print to `stdout`/`stderr`
+(or wherever the backend delivers them). The [env_logger] crate a backend
 that allows fine-grained customization at run time (e.g. you could hide
 messages from `hoomd-mc` and see messages from your own crate). The `verbose`
 option configures what level is visible from the command line (which can be
-overridden by the `RUST_LOG` environment variable). By default, `warning!` and
+overridden by the `RUST_LOG` environment variable). By default, only `warning!` and
 `info!` messages are shown. Pass `-q` or `-qq` to hide `info` and `warning`
-respectively. Pass `-v` to enable `debug!` messages and `-vv` to enable `trace!`.
+respectively. Pass `-v` to enable `debug!` messages and `-vv` to enable
+`trace!`.
 
 ```rust,ignore
 let log_level = match options.verbose.log_level_filter() {
@@ -113,9 +113,9 @@ Try adding `-v`, `-vv`, or `-q` to the command and see how the output changes.
 
 Notice that `main` returns an `anyhow::Result` and checks for errors with `?`.
 In this way, any errors that occur in methods called by main (or methods called
-by those methods, and on down the chain) will propagate all the way to the top,
-unless then are recovered from. When `main` returns an `Err`, `anyhow` prints
-a human readable form of the error message.
+by those methods, and on down the chain) will propagate all the way to the top
+When `main` returns an `Err`, [anyhow] prints a human readable form of the error
+message.
 
 To see an error message, execute:
 ```shell
@@ -131,7 +131,7 @@ Caused by:
 ```
 
 The `error initializing model` came from a call to `.with_context`.
-`anyhow` lists the original error message(s) under `Caused by`. In this case,
+[anyhow] lists the original error message(s) under `Caused by`. In this case,
 the state point with identifier `not-a-directory` is not found.
 
 ## Troubleshooting Difficult Errors

--- a/doc/src/workflow-tutorial/conclusion.md
+++ b/doc/src/workflow-tutorial/conclusion.md
@@ -4,19 +4,18 @@ There is a lot packed into the example workflow, so don't worry if you don't
 understand it all at first.
 
 To implement your own simulation model, start by modifying `state_point.rs`,
-`model.rs`, and `populate_workspace.rs` to implement your. You may need to
-modify `simulate.rs` or `action.rs` not at all or at least only minimally at
-first.
+`model.rs`, and `populate_workspace.rs`. You may need to make slight modifications
+to `simulate.rs` and `action.rs`.
 
 > [!NOTE]
 > Remember: Start your own Git repository history from scratch. Don't clone the
 > repository. Make a new one from the template or download the files directly.
 
-If you have any questions, please check the [hoomd-rs discussion board] first.
-If no one else has asked the same question, the *hoomd-rs* developers would be
-happy to answer yours. **PLEASE** include a fully working example of any code
-you have questions about (post it as a [gist] or link to your GitHub
-repository).
+If you have any questions, please check the [hoomd-rs discussion board]
+first. If no one else has asked the same question, post it and the *hoomd-rs*
+developers would be happy to answer yours. **PLEASE** include a fully working
+example of any code you have questions about (post it as a [gist] or link to
+your GitHub repository).
 
 Resources:
 - [Create a GitHub repository from the template]

--- a/doc/src/workflow-tutorial/conclusion.md
+++ b/doc/src/workflow-tutorial/conclusion.md
@@ -4,7 +4,7 @@ There is a lot packed into the example workflow, so don't worry if you don't
 understand it all at first.
 
 To implement your own simulation model, start by modifying `state_point.rs`,
-`model.rs`, and `populate_workspace.py` to implement your. You may need to
+`model.rs`, and `populate_workspace.rs` to implement your. You may need to
 modify `simulate.rs` or `action.rs` not at all or at least only minimally at
 first.
 
@@ -19,9 +19,9 @@ you have questions about (post it as a [gist] or link to your GitHub
 repository).
 
 Resources:
-- [hoomd-workflow repository]
 - [Create a GitHub repository from the template]
 - [Download the template]
+- [hoomd-workflow repository]
 
 [hoomd-rs discussion board]: https://github.com/glotzerlab/hoomd-rs/discussions
 [hoomd-workflow repository]: https://github.com/glotzerlab/hoomd-workflow

--- a/doc/src/workflow-tutorial/index.md
+++ b/doc/src/workflow-tutorial/index.md
@@ -4,13 +4,15 @@ By now, you have learned how to implement your simulation model using *hoomd-rs*
 and have been able to run several test cases. Changing `main.rs` and
 executing `cargo run` for each simulation is not very practical when your
 research study will require tens, hundreds, or thousands of different
-simulations. [Row] and [signac] can help you with that.
+simulations. [Row] and [signac] can help you with that. The [hoomd-workspace]
+crate implements a minimal Rust interface for [signac].
 
 This tutorial assumes that you already have a basic understanding of [row] and
 [signac]. If you don't, you should read their tutorials first. Here, you will
 learn the best practices to integrate your *hoomd-rs* simulations with [row]
 and [signac] including:
 
+* Adding state points to the workspace.
 * Reading the simulation parameters from a [signac] state point.
 * Writing status messages to `stdout` using the [log] crate.
 * Writing simulation trajectories to a [gsd] file.
@@ -26,8 +28,8 @@ or *fork* the repository (you don't need the template's commit history). You can
 create your own new repository on GitHub [from the template] (and then clone
 your own repository) or you can [download the template] for use locally.
 
-Once you have a local copy, launch a terminal and change to that directory.
-Then you can build the workflow binary with:
+Once you have a local copy, launch a terminal and change to that directory
+and you build the workflow binary with:
 ```shell
 $ cargo build --release
 ```
@@ -45,16 +47,15 @@ Then you can run the binary `target/release/action`.
 > may not have the network access needed to build and many parallel builds might
 > conflict.
 
-You are also going to need to install [row] and [signac]. You can activate the
-provided [Pixi] environment. In `bash` and `zsh`, you can run this command
-(see the [Pixi] documentation if you use another shell):
-```shell
-$ eval "$(pixi shell-hook)"
+You need to install [row] to execute the sample workflow. To do so, execute
 ```
-or you can install [row] and [signac] using your preferred package manager(s).
+$ cargo install row
+```
+or use your preferred conda-forge compatible package manager.
 
-[row]: https://row.readthedocs.io
 [signac]: https://signac.readthedocs.io
+[row]: https://row.readthedocs.io
+[hoomd-workspace]: ../../api/hoomd_workspace/index.html
 [log]: https://docs.rs/log
 [gsd]: https://gsd.readthedocs.org
 [parquet]: https://parquet.apache.org/

--- a/doc/src/workflow-tutorial/index.md
+++ b/doc/src/workflow-tutorial/index.md
@@ -28,7 +28,7 @@ or *fork* the repository (you don't need the template's commit history). You can
 create your own new repository on GitHub [from the template] (and then clone
 your own repository) or you can [download the template] for use locally.
 
-Once you have a local copy, launch a terminal and change to that directory
+Once you have a local copy, launch a terminal, change to that directory,
 and you build the workflow binary with:
 ```shell
 $ cargo build --release

--- a/doc/src/workflow-tutorial/index.md
+++ b/doc/src/workflow-tutorial/index.md
@@ -55,7 +55,7 @@ or use your preferred conda-forge compatible package manager.
 
 [signac]: https://signac.readthedocs.io
 [row]: https://row.readthedocs.io
-[hoomd-workspace]: ../../api/hoomd_workspace/index.html
+[hoomd-workspace]: ../api/hoomd_workspace/index.html
 [log]: https://docs.rs/log
 [gsd]: https://gsd.readthedocs.org
 [parquet]: https://parquet.apache.org/

--- a/doc/src/workflow-tutorial/row-workflow.md
+++ b/doc/src/workflow-tutorial/row-workflow.md
@@ -1,6 +1,6 @@
 # The Row Workflow
 
-Now, let's put this all together and automate the submission process with
+Let's put this all together and automate the submission process with
 [row].
 
 ## `workflow.toml`
@@ -30,8 +30,8 @@ command = "target/release/action $ACTION_NAME {directories}"
 ```
 The `command` tells [row] how to launch the `action` binary. Use the
 `$ACTION_NAME` environment variable instead of hard-coding `simulate`
-so that `command` is ready for use when you add more actions subcommands
-in the future.
+so that the default `command` can execute any new action subcommands
+you might add.
 
 ### Launcher
 
@@ -51,8 +51,7 @@ resources.threads_per_process = 1
 > The resulting resource contention will cause your simulations to run
 > *extremely slowly*.
 
-How should you choose `threads_per_process`? You need to choose it appropriately
-based on how you configure your simulation model. Most of *hoomd-rs* uses only
+How should you choose `threads_per_process`? Most of *hoomd-rs* uses only
 1 thread, so start thre. In the current release, only `hoomd_mc::ParallelSweep`
 and `hoomd_md::UpdateNetForce*` use multiple threads. Benchmark and see how your
 model scales before submitting a set of jobs to a cluster. You would waste your own
@@ -90,7 +89,7 @@ row submit -n 1
 again.
 
 This time, the action should quit after 1 minute (it defaults to a 5 minute wall
-time buffer) and will print:
+time buffer) and will output something like:
 ```
 ...
 [INFO  hoomd_workflow::simulate] Step 15000 / 100000 (15%)

--- a/doc/src/workflow-tutorial/row-workflow.md
+++ b/doc/src/workflow-tutorial/row-workflow.md
@@ -52,12 +52,12 @@ resources.threads_per_process = 1
 > *extremely slowly*.
 
 How should you choose `threads_per_process`? You need to choose it appropriately
-based on how you configure your simulation model. Most of *hoomd-rs* uses
-only 1 thread, so that should be the default. In the current release, only
-`ParallelSweep` uses multiple threads. Benchmark and see how your model scales
-before submitting a set of jobs to a cluster. It would be a waste of your time
-if you requested `threads_per_process=32`, but your model ran even faster with
-`threads_per_process=8`.
+based on how you configure your simulation model. Most of *hoomd-rs* uses only
+1 thread, so start thre. In the current release, only `hoomd_mc::ParallelSweep`
+and `hoomd_md::UpdateNetForce*` use multiple threads. Benchmark and see how your
+model scales before submitting a set of jobs to a cluster. You would waste your own
+time if you requested `threads_per_process=32`, but your model ran even
+faster with `threads_per_process=8`.
 
 ### Maximum Size
 

--- a/doc/src/workflow-tutorial/simulate-action.md
+++ b/doc/src/workflow-tutorial/simulate-action.md
@@ -85,7 +85,8 @@ while model.step() < TOTAL_STEPS {
 }
 
 let out_bytes: Vec<u8> = postcard::to_stdvec(&model)?;
-let mut file = File::create(MODEL_FILE).context("failed to create `{MODEL_FILE}`")?;
+let mut file =
+    File::create(job_directory.join(MODEL_FILE)).context("failed to create `{MODEL_FILE}`")?;
 file.write_all(&out_bytes)
     .context("failed to write `{MODEL_FILE}`")?;
 ```
@@ -99,7 +100,7 @@ environment variable.
 analysis:
 
 ```rust,ignore
-let mut gsd_file = HoomdGsdFile::open("trajectory.in-progress.gsd")
+let mut gsd_file = HoomdGsdFile::open(job_directory.join("trajectory.in-progress.gsd"))
     .context("error opening trajectory.in-progress.gsd")?;
 ```
 `open` works here because `get_model` created the GSD file.
@@ -116,8 +117,11 @@ drop(gsd_file);
 
 if model.step() == TOTAL_STEPS {
     info!("Simulation complete.");
-    fs::rename("trajectory.in-progress.gsd", "trajectory.gsd")
-        .context("failed to rename `trajectory.in-progress.gsd` to `trajectory.gsd`")?;
+    fs::rename(
+        job_directory.join("trajectory.in-progress.gsd"),
+        job_directory.join("trajectory.gsd"),
+    )
+    .context("failed to rename `trajectory.in-progress.gsd` to `trajectory.gsd`")?;
 }
 ```
 
@@ -132,8 +136,9 @@ The solution suggested by the [parquet] developers is to create multiple files.
 The `create_unique` method creates `log.parquet.0` on the first submission then
 `log.parquet.1` on the second, and so on:
 ```rust,ignore
-let mut parquet_logger = ParquetLogger::<LogRecord>::create_unique("log.parquet")
-    .context("error creating `log.parquet`")?;
+let mut parquet_logger =
+    ParquetLogger::<LogRecord>::create_unique(job_directory.join("log.parquet"))
+        .context("error creating `log.parquet`")?;
 ```
 
 When you visualize or post-process the log later, you should concatenate

--- a/doc/src/workflow-tutorial/simulate-action.md
+++ b/doc/src/workflow-tutorial/simulate-action.md
@@ -19,7 +19,7 @@ Most HPC resources limit the wall time your jobs may execute. To enable
 long-running simulation models, this workflow template monitors the wall time
 used and *serializes* the entire simulation state to a file a few minutes before
 the time is up. At that point, your HPC job ends and [row] will indicate that
-the directory is eligible again. When you submit the new job, `simulate` will
+the directory is eligible again. When you submit a new job, `simulate` will
 *deserialize* the simulation state and continue the simulation from where it
 left off.
 

--- a/doc/src/workflow-tutorial/simulate-action.md
+++ b/doc/src/workflow-tutorial/simulate-action.md
@@ -35,27 +35,29 @@ necessary logic. It first checks if `model.postcard` exists. If it does,
 it deserializes the simulation state and returns it. If not, it initializes
 a new simulation model from the [signac] state point:
 ```rust,ignore
-fn get_model() -> anyhow::Result<LennardJonesModel> {
-    match fs::read(MODEL_FILE) {
+    let model_file: PathBuf = [Path::new("workspace"), directory, Path::new(MODEL_FILE)]
+        .iter()
+        .collect();
+    match fs::read(&model_file) {
         Ok(bytes) => {
-            debug!("Continuing simulation from `{MODEL_FILE}`.");
+            debug!("Continuing simulation from `{}`.", model_file.display());
 
-            postcard::from_bytes(&bytes).with_context(|| format!("could not read `{MODEL_FILE}`"))
+            postcard::from_bytes(&bytes)
+                .with_context(|| format!("could not read `{}`", model_file.display()))
         }
         Err(error) => match error.kind() {
             io::ErrorKind::NotFound => {
                 debug!("Constructing a new simulation model.");
-                let state_point_bytes = fs::read("signac_statepoint.json")
-                    .context("unable to read `signac_statepoint.json`")?;
-                let state_point: StatePoint = serde_json::from_slice(&state_point_bytes)
-                    .context("could not parse signac_statepoint.json")?;
-                let _ = HoomdGsdFile::create("trajectory.in-progress.gsd");
+                let state_point: StatePoint = hoomd_workspace::state_point(directory)
+                    .context("could not read state point")?
+                    .ok_or(anyhow!("state point not found"))?;
+                let _ =
+                    HoomdGsdFile::create(state_point.path()?.join("trajectory.in-progress.gsd"));
                 LennardJonesModel::new(state_point)
             }
             _ => Err(error).with_context(|| format!("Could not read `{MODEL_FILE}`")),
         },
     }
-}
 ```
 
 `simulate_one` breaks out of the main simulation loop when the wall time is nearly

--- a/doc/src/workflow-tutorial/state-point.md
+++ b/doc/src/workflow-tutorial/state-point.md
@@ -87,4 +87,4 @@ let state_point: StatePoint = hoomd_workspace::state_point(directory)
 
 [signac]: https://signac.readthedocs.io
 [serde]: https://docs.rs/serde
-[hoomd-workspace]: ../../api/hoomd_workspace/index.html
+[hoomd-workspace]: ../api/hoomd_workspace/index.html

--- a/doc/src/workflow-tutorial/state-point.md
+++ b/doc/src/workflow-tutorial/state-point.md
@@ -66,13 +66,15 @@ To execute it, run:
 $ target/release/populate_workspace
 ```
 
-Signac stores these state points in JSON files in the `workspace` directory.
-Explor the `workspace` directory and inspect the `signac_statepoint.json` files
-you find. They should match the structs written by `populate_workspace.rs`.
+`populate_workspace` wrote these state points to JSON files in the `workspace`
+directory. Explor the `workspace` directory and inspect the `signac_statepoint.json`
+files you find. They should match the structs written by `populate_workspace.rs`.
+The workspace created by `hoomd-workspace` is compatible with the [signac] Python
+framework.
 
 In `simulate.rs` (explained later), the workflow reads the state point using
-the `state_point` function in [hoomd-workspace] which requires that the
-state point type implements the `Deserialize` trait:
+the `state_point` function in [hoomd-workspace], which uses the `Deserialize`
+trait to read the JSON file and parse the struct fields:
 ```rust,ignore
 let state_point: StatePoint = hoomd_workspace::state_point(directory)
     .context("could not read state point")?

--- a/doc/src/workflow-tutorial/state-point.md
+++ b/doc/src/workflow-tutorial/state-point.md
@@ -20,26 +20,69 @@ pub struct StatePoint {
 }
 ```
 
-Signac stores these state points in JSON files in the `workspace` directory.
-To populate that directory with three example state points, execute:
-```shell
-$ python populate_workspace.py
-```
-
-You might be wondering what the `#[derive(Serialize, Deserialize)]` is for.
-In `simulate.rs` (explained later), the workflow reads the state point using
-[serde_json]:
+The `#[derive(Serialize, Deserialize)]` line calls [serde] macros that
+automatically implement `Serialize` and `Deserialize` for the struct.
+`bin/populate_workspace.rs` uses the `Serialize` trait indirectly through
+[hoomd-workspace]'s `add` method to create several state point directories in
+the workspace:
 ```rust,ignore
-let state_point_bytes = fs::read("signac_statepoint.json")?;
-let state_point: StatePoint = serde_json::from_slice(&state_point_bytes)?;
+use hoomd_workflow::StatePoint;
+
+fn main() -> anyhow::Result<()> {
+    hoomd_workspace::add(&StatePoint {
+        n: 1_000,
+        epsilon: 1.0,
+        sigma: 1.0,
+        temperature: 1.0,
+        number_density: 0.4,
+        replicate: 0,
+    })?;
+
+    hoomd_workspace::add(&StatePoint {
+        n: 1_000,
+        epsilon: 1.0,
+        sigma: 1.0,
+        temperature: 1.0,
+        number_density: 0.4,
+        replicate: 1,
+    })?;
+
+    hoomd_workspace::add(&StatePoint {
+        n: 1_000,
+        epsilon: 1.0,
+        sigma: 1.0,
+        temperature: 0.7,
+        number_density: 0.4,
+        replicate: 0,
+    })?;
+
+    Ok(())
+}
 ```
 
-`#[derive(Serialize, Deserialize)]` invokes a macro that *automatically*
-implements the `Serialize` and `Deserialize` traits for our type.
+
+To execute it, run:
+```shell
+$ target/release/populate_workspace
+```
+
+Signac stores these state points in JSON files in the `workspace` directory.
+Explor the `workspace` directory and inspect the `signac_statepoint.json` files
+you find. They should match the structs written by `populate_workspace.rs`.
+
+In `simulate.rs` (explained later), the workflow reads the state point using
+the `state_point` function in [hoomd-workspace] which requires that the
+state point type implements the `Deserialize` trait:
+```rust,ignore
+let state_point: StatePoint = hoomd_workspace::state_point(directory)
+    .context("could not read state point")?
+    .ok_or(anyhow!("state point not found"))?;
+```
 
 > [!TIP]
 > To implement your own simulation model, replace the struct fields with
 > ones that match your state point.
 
 [signac]: https://signac.readthedocs.io
-[serde_json]: https://docs.rs/serde_json
+[serde]: https://docs.rs/serde
+[hoomd-workspace]: ../../api/hoomd_workspace/index.html


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Use hoomd-workspace in the workflow tutorial.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Show users how to populate new workspace directories in Rust and use `state_point` to read existing state points.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
The refactored workflow example https://github.com/glotzerlab/hoomd-workflow/pull/51 works as expected.

<!--- Please build the documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**hoomd-rs Contributor Agreement**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/credits.md`) in the pull request source branch.
- [x] I have summarized these changes in `release-notes.md` following the established format.
