### PR TITLE
Improve inlining and code generation in performance-critical paths.

### DIFF
--- a/doc/src/release-notes.md
+++ b/doc/src/release-notes.md
@@ -6,13 +6,22 @@
 
 *Changed:*
 
-`[tutorials]`:  The workflow tutorial now uses `hoomd-workspace` (#403).
+* `[tutorials]`: The workflow tutorial now uses `hoomd-workspace` (#403).
+* `[hoomd-interaction]`: `Isotropic::site_pair_energy` now compares squared distances in
+the pre-filter step (#416).
+* `[hoomd-geometry]`:
+* `MinkowskiDifference::composite_support_mapping` is now inline(always) for better
+performance (#416).
+* `[hoomd-spatial]`: `PointsIterator::next` is now inline(always) for
+better performance (#416).
 
 *Deprecated:*
 
 *Removed:*
 
 *Fixed:*
+
+`[hoomd-linear-algebra]`: `Matrix::add_assign` no longer uses excess memory (#416).
 
 ## 1.3.0 (2026-08-26)
 

--- a/hoomd-geometry/src/xenocollide.rs
+++ b/hoomd-geometry/src/xenocollide.rs
@@ -314,7 +314,7 @@ impl<'a, const N: usize, A: SupportMapping<Cartesian<N>>, B: SupportMapping<Cart
     MinkowskiDifference<'_, N, A, B>
 {
     /// Compute the support function on the Minkowski difference of two shapes.
-    #[inline]
+    #[inline(always)]
     fn composite_support_mapping(&self, n: Cartesian<N>) -> Cartesian<N> {
         // Support point of b in the direction of vij
         // 'translation/rotation formula comes from pg 168 of "Games Programming Gems 7"'

--- a/hoomd-interaction/src/pairwise/isotropic.rs
+++ b/hoomd-interaction/src/pairwise/isotropic.rs
@@ -148,7 +148,7 @@ where
         let r_squared = site_properties_i
             .position()
             .distance_squared(site_properties_j.position());
-        if r_squared >= self.r_cut * self.r_cut {
+        if r_squared >= self.r_cut.powi(2) {
             return 0.0;
         }
 
@@ -252,15 +252,15 @@ where
         site_properties_j: &S,
     ) -> (Self::Force, <Self::Force as Outer>::Tensor) {
         let r_ji = *site_properties_i.position() - *site_properties_j.position();
-        let distance = r_ji.norm();
-
-        if distance >= self.r_cut {
-            (V::default(), V::Tensor::default())
-        } else {
-            let force = (r_ji / distance) * self.interaction.force(distance);
-            let virial = (force / 2.0).outer(&r_ji);
-            (force, virial)
+        let r_squared = r_ji.norm_squared();
+        if r_squared >= self.r_cut.powi(2) {
+            return (V::default(), V::Tensor::default());
         }
+
+        let distance = r_squared.sqrt();
+        let force = (r_ji / distance) * self.interaction.force(distance);
+        let virial = (force / 2.0).outer(&r_ji);
+        (force, virial)
     }
 }
 
@@ -295,15 +295,14 @@ where
         site_properties_j: &S,
     ) -> (V, <Self::Force as Outer>::Tensor, V::Bivector) {
         let r_ji = *site_properties_i.position() - *site_properties_j.position();
-        let distance = r_ji.norm();
-
-        if distance >= self.r_cut {
-            (V::default(), V::Tensor::default(), V::Bivector::default())
-        } else {
-            let force = (r_ji / distance) * self.interaction.force(distance);
-            let virial = (force / 2.0).outer(&r_ji);
-            let torque = V::Bivector::default();
-            (force, virial, torque)
+        let r_squared = r_ji.norm_squared();
+        if r_squared >= self.r_cut.powi(2) {
+            return (V::default(), V::Tensor::default(), V::Bivector::default());
         }
+
+        let distance = r_squared.sqrt();
+        let force = (r_ji / distance) * self.interaction.force(distance);
+        let virial = (force / 2.0).outer(&r_ji);
+        (force, virial, V::Bivector::default())
     }
 }

--- a/hoomd-interaction/src/pairwise/isotropic.rs
+++ b/hoomd-interaction/src/pairwise/isotropic.rs
@@ -145,14 +145,14 @@ where
     /// ```
     #[inline]
     fn site_pair_energy(&self, site_properties_i: &S, site_properties_j: &S) -> f64 {
-        let r = site_properties_i
+        let r_squared = site_properties_i
             .position()
-            .distance(site_properties_j.position());
-        if r >= self.r_cut {
+            .distance_squared(site_properties_j.position());
+        if r_squared >= self.r_cut * self.r_cut {
             return 0.0;
         }
 
-        self.interaction.energy(r)
+        self.interaction.energy(r_squared.sqrt())
     }
 }
 

--- a/hoomd-linear-algebra/src/matrix/ops.rs
+++ b/hoomd-linear-algebra/src/matrix/ops.rs
@@ -131,11 +131,13 @@ impl<const N: usize, const M: usize> Add<Self> for Matrix<N, M> {
     }
 }
 impl<const N: usize, const M: usize> AddAssign for Matrix<N, M> {
-    #[inline]
+    #[inline(always)]
     fn add_assign(&mut self, rhs: Self) {
-        self.iter_elements_mut()
-            .zip(rhs.iter_elements())
-            .for_each(|(x, r)| *x += r);
+        for i in 0..N {
+            for j in 0..M {
+                self.rows[i][j] += rhs.rows[i][j];
+            }
+        }
     }
 }
 impl<const N: usize, const M: usize> Sub<Self> for Matrix<N, M> {

--- a/hoomd-spatial/src/vec_cell.rs
+++ b/hoomd-spatial/src/vec_cell.rs
@@ -646,7 +646,7 @@ where
 {
     type Item = K;
 
-    #[inline]
+    #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(keys) = self.keys
@@ -707,7 +707,7 @@ where
     /// Panics when `radius` is larger than the *maximum search radius*
     /// provided at construction, rounded up to the nearest integer multiple
     /// of the *nominal search radius*.
-    #[inline]
+    #[inline(always)]
     fn points_near_ball(&self, position: &Cartesian<D>, radius: f64) -> impl Iterator<Item = K> {
         let stencil_index = (radius / self.cell_width.get()).ceil() as usize - 1;
         assert!(


### PR DESCRIPTION
## Description

Eliminate a few inefficiencies throughout the codebase, primarily by improving codegen or eliminating redundant work. Everything here is functionally identical but not bitwise identical (which is fine).

## Motivation and context

This PR yields net performance gains across the board, with the most significant improvements to lennard-Jones and the octahedron bench.

```
| benchmark | 1-thread Δ |
|---|---|
| `mc_2d_sphere` | +0.3 ± 1.2% |
| `mc_2d_lennard_jones` | **+11.4 ± 1.4%** |
| `mc_2d_hexagon` | +0.4 ± 1.1% |
| `md_2d_lennard_jones` | **+21.4 ± 1.2%** |
| `mc_3d_sphere` | **+14.2 ± 2.1%** |
| `mc_3d_lennard_jones` | **+38.1 ± 1.9%** |
| `mc_3d_octahedron` | **+15.7 ± 1.6%** |
| `mc_3d_ellipsoid` | **+6.0 ± 1.8%** |
| `mc_3d_sphere_triclinic` | **+13.7 ± 2.0%** |
| `md_3d_lennard_jones` | **+24.6 ± 1.9%** |
```

<img width="1766" height="691" alt="threads_ab" src="https://github.com/user-attachments/assets/0d29ec9c-1f5f-4bdc-8849-e066d877a9b2" />


- [ ] TODO: run on anvil as well
- [x] ~EDIT: need to rerun benches with fewer processes running~ MC LJ results are slightly slower now, everything else is consistent

## How has this been tested?

Existing tests pass and this has been benchmarked thoroughly. 

## Checklist:

- [x] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/CONTRIBUTING.md).
- [x] I agree with the terms of the [**hoomd-rs Contributor Agreement**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/ContributorAgreement.md).
- [x] My name is on the list of contributors (`doc/src/credits.md`) in the pull request source branch.
- [x] I have summarized these changes in `release-notes.md` following the established format.
