### PR TITLE
Document hoomd-order design. Implement psi_k and q_L order parameters.

### DIFF
--- a/.codebook.toml
+++ b/.codebook.toml
@@ -1,4 +1,5 @@
 words = [
+    "Steinhardt",
     "abelian",
     "binaryen",
     "bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4000,6 +4000,7 @@ dependencies = [
  "anyhow",
  "approxim",
  "divan",
+ "hoomd-geometry",
  "hoomd-microstate",
  "hoomd-spatial",
  "hoomd-vector",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3999,6 +3999,8 @@ version = "1.3.0"
 dependencies = [
  "approxim",
  "divan",
+ "hoomd-microstate",
+ "hoomd-spatial",
  "hoomd-vector",
  "num-complex",
  "rand 0.10.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3997,11 +3997,13 @@ dependencies = [
 name = "hoomd-order"
 version = "1.3.0"
 dependencies = [
+ "anyhow",
  "approxim",
  "divan",
  "hoomd-microstate",
  "hoomd-spatial",
  "hoomd-vector",
+ "itertools 0.15.0",
  "num-complex",
  "rand 0.10.2",
  "rstest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4009,6 +4009,7 @@ dependencies = [
  "rand 0.10.2",
  "rstest",
  "sphrs",
+ "thiserror 2.0.20",
 ]
 
 [[package]]

--- a/hoomd-order/ARCHITECTURE.md
+++ b/hoomd-order/ARCHITECTURE.md
@@ -1,0 +1,114 @@
+# hoomd_order
+
+The `hoomd-order` crate implements order parameters and other related calculations,
+such as k-atic, Steinhardt, radial distribution functions, and spatial correlation
+functions. It is the evolution of the functionality available in the [`freud`] Python
+package.
+
+## Design goals
+
+### Generality
+
+[`freud`] is popular because it operates directly on point sets. Where possible,
+`hoomd-order` should maintain this level of generality. At the same time,
+[`freud`] users have difficulties when using it directly coupled to a running
+simulation as `freud` needs to compute spatial data structures that are already
+present in the simulation. `hoomd-order` should solve this problem by allowing
+users to operate directly on sites in a `Microstate` and thereby make use
+of the existing spatial data structures. `Microstate` also implements the
+ghost site logic needed to realize periodic boundary conditions.
+
+One approach to solving this dual problem is to implement all analysis
+methods in `hoomd-order` independent of `Microstate` so that they can be
+used on general point sets. A higher level API layer could provide convenience
+methods that operate on `Microstate`.
+
+### Simplicity
+
+All methods in `hoomd-order` should be the most natural possible expression
+of the underlying mathematical operation. This provides complete clarity to
+the caller so that there is no ambiguity over what input maps to what
+(see e.g. the confusion over `query_points` and `points` in [`freud]`).
+
+For example, the k-atic order parameter can be expressed as a function with
+the signature:
+```rust
+fn k_atic_psi<I: IntoIterator<Item=Cartesian<2>>>(k: f64, r_i: Cartesian<2>, neighbors: I) -> Complex<f64>;
+```
+
+Analysis methods should be exposed as functions where possible and structs only when
+they need to store some internal state (such as the g(r) histogram).
+
+Note that unlike in [`freud`], the k-atic function computes an order parameter for
+a single point rather than for an entire system of points. This grants the caller
+the flexibility to call it only when needed for specific points without the need
+to design a complicated filter/selection system.
+
+[`freud`]: https://freud.readthedocs.io/en/latest/
+
+## Neighbor queries
+
+As shown in the `k_atic_psi` signature above, neighbor queries in `hoomd-order`
+simply become iterators. The iterator item depends on context, sometimes it may
+be only position while other methods might need position and orientation, or
+position, orientation, and weight. This grants the caller infinite flexibility.
+For example, they could form a chain of iterators starting with
+`Microstate::iter_sites_near` that filters for specific sites, collects into a vector,
+sorts the vector by distance to `r_i` and takes the first 6 items.
+
+Some users will appreciate that flexibility while others will find it onerous.
+`hoomd-order` should provide implementations of common methods, like the ball
+query and the nearest *k* neighbors (within a ball). To keep some amount of generality,
+the provided methods should emit `Site` items so that callers can further filter.
+At the same time, there should be provided implementations that produce positions
+(and positions/orientations) directly so calls to `k_atic_psi` can be a
+one-liner in simple situations. Optional exclusion of the *i* site should be
+handled by the neighbor query, not each analysis method.
+
+Each query will need to hold some state (such as `r_cut`, the identity of `i`, etc...)
+so they should be implemented as structs. There will not be a `NeighborQuery` trait.
+Say a caller already has their neighbor positions listed in a `Vec` (e.g. from an
+explicit list of bonds). When the `neighbors` argument is `IntoIterator`, callers
+can simply pass in the `vec.iter()`. If `neighbors` had to implement the
+`NeighborQuery` trait, then callers would have to implement that trait for many
+common types. Rather, `BallQuery` and similar structs will follow a standard API
+format, but otherwise remain as independent types.
+
+Neighbor queries are the first example where `hoomd-order` provides convenience
+methods that operate on `Microstate`. The provided queries will take in `&Microstate`
+and use its `iter_sites_near` method.
+
+## Site tags
+
+The concept of site tags has already come up in the neighbor query design. This is
+a feature that [`freud`] lacks (almost) entirely. `hoomd-order` will employ site tags
+whenever they are needed, such as avoiding the *i* site in a neighbor query.
+When tags are not necessary (such as in the base `k_atic_phi` method), `hoomd-order`
+will not require them following the simplicity rule.
+
+Other analysis methods will need the concept of a tag implicitly. For example,
+the average Steinhardt order parameter needs to know a) the non-averaged order
+parameter for each site tag and b) the tags of neighbors of site with a given tag.
+For generality, the `average_over_neighbors` method will be general so that
+it can be applied to any quantity, not just Steinhardt. Its design remains TBD
+as of this writing, but might likely involve a `HashMap` that maps tags to
+`q` values.
+
+It's neighbor query is not an iterator, but a callable that produces
+the neighboring tags given a tag. The neighbor queries built around `Mircostate`
+can of course provide this callable. Users working outside `Microstate` will need
+to implement some sort of equivalent data structures to use `average_over_neighbors`.
+Note that the neighbor query customization path is different for this type of
+signature. When `neighbors` is an iterator, callers can customize it by chaining.
+When it is a callable, they need to implement a new callable (which can contain
+the same chain as above). It might be advantageous to have only one API for this,
+but forcing the concept of tags into methods like `k_atic_psi` breaks the
+simplicity design goal.
+
+In this scheme, callers will still need to build the `HashMap` directly as
+the *simplicty* goal precludes analysis methods that operate on the whole
+`Microstate` (unless strictly necessary). We can provide a fully working
+example in the documentation for users to copy and paste.
+
+Clustering is another example where tags will be inherent even in the general
+implementation.

--- a/hoomd-order/ARCHITECTURE.md
+++ b/hoomd-order/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 The `hoomd-order` crate implements order parameters and other related calculations,
 such as k-atic, Steinhardt, radial distribution functions, and spatial correlation
-functions. It is the evolution of the functionality available in the [`freud`] Python
+functions. It is an evolution of the functionality available in the [`freud`] Python
 package.
 
 ## Design goals
@@ -25,15 +25,15 @@ methods that operate on `Microstate`.
 
 ### Simplicity
 
-All methods in `hoomd-order` should be the most natural possible expression
-of the underlying mathematical operation. This provides complete clarity to
-the caller so that there is no ambiguity over what input maps to what
+All method signatures in `hoomd-order` should be the most natural possible
+expression of the underlying mathematical operation. This provides complete
+clarity to the caller so that there is no ambiguity over what input maps to what
 (see e.g. the confusion over `query_points` and `points` in [`freud]`).
 
 For example, the k-atic order parameter can be expressed as a function with
 the signature:
 ```rust
-fn k_atic_psi<I: IntoIterator<Item=Cartesian<2>>>(k: f64, r_i: Cartesian<2>, neighbors: I) -> Complex<f64>;
+fn k_atic_psi<I: IntoIterator<Item=Cartesian<2>>>(k: f64, r_i: &Cartesian<2>, neighbors: I) -> Complex<f64>;
 ```
 
 Analysis methods should be exposed as functions where possible and structs only when
@@ -42,14 +42,14 @@ they need to store some internal state (such as the g(r) histogram).
 Note that unlike in [`freud`], the k-atic function computes an order parameter for
 a single point rather than for an entire system of points. This grants the caller
 the flexibility to call it only when needed for specific points without the need
-to design a complicated filter/selection system.
+for a complicated filter/selection system.
 
 [`freud`]: https://freud.readthedocs.io/en/latest/
 
 ## Neighbor queries
 
 As shown in the `k_atic_psi` signature above, neighbor queries in `hoomd-order`
-simply become iterators. The iterator item depends on context, sometimes it may
+are iterators. The iterator item depends on context, sometimes it may
 be only position while other methods might need position and orientation, or
 position, orientation, and weight. This grants the caller infinite flexibility.
 For example, they could form a chain of iterators starting with
@@ -88,16 +88,15 @@ will not require them following the simplicity rule.
 
 Other analysis methods will need the concept of a tag implicitly. For example,
 the average Steinhardt order parameter needs to know a) the non-averaged order
-parameter for each site tag and b) the tags of neighbors of site with a given tag.
-For generality, the `average_over_neighbors` method will be general so that
-it can be applied to any quantity, not just Steinhardt. Its design remains TBD
-as of this writing, but might likely involve a `HashMap` that maps tags to
-`q` values.
+parameter for each site tag and b) the tags of neighbors of site with a given
+tag. The `average_over_neighbors` method will be general so that it can be
+applied to any quantity, not just Steinhardt. Its design remains TBD as of this
+writing, but will likely involve a `HashMap` that maps tags to `q` values.
 
 It's neighbor query is not an iterator, but a callable that produces
 the neighboring tags given a tag. The neighbor queries built around `Mircostate`
 can of course provide this callable. Users working outside `Microstate` will need
-to implement some sort of equivalent data structures to use `average_over_neighbors`.
+to implement some sort of equivalent data structures to use methods like `average_over_neighbors`.
 Note that the neighbor query customization path is different for this type of
 signature. When `neighbors` is an iterator, callers can customize it by chaining.
 When it is a callable, they need to implement a new callable (which can contain

--- a/hoomd-order/Cargo.toml
+++ b/hoomd-order/Cargo.toml
@@ -12,10 +12,11 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+num-complex.workspace = true
+
 hoomd-microstate.workspace = true
 hoomd-spatial.workspace = true
 hoomd-vector.workspace = true
-num-complex.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true
@@ -25,6 +26,8 @@ itertools.workspace = true
 rand.workspace = true
 rstest.workspace = true
 sphrs.workspace = true
+
+hoomd-geometry.workspace = true
 
 [lints]
 workspace = true

--- a/hoomd-order/Cargo.toml
+++ b/hoomd-order/Cargo.toml
@@ -13,6 +13,7 @@ categories.workspace = true
 
 [dependencies]
 num-complex.workspace = true
+thiserror.workspace = true
 
 hoomd-microstate.workspace = true
 hoomd-spatial.workspace = true

--- a/hoomd-order/Cargo.toml
+++ b/hoomd-order/Cargo.toml
@@ -18,8 +18,10 @@ hoomd-vector.workspace = true
 num-complex.workspace = true
 
 [dev-dependencies]
+anyhow.workspace = true
 approxim.workspace = true
 divan.workspace = true
+itertools.workspace = true
 rand.workspace = true
 rstest.workspace = true
 sphrs.workspace = true

--- a/hoomd-order/Cargo.toml
+++ b/hoomd-order/Cargo.toml
@@ -12,6 +12,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+hoomd-microstate.workspace = true
+hoomd-spatial.workspace = true
 hoomd-vector.workspace = true
 num-complex.workspace = true
 

--- a/hoomd-order/src/average_over_neighbors.rs
+++ b/hoomd-order/src/average_over_neighbors.rs
@@ -1,0 +1,139 @@
+// Copyright (c) 2024-2026 The Regents of the University of Michigan.
+// Part of hoomd-rs, released under the BSD 3-Clause License.
+
+//! Implement `average_over_neighbors`
+
+use std::{
+    collections::HashMap,
+    ops::{AddAssign, Div},
+};
+
+use crate::Error;
+
+/// Average a quantity over the neighbors around a site.
+///
+/// The average quantity is:
+/// ```math
+/// \bar{x}_i = \frac{1}{n_i} \sum_j x_j
+/// ```
+/// where $` n_i `$ is the number of *j* tags produced by the iterator `neighbors(i)`.
+///
+/// # Errors
+///
+/// [`Error::SiteTagMissing`] when any *j* produced by a `neighbors` iterator is not present
+/// as a key in `x`.
+///
+/// # Example
+///
+/// Estimate the position of a lattice site as the average of the nearest neighbor positions:
+/// ```
+/// use std::collections::HashMap;
+///
+/// use hoomd_geometry::shape::Rectangle;
+/// use hoomd_microstate::{Body, Microstate, Replicate, boundary::Periodic};
+/// use hoomd_order::SitesInBall;
+/// use hoomd_spatial::VecCell;
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let model_maximum_interaction_range: f64 = 1.0;
+/// let order_maximum_neighbor_distance: f64 = 1.5;
+/// let maximum_interaction_range =
+///     model_maximum_interaction_range.max(order_maximum_neighbor_distance);
+///
+/// let unit_cell_square = Rectangle::with_equal_edges(1.0.try_into()?);
+/// let periodic_unit_cell = Periodic::new(0.0, unit_cell_square)?;
+/// let vec_cell = VecCell::builder()
+///     .nominal_search_radius(model_maximum_interaction_range.try_into()?)
+///     .maximum_search_radius(maximum_interaction_range)
+///     .build();
+/// let microstate = Microstate::builder()
+///     .boundary(periodic_unit_cell)
+///     .spatial_data(vec_cell)
+///     .bodies([Body::point(Cartesian::default())])
+///     .try_build()?
+///     .replicate_with_maximum_interaction_range(
+///         [16; 2],
+///         maximum_interaction_range,
+///     )?;
+///
+/// let mut r: HashMap<usize, Cartesian<2>> = microstate
+///     .sites()
+///     .iter()
+///     .map(|s| (s.site_tag, s.properties.position))
+///     .collect();
+/// let r_average = hoomd_order::average_over_neighbors(&r, |site_tag| {
+///     SitesInBall::near_site(
+///         &microstate,
+///         microstate.site_indices()[site_tag].expect("site tag should be present"),
+///         order_maximum_neighbor_distance,
+///     )
+///     .iter_site_tags()
+///     .collect::<Vec<_>>()
+/// })?;
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn average_over_neighbors<T, F, I, S>(
+    x: &HashMap<usize, T, S>,
+    neighbor_tags: F,
+) -> Result<HashMap<usize, T, S>, Error>
+where
+    T: AddAssign + Copy + Default + Div<f64, Output = T>,
+    F: Fn(usize) -> I,
+    I: IntoIterator<Item = usize>,
+    S: ::std::hash::BuildHasher + Default,
+{
+    let mut result = HashMap::with_capacity_and_hasher(x.len(), S::default());
+
+    for site_tag_i in x.keys() {
+        let mut total = T::default();
+        let mut count = 0;
+
+        for site_tag_j in neighbor_tags(*site_tag_i) {
+            total += *x
+                .get(&site_tag_j)
+                .ok_or(Error::SiteTagMissing(site_tag_j, *site_tag_i))?;
+            count += 1;
+        }
+
+        result.insert(*site_tag_i, total / f64::from(count));
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use approxim::assert_relative_eq;
+
+    #[test]
+    fn base_case() -> anyhow::Result<()> {
+        let neighbors: [Vec<usize>; 4] = [vec![1, 2, 3], vec![0], vec![0, 3], vec![0, 2]];
+        let x: HashMap<usize, f64> = [(0, 1.0), (1, 3.0), (2, 2.0), (3, 4.0)]
+            .into_iter()
+            .collect();
+
+        let x_average = average_over_neighbors(&x, |tag| neighbors[tag].iter().copied())?;
+        assert_eq!(x_average.len(), 4);
+        assert_relative_eq!(x_average.get(&0).unwrap(), &3.0);
+        assert_relative_eq!(x_average.get(&1).unwrap(), &1.0);
+        assert_relative_eq!(x_average.get(&2).unwrap(), &2.5);
+        assert_relative_eq!(x_average.get(&3).unwrap(), &1.5);
+
+        Ok(())
+    }
+
+    #[test]
+    fn missing_neighbor() {
+        let neighbors: [Vec<usize>; 1] = [vec![1, 2, 3]];
+        let x: HashMap<usize, f64> = [(0, 1.0)].into_iter().collect();
+
+        assert!(matches!(
+            average_over_neighbors(&x, |tag| neighbors[tag].iter().copied()),
+            Err(Error::SiteTagMissing(1, 0))
+        ));
+    }
+}

--- a/hoomd-order/src/k_atic_psi.rs
+++ b/hoomd-order/src/k_atic_psi.rs
@@ -1,0 +1,23 @@
+// Copyright (c) 2024-2026 The Regents of the University of Michigan.
+// Part of hoomd-rs, released under the BSD 3-Clause License.
+
+//! Implement `k_atic_psi`
+
+use num_complex::Complex;
+
+use hoomd_vector::Cartesian;
+
+/// Compute the 2D *k-atic* order parameter $` \psi_k `$.
+///
+/// Let the `neighbors` iterator produce `n` points; $` \vec{r}_j `$.
+/// 
+/// The *k-atic* order parameter is given by:
+/// ```math
+/// \psi_k = \frac{1}{n} \sum \limits_j e^{k i \theta_{ij}}
+/// ```
+/// where $` \theta_{ij} `$ is the polar angle of the vector
+/// $`\vec{r}_{ij} = \vec{r}_j - \vec{r}_i`$.
+#[inline]
+pub fn k_atic_psi<I: IntoIterator<Item=Cartesian<2>>>(k: f64, r_i: Cartesian<2>, neighbors: I) -> Complex<f64> {
+    Complex::default()
+}

--- a/hoomd-order/src/k_atic_psi.rs
+++ b/hoomd-order/src/k_atic_psi.rs
@@ -28,6 +28,8 @@ use hoomd_vector::Cartesian;
 ///
 /// assert_relative_eq!(psi, Complex::new(1.0, 0.0), epsilon = 1e-12);
 /// ```
+///
+/// TODO: Example with microstate and `k_atic_psi` on all sites using `SitesInBall`.
 #[inline]
 pub fn k_atic_psi<I: IntoIterator<Item=Cartesian<2>>>(k: f64, r: &Cartesian<2>, neighbors: I) -> Complex<f64> {
     let mut total: Complex<f64> = Complex::default();

--- a/hoomd-order/src/k_atic_psi.rs
+++ b/hoomd-order/src/k_atic_psi.rs
@@ -18,13 +18,18 @@ use hoomd_vector::Cartesian;
 ///
 /// # Example
 ///
-/// Compute $` \psi `$ for a single arrangement of points:
+/// Compute $` \psi_4 `$ for a single arrangement of points:
 /// ```
-/// use num_complex::Complex;
 /// use approxim::assert_relative_eq;
+/// use num_complex::Complex;
 ///
 /// let r = [0.0, 0.0].into();
-/// let neighbors = [[1.0, 0.0].into(), [0.0, 1.0].into(), [-1.0, 0.0].into(), [0.0, -1.0].into()];
+/// let neighbors = [
+///     [1.0, 0.0].into(),
+///     [0.0, 1.0].into(),
+///     [-1.0, 0.0].into(),
+///     [0.0, -1.0].into(),
+/// ];
 /// let psi = hoomd_order::k_atic_psi(4.0, &r, neighbors);
 ///
 /// assert_relative_eq!(psi, Complex::new(1.0, 0.0), epsilon = 1e-12);
@@ -35,7 +40,7 @@ use hoomd_vector::Cartesian;
 /// use std::collections::HashMap;
 ///
 /// use hoomd_geometry::shape::Rectangle;
-/// use hoomd_microstate::{Microstate, Body, Replicate, boundary::Periodic};
+/// use hoomd_microstate::{Body, Microstate, Replicate, boundary::Periodic};
 /// use hoomd_order::SitesInBall;
 /// use hoomd_spatial::VecCell;
 /// use hoomd_vector::Cartesian;
@@ -43,7 +48,8 @@ use hoomd_vector::Cartesian;
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let model_maximum_interaction_range: f64 = 1.0;
 /// let order_maximum_neighbor_distance: f64 = 1.5;
-/// let maximum_interaction_range = model_maximum_interaction_range.max(order_maximum_neighbor_distance);
+/// let maximum_interaction_range =
+///     model_maximum_interaction_range.max(order_maximum_neighbor_distance);
 ///
 /// let unit_cell_square = Rectangle::with_equal_edges(1.0.try_into()?);
 /// let periodic_unit_cell = Periodic::new(0.0, unit_cell_square)?;
@@ -63,17 +69,32 @@ use hoomd_vector::Cartesian;
 ///
 /// let mut psi_4 = HashMap::new();
 /// for (site_index, site) in microstate.sites().iter().enumerate() {
-///     let neighbors = SitesInBall::near_site(&microstate, site_index, order_maximum_neighbor_distance);
-///     psi_4.insert(site.site_tag, hoomd_order::k_atic_psi(4.0, &site.properties.position, neighbors.iter_site_positions().copied()));
+///     let neighbors = SitesInBall::near_site(
+///         &microstate,
+///         site_index,
+///         order_maximum_neighbor_distance,
+///     );
+///     psi_4.insert(
+///         site.site_tag,
+///         hoomd_order::k_atic_psi(
+///             4.0,
+///             &site.properties.position,
+///             neighbors.iter_site_positions().copied(),
+///         ),
+///     );
 /// }
 /// # Ok(())
 /// # }
 /// ```
 #[inline]
-pub fn k_atic_psi<I: IntoIterator<Item=Cartesian<2>>>(k: f64, r: &Cartesian<2>, neighbors: I) -> Complex<f64> {
+pub fn k_atic_psi<I: IntoIterator<Item = Cartesian<2>>>(
+    k: f64,
+    r: &Cartesian<2>,
+    neighbors: I,
+) -> Complex<f64> {
     let mut total: Complex<f64> = Complex::default();
     let mut count: usize = 0;
-    
+
     for r_j in neighbors {
         let delta_r = r_j - *r;
         let theta = delta_r[1].atan2(delta_r[0]);
@@ -95,12 +116,36 @@ mod tests {
         let r = [0.0, 0.0].into();
         let neighbors = [[1.0, 0.0].into()];
 
-        assert_relative_eq!(k_atic_psi(1.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(3.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(4.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(5.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(6.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(
+            k_atic_psi(1.0, &r, neighbors),
+            Complex::new(1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(2.0, &r, neighbors),
+            Complex::new(1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(3.0, &r, neighbors),
+            Complex::new(1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(4.0, &r, neighbors),
+            Complex::new(1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(5.0, &r, neighbors),
+            Complex::new(1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(6.0, &r, neighbors),
+            Complex::new(1.0, 0.0),
+            epsilon = 1e-12
+        );
     }
 
     #[test]
@@ -108,46 +153,172 @@ mod tests {
         let r = [-5.0, 4.0].into();
         let neighbors = [[-4.0, 4.0].into()];
 
-        assert_relative_eq!(k_atic_psi(1.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(3.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(4.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(5.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(6.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(
+            k_atic_psi(1.0, &r, neighbors),
+            Complex::new(1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(2.0, &r, neighbors),
+            Complex::new(1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(3.0, &r, neighbors),
+            Complex::new(1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(4.0, &r, neighbors),
+            Complex::new(1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(5.0, &r, neighbors),
+            Complex::new(1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(6.0, &r, neighbors),
+            Complex::new(1.0, 0.0),
+            epsilon = 1e-12
+        );
     }
 
     #[test]
     fn rotated() {
         let r = [0.0, 0.0].into();
 
-        assert_relative_eq!(k_atic_psi(2.0, &r, [[1.0, 0.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r, [[-1.0, 0.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r, [[0.0, 1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r, [[0.0, -1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r, [[1.0, 1.0].into()]), Complex::new(0.0, 1.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r, [[1.0, -1.0].into()]), Complex::new(0.0, -1.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r, [[-1.0, 1.0].into()]), Complex::new(0.0, -1.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r, [[-1.0, -1.0].into()]), Complex::new(0.0, 1.0), epsilon = 1e-12);
+        assert_relative_eq!(
+            k_atic_psi(2.0, &r, [[1.0, 0.0].into()]),
+            Complex::new(1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(2.0, &r, [[-1.0, 0.0].into()]),
+            Complex::new(1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(2.0, &r, [[0.0, 1.0].into()]),
+            Complex::new(-1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(2.0, &r, [[0.0, -1.0].into()]),
+            Complex::new(-1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(2.0, &r, [[1.0, 1.0].into()]),
+            Complex::new(0.0, 1.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(2.0, &r, [[1.0, -1.0].into()]),
+            Complex::new(0.0, -1.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(2.0, &r, [[-1.0, 1.0].into()]),
+            Complex::new(0.0, -1.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(2.0, &r, [[-1.0, -1.0].into()]),
+            Complex::new(0.0, 1.0),
+            epsilon = 1e-12
+        );
 
-        assert_relative_eq!(k_atic_psi(4.0, &r, [[1.0, 0.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(4.0, &r, [[0.0, 1.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(4.0, &r, [[-1.0, 0.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(4.0, &r, [[0.0, -1.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(4.0, &r, [[1.0, 1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(4.0, &r, [[1.0, -1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(4.0, &r, [[-1.0, 1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(4.0, &r, [[-1.0, -1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(
+            k_atic_psi(4.0, &r, [[1.0, 0.0].into()]),
+            Complex::new(1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(4.0, &r, [[0.0, 1.0].into()]),
+            Complex::new(1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(4.0, &r, [[-1.0, 0.0].into()]),
+            Complex::new(1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(4.0, &r, [[0.0, -1.0].into()]),
+            Complex::new(1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(4.0, &r, [[1.0, 1.0].into()]),
+            Complex::new(-1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(4.0, &r, [[1.0, -1.0].into()]),
+            Complex::new(-1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(4.0, &r, [[-1.0, 1.0].into()]),
+            Complex::new(-1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(4.0, &r, [[-1.0, -1.0].into()]),
+            Complex::new(-1.0, 0.0),
+            epsilon = 1e-12
+        );
     }
 
     #[test]
     fn average() {
         let r = [0.0, 0.0].into();
 
-        assert_relative_eq!(k_atic_psi(2.0, &r, [[1.0, 0.0].into(), [-1.0, 0.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r, [[0.0, 1.0].into(), [0.0, -1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r, [[-1.0, 1.0].into(), [-1.0, -1.0].into()]), Complex::new(0.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(
+            k_atic_psi(2.0, &r, [[1.0, 0.0].into(), [-1.0, 0.0].into()]),
+            Complex::new(1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(2.0, &r, [[0.0, 1.0].into(), [0.0, -1.0].into()]),
+            Complex::new(-1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(2.0, &r, [[-1.0, 1.0].into(), [-1.0, -1.0].into()]),
+            Complex::new(0.0, 0.0),
+            epsilon = 1e-12
+        );
 
-        assert_relative_eq!(k_atic_psi(4.0, &r, [[1.0, 0.0].into(), [0.0, 1.0].into(), [-1.0, 0.0].into(), [0.0, -1.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(4.0, &r, [[1.0, 1.0].into(), [1.0, -1.0].into(), [-1.0, 1.0].into(), [-1.0, -1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(
+            k_atic_psi(
+                4.0,
+                &r,
+                [
+                    [1.0, 0.0].into(),
+                    [0.0, 1.0].into(),
+                    [-1.0, 0.0].into(),
+                    [0.0, -1.0].into()
+                ]
+            ),
+            Complex::new(1.0, 0.0),
+            epsilon = 1e-12
+        );
+        assert_relative_eq!(
+            k_atic_psi(
+                4.0,
+                &r,
+                [
+                    [1.0, 1.0].into(),
+                    [1.0, -1.0].into(),
+                    [-1.0, 1.0].into(),
+                    [-1.0, -1.0].into()
+                ]
+            ),
+            Complex::new(-1.0, 0.0),
+            epsilon = 1e-12
+        );
     }
 }

--- a/hoomd-order/src/k_atic_psi.rs
+++ b/hoomd-order/src/k_atic_psi.rs
@@ -18,6 +18,7 @@ use hoomd_vector::Cartesian;
 ///
 /// # Example
 ///
+/// Compute $` \psi `$ for a single arrangement of points:
 /// ```
 /// use num_complex::Complex;
 /// use approxim::assert_relative_eq;
@@ -29,7 +30,45 @@ use hoomd_vector::Cartesian;
 /// assert_relative_eq!(psi, Complex::new(1.0, 0.0), epsilon = 1e-12);
 /// ```
 ///
-/// TODO: Example with microstate and `k_atic_psi` on all sites using `SitesInBall`.
+/// Compute $` \psi_4 `$ for all sites in a microstate:
+/// ```
+/// use std::collections::HashMap;
+///
+/// use hoomd_geometry::shape::Rectangle;
+/// use hoomd_microstate::{Microstate, Body, Replicate, boundary::Periodic};
+/// use hoomd_order::SitesInBall;
+/// use hoomd_spatial::VecCell;
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let model_maximum_interaction_range: f64 = 1.0;
+/// let order_maximum_neighbor_distance: f64 = 1.5;
+/// let maximum_interaction_range = model_maximum_interaction_range.max(order_maximum_neighbor_distance);
+///
+/// let unit_cell_square = Rectangle::with_equal_edges(1.0.try_into()?);
+/// let periodic_unit_cell = Periodic::new(0.0, unit_cell_square)?;
+/// let vec_cell = VecCell::builder()
+///     .nominal_search_radius(model_maximum_interaction_range.try_into()?)
+///     .maximum_search_radius(maximum_interaction_range)
+///     .build();
+/// let microstate = Microstate::builder()
+///     .boundary(periodic_unit_cell)
+///     .spatial_data(vec_cell)
+///     .bodies([Body::point(Cartesian::default())])
+///     .try_build()?
+///     .replicate_with_maximum_interaction_range(
+///         [16; 2],
+///         maximum_interaction_range,
+///     )?;
+///
+/// let mut psi_4 = HashMap::new();
+/// for (site_index, site) in microstate.sites().iter().enumerate() {
+///     let neighbors = SitesInBall::near_site(&microstate, site_index, order_maximum_neighbor_distance);
+///     psi_4.insert(site.site_tag, hoomd_order::k_atic_psi(4.0, &site.properties.position, neighbors.iter_site_positions().copied()));
+/// }
+/// # Ok(())
+/// # }
+/// ```
 #[inline]
 pub fn k_atic_psi<I: IntoIterator<Item=Cartesian<2>>>(k: f64, r: &Cartesian<2>, neighbors: I) -> Complex<f64> {
     let mut total: Complex<f64> = Complex::default();
@@ -46,7 +85,7 @@ pub fn k_atic_psi<I: IntoIterator<Item=Cartesian<2>>>(k: f64, r: &Cartesian<2>, 
     total / Complex::new(count as f64, 0.0)
 }
 
- #[cfg(test)]
+#[cfg(test)]
 mod tests {
     use super::*;
     use approxim::assert_relative_eq;

--- a/hoomd-order/src/k_atic_psi.rs
+++ b/hoomd-order/src/k_atic_psi.rs
@@ -13,11 +13,102 @@ use hoomd_vector::Cartesian;
 /// 
 /// The *k-atic* order parameter is given by:
 /// ```math
-/// \psi_k = \frac{1}{n} \sum \limits_j e^{k i \theta_{ij}}
+/// \psi_k = \frac{1}{n} \sum \limits_j e^{i k \theta_{ij}}
 /// ```
 /// where $` \theta_{ij} `$ is the polar angle of the vector
 /// $`\vec{r}_{ij} = \vec{r}_j - \vec{r}_i`$.
+///
+/// # Example
+///
+/// ```
+/// use num_complex::Complex;
+/// use approxim::assert_relative_eq;
+///
+/// let r_i = [0.0, 0.0].into();
+/// let neighbors = [[1.0, 0.0].into(), [0.0, 1.0].into(), [-1.0, 0.0].into(), [0.0, -1.0].into()];
+/// let psi = hoomd_order::k_atic_psi(4.0, &r_i, neighbors);
+///
+/// assert_relative_eq!(psi, Complex::new(1.0, 0.0), epsilon = 1e-12);
+/// ```
 #[inline]
-pub fn k_atic_psi<I: IntoIterator<Item=Cartesian<2>>>(k: f64, r_i: Cartesian<2>, neighbors: I) -> Complex<f64> {
-    Complex::default()
+pub fn k_atic_psi<I: IntoIterator<Item=Cartesian<2>>>(k: f64, r_i: &Cartesian<2>, neighbors: I) -> Complex<f64> {
+    let mut total: Complex<f64> = Complex::default();
+    let mut count: usize = 0;
+    
+    for r_j in neighbors {
+        let delta_r = r_j - *r_i;
+        let theta = delta_r[1].atan2(delta_r[0]);
+        let (sin, cos) = (k * theta).sin_cos();
+        total += Complex::new(cos, sin);
+        count += 1;
+    }
+
+    total / Complex::new(count as f64, 0.0)
+}
+
+ #[cfg(test)]
+mod tests {
+    use super::*;
+    use approxim::assert_relative_eq;
+
+    #[test]
+    fn single() {
+        let r_i = [0.0, 0.0].into();
+        let neighbors = [[1.0, 0.0].into()];
+
+        assert_relative_eq!(k_atic_psi(1.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(3.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(5.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(6.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+    }
+
+    #[test]
+    fn shifted() {
+        let r_i = [-5.0, 4.0].into();
+        let neighbors = [[-4.0, 4.0].into()];
+
+        assert_relative_eq!(k_atic_psi(1.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(3.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(5.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(6.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+    }
+
+    #[test]
+    fn rotated() {
+        let r_i = [0.0, 0.0].into();
+
+        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[1.0, 0.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[-1.0, 0.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[0.0, 1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[0.0, -1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[1.0, 1.0].into()]), Complex::new(0.0, 1.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[1.0, -1.0].into()]), Complex::new(0.0, -1.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[-1.0, 1.0].into()]), Complex::new(0.0, -1.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[-1.0, -1.0].into()]), Complex::new(0.0, 1.0), epsilon = 1e-12);
+
+        assert_relative_eq!(k_atic_psi(4.0, &r_i, [[1.0, 0.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r_i, [[0.0, 1.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r_i, [[-1.0, 0.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r_i, [[0.0, -1.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r_i, [[1.0, 1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r_i, [[1.0, -1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r_i, [[-1.0, 1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r_i, [[-1.0, -1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
+    }
+
+    #[test]
+    fn average() {
+        let r_i = [0.0, 0.0].into();
+
+        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[1.0, 0.0].into(), [-1.0, 0.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[0.0, 1.0].into(), [0.0, -1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[-1.0, 1.0].into(), [-1.0, -1.0].into()]), Complex::new(0.0, 0.0), epsilon = 1e-12);
+
+        assert_relative_eq!(k_atic_psi(4.0, &r_i, [[1.0, 0.0].into(), [0.0, 1.0].into(), [-1.0, 0.0].into(), [0.0, -1.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r_i, [[1.0, 1.0].into(), [1.0, -1.0].into(), [-1.0, 1.0].into(), [-1.0, -1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
+    }
 }

--- a/hoomd-order/src/k_atic_psi.rs
+++ b/hoomd-order/src/k_atic_psi.rs
@@ -9,14 +9,12 @@ use hoomd_vector::Cartesian;
 
 /// Compute the 2D *k-atic* order parameter $` \psi_k `$.
 ///
-/// Let the `neighbors` iterator produce `n` points; $` \vec{r}_j `$.
-/// 
-/// The *k-atic* order parameter is given by:
+/// Let the `neighbors` iterator produce `n` points $` \vec{r}_j `$ and
+/// $` \theta_j `$ be the polar angle of the vector $`\vec{r}_j - \vec{r}`$.
+/// The *k-atic* order parameter is then:
 /// ```math
-/// \psi_k = \frac{1}{n} \sum \limits_j e^{i k \theta_{ij}}
+/// \psi_k = \frac{1}{n} \sum_j e^{i k \theta_j}
 /// ```
-/// where $` \theta_{ij} `$ is the polar angle of the vector
-/// $`\vec{r}_{ij} = \vec{r}_j - \vec{r}_i`$.
 ///
 /// # Example
 ///
@@ -24,19 +22,19 @@ use hoomd_vector::Cartesian;
 /// use num_complex::Complex;
 /// use approxim::assert_relative_eq;
 ///
-/// let r_i = [0.0, 0.0].into();
+/// let r = [0.0, 0.0].into();
 /// let neighbors = [[1.0, 0.0].into(), [0.0, 1.0].into(), [-1.0, 0.0].into(), [0.0, -1.0].into()];
-/// let psi = hoomd_order::k_atic_psi(4.0, &r_i, neighbors);
+/// let psi = hoomd_order::k_atic_psi(4.0, &r, neighbors);
 ///
 /// assert_relative_eq!(psi, Complex::new(1.0, 0.0), epsilon = 1e-12);
 /// ```
 #[inline]
-pub fn k_atic_psi<I: IntoIterator<Item=Cartesian<2>>>(k: f64, r_i: &Cartesian<2>, neighbors: I) -> Complex<f64> {
+pub fn k_atic_psi<I: IntoIterator<Item=Cartesian<2>>>(k: f64, r: &Cartesian<2>, neighbors: I) -> Complex<f64> {
     let mut total: Complex<f64> = Complex::default();
     let mut count: usize = 0;
     
     for r_j in neighbors {
-        let delta_r = r_j - *r_i;
+        let delta_r = r_j - *r;
         let theta = delta_r[1].atan2(delta_r[0]);
         let (sin, cos) = (k * theta).sin_cos();
         total += Complex::new(cos, sin);
@@ -53,62 +51,62 @@ mod tests {
 
     #[test]
     fn single() {
-        let r_i = [0.0, 0.0].into();
+        let r = [0.0, 0.0].into();
         let neighbors = [[1.0, 0.0].into()];
 
-        assert_relative_eq!(k_atic_psi(1.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(3.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(4.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(5.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(6.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(1.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(3.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(5.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(6.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
     }
 
     #[test]
     fn shifted() {
-        let r_i = [-5.0, 4.0].into();
+        let r = [-5.0, 4.0].into();
         let neighbors = [[-4.0, 4.0].into()];
 
-        assert_relative_eq!(k_atic_psi(1.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(3.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(4.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(5.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(6.0, &r_i, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(1.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(3.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(5.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(6.0, &r, neighbors), Complex::new(1.0, 0.0), epsilon = 1e-12);
     }
 
     #[test]
     fn rotated() {
-        let r_i = [0.0, 0.0].into();
+        let r = [0.0, 0.0].into();
 
-        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[1.0, 0.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[-1.0, 0.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[0.0, 1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[0.0, -1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[1.0, 1.0].into()]), Complex::new(0.0, 1.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[1.0, -1.0].into()]), Complex::new(0.0, -1.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[-1.0, 1.0].into()]), Complex::new(0.0, -1.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[-1.0, -1.0].into()]), Complex::new(0.0, 1.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r, [[1.0, 0.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r, [[-1.0, 0.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r, [[0.0, 1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r, [[0.0, -1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r, [[1.0, 1.0].into()]), Complex::new(0.0, 1.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r, [[1.0, -1.0].into()]), Complex::new(0.0, -1.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r, [[-1.0, 1.0].into()]), Complex::new(0.0, -1.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r, [[-1.0, -1.0].into()]), Complex::new(0.0, 1.0), epsilon = 1e-12);
 
-        assert_relative_eq!(k_atic_psi(4.0, &r_i, [[1.0, 0.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(4.0, &r_i, [[0.0, 1.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(4.0, &r_i, [[-1.0, 0.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(4.0, &r_i, [[0.0, -1.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(4.0, &r_i, [[1.0, 1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(4.0, &r_i, [[1.0, -1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(4.0, &r_i, [[-1.0, 1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(4.0, &r_i, [[-1.0, -1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r, [[1.0, 0.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r, [[0.0, 1.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r, [[-1.0, 0.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r, [[0.0, -1.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r, [[1.0, 1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r, [[1.0, -1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r, [[-1.0, 1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r, [[-1.0, -1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
     }
 
     #[test]
     fn average() {
-        let r_i = [0.0, 0.0].into();
+        let r = [0.0, 0.0].into();
 
-        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[1.0, 0.0].into(), [-1.0, 0.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[0.0, 1.0].into(), [0.0, -1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(2.0, &r_i, [[-1.0, 1.0].into(), [-1.0, -1.0].into()]), Complex::new(0.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r, [[1.0, 0.0].into(), [-1.0, 0.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r, [[0.0, 1.0].into(), [0.0, -1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(2.0, &r, [[-1.0, 1.0].into(), [-1.0, -1.0].into()]), Complex::new(0.0, 0.0), epsilon = 1e-12);
 
-        assert_relative_eq!(k_atic_psi(4.0, &r_i, [[1.0, 0.0].into(), [0.0, 1.0].into(), [-1.0, 0.0].into(), [0.0, -1.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
-        assert_relative_eq!(k_atic_psi(4.0, &r_i, [[1.0, 1.0].into(), [1.0, -1.0].into(), [-1.0, 1.0].into(), [-1.0, -1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r, [[1.0, 0.0].into(), [0.0, 1.0].into(), [-1.0, 0.0].into(), [0.0, -1.0].into()]), Complex::new(1.0, 0.0), epsilon = 1e-12);
+        assert_relative_eq!(k_atic_psi(4.0, &r, [[1.0, 1.0].into(), [1.0, -1.0].into(), [-1.0, 1.0].into(), [-1.0, -1.0].into()]), Complex::new(-1.0, 0.0), epsilon = 1e-12);
     }
 }

--- a/hoomd-order/src/lib.rs
+++ b/hoomd-order/src/lib.rs
@@ -4,3 +4,6 @@
 //! TODO
 
 pub mod math;
+
+mod k_atic_psi;
+pub use k_atic_psi::k_atic_psi;

--- a/hoomd-order/src/lib.rs
+++ b/hoomd-order/src/lib.rs
@@ -10,3 +10,6 @@ pub use k_atic_psi::k_atic_psi;
 
 mod steinhardt;
 pub use steinhardt::Steinhardt;
+
+mod sites_in_ball;
+pub use sites_in_ball::SitesInBall;

--- a/hoomd-order/src/lib.rs
+++ b/hoomd-order/src/lib.rs
@@ -12,6 +12,23 @@
 //! or the overall maximum range (when more time is spent evaluating order
 //! parameters).
 
+use hoomd_vector::Cartesian;
+use thiserror::Error;
+
+/// Enumerate possible sources of error in fallible hoomd-order methods.
+#[non_exhaustive]
+#[derive(Error, PartialEq, Debug)]
+pub enum Error {
+    /// Failed to convert `r_j` - `r` to a unit vector.
+    #[error("{0} - {1} could not be converted to a unit vector")]
+    InvalidDeltaR3(Cartesian<3>, Cartesian<3>, #[source] hoomd_vector::Error),
+    /// Neighbor site tag missing in value map.
+    #[error(
+        "the site with tag {0} (a neighbor of the site tag {1}) is not present in the value map"
+    )]
+    SiteTagMissing(usize, usize),
+}
+
 pub mod math;
 
 mod k_atic_psi;
@@ -22,3 +39,6 @@ pub use steinhardt::Steinhardt;
 
 mod sites_in_ball;
 pub use sites_in_ball::SitesInBall;
+
+mod average_over_neighbors;
+pub use average_over_neighbors::average_over_neighbors;

--- a/hoomd-order/src/lib.rs
+++ b/hoomd-order/src/lib.rs
@@ -7,3 +7,6 @@ pub mod math;
 
 mod k_atic_psi;
 pub use k_atic_psi::k_atic_psi;
+
+mod steinhardt;
+pub use steinhardt::Steinhardt;

--- a/hoomd-order/src/lib.rs
+++ b/hoomd-order/src/lib.rs
@@ -1,7 +1,16 @@
 // Copyright (c) 2024-2026 The Regents of the University of Michigan.
 // Part of hoomd-rs, released under the BSD 3-Clause License.
 
-//! TODO
+//! TODO: Overview and examples
+//! # Tips
+//!
+//! When using a microstate for both simulation and analysis, set the maximum
+//! interaction range to the larger of the model's maximum interaction range and
+//! the largest neighbor distance you will use when computing order parameters.
+//! You may get better performance setting `nominal_search_radius` to the
+//! model's interaction range (when more time is spent in evaluating the model)
+//! or the overall maximum range (when more time is spent evaluating order
+//! parameters).
 
 pub mod math;
 

--- a/hoomd-order/src/math/spherical_harmonic.rs
+++ b/hoomd-order/src/math/spherical_harmonic.rs
@@ -9,69 +9,11 @@
 //! typically attempt to evaluate all values of `l` up to the target. When computing
 //! Steinhardt order parameters or similar algorithms, this code is much faster than
 //! alternatives, with good numerical stability even out to large values of `l`.
-//!
-//! # Example
-//! ```
-//! use hoomd_order::math::SphericalHarmonic;
-//! use num_complex::Complex64;
-//! use hoomd_vector::{Cartesian, InnerProduct};
-//! use approxim::assert_abs_diff_eq;
-//! use std::f64::consts::PI;
-//!
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! // Initialize the SphericalHarmonic container, which can be reused
-//! // to compute Y_6^m at a large number of points.
-//! let y_6 = SphericalHarmonic::<6>::new();
-//!
-//! // Values of m in 0..=L are returned as a HarmonicOutput<L> container, which behaves
-//! // like a [f64; L+1] array.
-//! let (point, _) = Cartesian::<3>::from([1.0; 3]).to_unit()?;
-//! let sh = y_6.evaluate(&point);
-//! assert_eq!(sh.len(), 6+1);
-//!
-//! // Zonal harmonic (m=0) is always purely real
-//! assert_eq!(sh[0].im, 0.0);
-//!
-//! // Y_6^0 = sqrt(13/(4pi)) * P_6(1/sqrt(3)) = sqrt(13/(4pi)) * 2/9
-//! let expected_m0 = 2.0 * f64::sqrt(13.0 / (4.0 * PI)) / 9.0;
-//! assert_abs_diff_eq!(sh[0].re, expected_m0, epsilon = 1e-15);
-//!
-//! /// Implement the Steinhardt order parameter q6.
-//! fn q6(bonds: &[Cartesian<3>]) -> f64 {
-//!     let mut accum = [Complex64::ZERO; 7];
-//!     let y6 = SphericalHarmonic::<6>::new();
-//!
-//!     for &bond in bonds {
-//!         let (unit_bond, _) = bond.to_unit().expect("Bond should have non-zero distance!");
-//!         let qlmi = y6.evaluate(&unit_bond);
-//!         for m in 0..7 { accum[m] += qlmi[m]; }
-//!     }
-//!
-//!     // We multiply the `m>0` components by two to account for `-m` contributions.
-//!     let sum_sq = accum[0].norm_sqr()
-//!         + 2.0 * accum[1..].iter().map(Complex64::norm_sqr).sum::<f64>();
-//!     let n = bonds.len() as f64;
-//!
-//!     (4.0 * PI / 13.0 * sum_sq).sqrt() / n
-//! }
-//!
-//! // FCC nearest neighbors: permutations of (±1, ±1, 0)
-//! let fcc_bonds: Vec<Cartesian<3>> = [
-//!     [-1.0, -1.0,  0.0], [-1.0,  1.0,  0.0], [1.0, -1.0,  0.0], [1.0,  1.0,  0.0],
-//!     [-1.0,  0.0, -1.0], [-1.0,  0.0,  1.0], [1.0,  0.0, -1.0], [1.0,  0.0,  1.0],
-//!     [ 0.0, -1.0, -1.0], [ 0.0, -1.0,  1.0], [0.0,  1.0, -1.0], [0.0,  1.0,  1.0],
-//! ].map(Cartesian::<3>::from).to_vec();
-//! assert_abs_diff_eq!(q6(&fcc_bonds), 0.57452416, epsilon = 1e-6);
-//! # Ok(())
-//! # }
-//! ```
 
 use hoomd_vector::{Cartesian, Unit};
-use num_complex::Complex64;
+use num_complex::Complex;
 use std::{
-    f64::consts::{FRAC_1_SQRT_2, PI, SQRT_2},
-    fmt,
-    ops::Index,
+    array, f64::consts::{FRAC_1_SQRT_2, PI, SQRT_2}, fmt, ops::{Add, AddAssign, Div, Index, Mul},
 };
 
 /// The spherical harmonic of degree `L`.
@@ -206,24 +148,24 @@ impl<const L: usize> SphericalHarmonic<L> {
             self.z_coeff[0] * z * h[0] - rxy2 * self.rxy_coeff[0] * h_plus1
         };
 
-        let mut result = [Complex64::ZERO; L];
+        let mut result = [Complex::ZERO; L];
 
         if L > 0 {
             let mut cm = x;
             let mut sm = y;
-            result[0] = Complex64::new(h[0] * cm, h[0] * sm);
+            result[0] = Complex::new(h[0] * cm, h[0] * sm);
 
             for m in 1..L {
                 let prev_cm = cm;
                 let prev_sm = sm;
                 cm = prev_cm * x - prev_sm * y;
                 sm = prev_cm * y + prev_sm * x;
-                result[m] = Complex64::new(h[m] * cm, h[m] * sm);
+                result[m] = Complex::new(h[m] * cm, h[m] * sm);
             }
         }
 
         SphericalHarmonicOutputs {
-            m0: Complex64::new(h_0, 0.0),
+            m0: Complex::new(h_0, 0.0),
             mp: result,
         }
     }
@@ -241,6 +183,9 @@ impl<const L: usize> Default for SphericalHarmonic<L> {
 /// Call [`SphericalHarmonic::evaluate`] to obtain the resulting value as
 /// [`SphericalHarmonicOutputs`]. The output contains the values at
 /// all non-negative values of *m*.
+///
+/// [`SphericalHarmonicOutputs`] add element-wise and can be multiplied and
+/// divided by scalars.
 ///
 /// # Examples
 ///
@@ -279,16 +224,16 @@ impl<const L: usize> Default for SphericalHarmonic<L> {
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct SphericalHarmonicOutputs<const L: usize> {
     /// `Y_L^0` (zonal harmonic, always real).
-    m0: Complex64,
+    m0: Complex<f64>,
     /// `Y_L^m` for m = 1..=L, stored at index m − 1.
-    mp: [Complex64; L],
+    mp: [Complex<f64>; L],
 }
 
 impl<const L: usize> Index<usize> for SphericalHarmonicOutputs<L> {
-    type Output = Complex64;
+    type Output = Complex<f64>;
 
     #[inline]
-    fn index(&self, index: usize) -> &Complex64 {
+    fn index(&self, index: usize) -> &Complex<f64> {
         match index {
             0 => &self.m0,
             n => &self.mp[n - 1],
@@ -297,9 +242,9 @@ impl<const L: usize> Index<usize> for SphericalHarmonicOutputs<L> {
 }
 
 impl<const L: usize> IntoIterator for SphericalHarmonicOutputs<L> {
-    type Item = Complex64;
+    type Item = Complex<f64>;
     type IntoIter =
-        std::iter::Chain<std::iter::Once<Complex64>, std::array::IntoIter<Complex64, L>>;
+        std::iter::Chain<std::iter::Once<Complex<f64>>, std::array::IntoIter<Complex<f64>, L>>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
@@ -338,7 +283,7 @@ impl<const L: usize> SphericalHarmonicOutputs<L> {
     /// # }
     /// ```
     #[inline]
-    pub fn iter(&self) -> impl Iterator<Item = Complex64> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = Complex<f64>> + '_ {
         std::iter::once(self.m0).chain(self.mp.iter().copied())
     }
 
@@ -357,10 +302,78 @@ impl<const L: usize> SphericalHarmonicOutputs<L> {
     }
 }
 
+impl<const L: usize> Default for SphericalHarmonicOutputs<L> {
+    /// The default [`SphericalHarmonicOutputs`] contains all 0's
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use num_complex::Complex;
+    /// use hoomd_order::math::SphericalHarmonicOutputs;
+    ///
+    /// let default = SphericalHarmonicOutputs::<3>::default();
+    /// assert_eq!(default[0], Complex::new(0.0, 0.0));
+    /// assert_eq!(default[1], Complex::new(0.0, 0.0));
+    /// assert_eq!(default[2], Complex::new(0.0, 0.0));
+    /// assert_eq!(default[3], Complex::new(0.0, 0.0));
+    /// ```
+    #[inline(always)]
+    fn default() -> Self {
+        Self { m0: Complex::default(), mp: [Complex::default(); L] }
+    }
+}
+
+impl<const L: usize> AddAssign for SphericalHarmonicOutputs<L> {
+    #[inline(always)]
+    fn add_assign(&mut self, rhs: Self) {
+        self.m0 += rhs.m0;
+        for i in 0..L {
+            self.mp[i] += rhs.mp[i];
+        }
+    }
+}
+
+impl<const L: usize> Add for SphericalHarmonicOutputs<L> {
+    type Output = SphericalHarmonicOutputs<L>;
+
+    #[inline(always)]
+    fn add(self, rhs: SphericalHarmonicOutputs<L>) -> Self::Output {
+        Self {
+            m0: self.m0 + rhs.m0,
+            mp: array::from_fn(|i| self.mp[i] + rhs.mp[i]),
+        }
+    }
+}
+
+impl<const L: usize> Div<f64> for SphericalHarmonicOutputs<L> {
+    type Output = SphericalHarmonicOutputs<L>;
+
+    #[inline(always)]
+    fn div(self, rhs: f64) -> Self::Output {
+        Self {
+            m0: self.m0 / rhs,
+            mp: array::from_fn(|i| self.mp[i] / rhs),
+        }
+    }
+}
+
+impl<const L: usize> Mul<f64> for SphericalHarmonicOutputs<L> {
+    type Output = SphericalHarmonicOutputs<L>;
+
+    #[inline(always)]
+    fn mul(self, rhs: f64) -> Self::Output {
+        Self {
+            m0: self.m0 * rhs,
+            mp: array::from_fn(|i| self.mp[i] * rhs),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use approxim::assert_abs_diff_eq;
+    use num_complex::Complex;
     use rstest::rstest;
     use std::marker::PhantomData;
 
@@ -374,7 +387,7 @@ mod tests {
         let sh = SphericalHarmonic::<0>::new();
         let out = sh.evaluate(&[0.0, 0.0, 1.0].try_into()?);
         let expected = 1.0 / (2.0 * f64::sqrt(PI));
-        assert_abs_diff_eq!(out[0], Complex64::new(expected, 0.0f64), epsilon = 1e-12);
+        assert_abs_diff_eq!(out[0], Complex::new(expected, 0.0f64), epsilon = 1e-12);
         assert_eq!(out.mp.len(), 0);
         Ok(())
     }
@@ -384,8 +397,8 @@ mod tests {
         let sh = SphericalHarmonic::<1>::new();
         let out = sh.evaluate(&[0.0, 0.0, 1.0].try_into()?);
         let c = f64::sqrt(3.0 / (4.0 * PI));
-        assert_abs_diff_eq!(out[0], Complex64::new(c, 0.0), epsilon = 1e-12);
-        assert_abs_diff_eq!(out[1], Complex64::ZERO, epsilon = 1e-12);
+        assert_abs_diff_eq!(out[0], Complex::new(c, 0.0), epsilon = 1e-12);
+        assert_abs_diff_eq!(out[1], Complex::ZERO, epsilon = 1e-12);
         Ok(())
     }
 
@@ -394,8 +407,8 @@ mod tests {
         let sh = SphericalHarmonic::<1>::new();
         let out = sh.evaluate(&[1.0, 0.0, 0.0].try_into()?);
         let c = f64::sqrt(3.0 / (8.0 * PI));
-        assert_abs_diff_eq!(out[0], Complex64::ZERO, epsilon = 1e-12);
-        assert_abs_diff_eq!(out[1], Complex64::new(c, 0.0), epsilon = 1e-12);
+        assert_abs_diff_eq!(out[0], Complex::ZERO, epsilon = 1e-12);
+        assert_abs_diff_eq!(out[1], Complex::new(c, 0.0), epsilon = 1e-12);
         Ok(())
     }
 
@@ -404,8 +417,8 @@ mod tests {
         let sh = SphericalHarmonic::<1>::new();
         let out = sh.evaluate(&[0.0, 1.0, 0.0].try_into()?);
         let c = f64::sqrt(3.0 / (8.0 * PI));
-        assert_abs_diff_eq!(out[0], Complex64::ZERO, epsilon = 1e-12);
-        assert_abs_diff_eq!(out[1], Complex64::new(0.0, c), epsilon = 1e-12);
+        assert_abs_diff_eq!(out[0], Complex::ZERO, epsilon = 1e-12);
+        assert_abs_diff_eq!(out[1], Complex::new(0.0, c), epsilon = 1e-12);
         Ok(())
     }
 
@@ -458,7 +471,7 @@ mod tests {
         let coords = Coordinates::cartesian(x, y, z);
 
         let expected_m0: f64 = RealSH::Spherical.eval(l, 0, &coords);
-        assert_abs_diff_eq!(out[0], Complex64::new(expected_m0, 0.0), epsilon = 1e-8);
+        assert_abs_diff_eq!(out[0], Complex::new(expected_m0, 0.0), epsilon = 1e-8);
 
         for m in 1..=L {
             let m_i64 = i64::try_from(m).expect("m should not overflow i64");
@@ -466,7 +479,7 @@ mod tests {
             let s_neg: f64 = RealSH::Spherical.eval(l, -m_i64, &coords);
             assert_abs_diff_eq!(
                 out[m],
-                Complex64::new(s_pos * FRAC_1_SQRT_2, s_neg * FRAC_1_SQRT_2),
+                Complex::new(s_pos * FRAC_1_SQRT_2, s_neg * FRAC_1_SQRT_2),
                 epsilon = 1e-8
             );
         }
@@ -548,5 +561,58 @@ mod tests {
             0.7_f64.cos(),
         ];
         check_completeness::<L>(point).unwrap();
+    }
+
+    #[test]
+    fn add_outputs() {
+        let a = SphericalHarmonicOutputs {
+            m0: Complex::new(1.0, 0.0),
+            mp: [Complex::new(2.0, 3.0), Complex::new(-4.0, -5.0), Complex::new(1.0, 0.5)],
+        };
+        let b = SphericalHarmonicOutputs {
+            m0: Complex::new(2.0, 0.0),
+            mp: [Complex::new(3.0, -4.0), Complex::new(6.0, -3.0), Complex::new(5.0, 8.0)],
+        };
+
+        let mut c = a;
+        c += b;
+        assert_eq!(c[0], Complex::new(3.0, 0.0));
+        assert_eq!(c[1], Complex::new(5.0, -1.0));
+        assert_eq!(c[2], Complex::new(2.0, -8.0));
+        assert_eq!(c[3], Complex::new(6.0, 8.5));
+
+        let c = a + b;
+        assert_eq!(c[0], Complex::new(3.0, 0.0));
+        assert_eq!(c[1], Complex::new(5.0, -1.0));
+        assert_eq!(c[2], Complex::new(2.0, -8.0));
+        assert_eq!(c[3], Complex::new(6.0, 8.5));
+    }
+
+    #[test]
+    fn div_outputs() {
+        let a = SphericalHarmonicOutputs {
+            m0: Complex::new(1.0, 0.0),
+            mp: [Complex::new(2.0, 4.0), Complex::new(-4.0, -6.0), Complex::new(1.0, 0.5)],
+        };
+
+        let b = a / 2.0;
+        assert_eq!(b[0], Complex::new(0.5, 0.0));
+        assert_eq!(b[1], Complex::new(1.0, 2.0));
+        assert_eq!(b[2], Complex::new(-2.0, -3.0));
+        assert_eq!(b[3], Complex::new(0.5, 0.25));
+    }
+
+    #[test]
+    fn mul_outputs() {
+        let a = SphericalHarmonicOutputs {
+            m0: Complex::new(1.0, 0.0),
+            mp: [Complex::new(2.0, 4.0), Complex::new(-4.0, -6.0), Complex::new(1.0, 0.5)],
+        };
+
+        let b = a * 2.0;
+        assert_eq!(b[0], Complex::new(2.0, 0.0));
+        assert_eq!(b[1], Complex::new(4.0, 8.0));
+        assert_eq!(b[2], Complex::new(-8.0, -12.0));
+        assert_eq!(b[3], Complex::new(2.0, 1.0));
     }
 }

--- a/hoomd-order/src/math/spherical_harmonic.rs
+++ b/hoomd-order/src/math/spherical_harmonic.rs
@@ -13,7 +13,10 @@
 use hoomd_vector::{Cartesian, Unit};
 use num_complex::Complex;
 use std::{
-    array, f64::consts::{FRAC_1_SQRT_2, PI, SQRT_2}, fmt, ops::{Add, AddAssign, Div, Index, Mul},
+    array,
+    f64::consts::{FRAC_1_SQRT_2, PI, SQRT_2},
+    fmt,
+    ops::{Add, AddAssign, Div, Index, Mul},
 };
 
 /// The spherical harmonic of degree `L`.
@@ -308,8 +311,8 @@ impl<const L: usize> Default for SphericalHarmonicOutputs<L> {
     /// # Example
     ///
     /// ```
-    /// use num_complex::Complex;
     /// use hoomd_order::math::SphericalHarmonicOutputs;
+    /// use num_complex::Complex;
     ///
     /// let default = SphericalHarmonicOutputs::<3>::default();
     /// assert_eq!(default[0], Complex::new(0.0, 0.0));
@@ -319,7 +322,10 @@ impl<const L: usize> Default for SphericalHarmonicOutputs<L> {
     /// ```
     #[inline(always)]
     fn default() -> Self {
-        Self { m0: Complex::default(), mp: [Complex::default(); L] }
+        Self {
+            m0: Complex::default(),
+            mp: [Complex::default(); L],
+        }
     }
 }
 
@@ -567,11 +573,19 @@ mod tests {
     fn add_outputs() {
         let a = SphericalHarmonicOutputs {
             m0: Complex::new(1.0, 0.0),
-            mp: [Complex::new(2.0, 3.0), Complex::new(-4.0, -5.0), Complex::new(1.0, 0.5)],
+            mp: [
+                Complex::new(2.0, 3.0),
+                Complex::new(-4.0, -5.0),
+                Complex::new(1.0, 0.5),
+            ],
         };
         let b = SphericalHarmonicOutputs {
             m0: Complex::new(2.0, 0.0),
-            mp: [Complex::new(3.0, -4.0), Complex::new(6.0, -3.0), Complex::new(5.0, 8.0)],
+            mp: [
+                Complex::new(3.0, -4.0),
+                Complex::new(6.0, -3.0),
+                Complex::new(5.0, 8.0),
+            ],
         };
 
         let mut c = a;
@@ -592,7 +606,11 @@ mod tests {
     fn div_outputs() {
         let a = SphericalHarmonicOutputs {
             m0: Complex::new(1.0, 0.0),
-            mp: [Complex::new(2.0, 4.0), Complex::new(-4.0, -6.0), Complex::new(1.0, 0.5)],
+            mp: [
+                Complex::new(2.0, 4.0),
+                Complex::new(-4.0, -6.0),
+                Complex::new(1.0, 0.5),
+            ],
         };
 
         let b = a / 2.0;
@@ -606,7 +624,11 @@ mod tests {
     fn mul_outputs() {
         let a = SphericalHarmonicOutputs {
             m0: Complex::new(1.0, 0.0),
-            mp: [Complex::new(2.0, 4.0), Complex::new(-4.0, -6.0), Complex::new(1.0, 0.5)],
+            mp: [
+                Complex::new(2.0, 4.0),
+                Complex::new(-4.0, -6.0),
+                Complex::new(1.0, 0.5),
+            ],
         };
 
         let b = a * 2.0;

--- a/hoomd-order/src/sites_in_ball.rs
+++ b/hoomd-order/src/sites_in_ball.rs
@@ -47,15 +47,22 @@ use hoomd_vector::Metric;
 ///
 /// let near_site_0 = SitesInBall::near_site(&microstate, 0, 1.5);
 ///
-/// let psi_0 = hoomd_order::k_atic_psi(4.0, near_site_0.point(), near_site_0.iter_site_positions().copied());
+/// let psi_0 = hoomd_order::k_atic_psi(
+///     4.0,
+///     near_site_0.point(),
+///     near_site_0.iter_site_positions().copied(),
+/// );
 /// # Ok(())
 /// # }
 /// ```
-/// 
+///
 /// Use [`iter_sites`] to perform additional filtering. For example, compute an order parameter
 /// only on neighboring sites of type *A*:
 /// ```
-/// use hoomd_microstate::{Body, Microstate, Transform, property::{Point, Position}};
+/// use hoomd_microstate::{
+///     Body, Microstate, Transform,
+///     property::{Point, Position},
+/// };
 /// use hoomd_order::SitesInBall;
 /// use hoomd_vector::Cartesian;
 ///
@@ -78,7 +85,10 @@ use hoomd_vector::Metric;
 /// }
 ///
 /// impl Transform<SiteProperties> for BodyProperties {
-///     fn transform(&self, site_properties: &SiteProperties) -> SiteProperties {
+///     fn transform(
+///         &self,
+///         site_properties: &SiteProperties,
+///     ) -> SiteProperties {
 ///         SiteProperties {
 ///             position: self.position + site_properties.position,
 ///             ..*site_properties
@@ -88,19 +98,51 @@ use hoomd_vector::Metric;
 ///
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut microstate = Microstate::new();
-/// microstate.add_body(Body::single_site(Point::new(Cartesian::from([0.0, 0.0])), SiteProperties::default()))?;
-/// microstate.add_body(Body::single_site(Point::new(Cartesian::from([1.0, 0.0])), SiteProperties::default()))?;
-/// microstate.add_body(Body::single_site(Point::new(Cartesian::from([0.0, 1.0])), SiteProperties::default()))?;
-/// microstate.add_body(Body::single_site(Point::new(Cartesian::from([-1.0, 0.0])), SiteProperties::default()))?;
-/// microstate.add_body(Body::single_site(Point::new(Cartesian::from([0.0, -1.0])), SiteProperties::default()))?;
-/// microstate.add_body(Body::single_site(Point::new(Cartesian::from([1.0, 1.0])), SiteProperties { site_type: SiteType::A, ..Default::default() }))?;
-/// microstate.add_body(Body::single_site(Point::new(Cartesian::from([-1.0, -1.0])), SiteProperties { site_type: SiteType::A, ..Default::default() }))?;
+/// microstate.add_body(Body::single_site(
+///     Point::new(Cartesian::from([0.0, 0.0])),
+///     SiteProperties::default(),
+/// ))?;
+/// microstate.add_body(Body::single_site(
+///     Point::new(Cartesian::from([1.0, 0.0])),
+///     SiteProperties::default(),
+/// ))?;
+/// microstate.add_body(Body::single_site(
+///     Point::new(Cartesian::from([0.0, 1.0])),
+///     SiteProperties::default(),
+/// ))?;
+/// microstate.add_body(Body::single_site(
+///     Point::new(Cartesian::from([-1.0, 0.0])),
+///     SiteProperties::default(),
+/// ))?;
+/// microstate.add_body(Body::single_site(
+///     Point::new(Cartesian::from([0.0, -1.0])),
+///     SiteProperties::default(),
+/// ))?;
+/// microstate.add_body(Body::single_site(
+///     Point::new(Cartesian::from([1.0, 1.0])),
+///     SiteProperties {
+///         site_type: SiteType::A,
+///         ..Default::default()
+///     },
+/// ))?;
+/// microstate.add_body(Body::single_site(
+///     Point::new(Cartesian::from([-1.0, -1.0])),
+///     SiteProperties {
+///         site_type: SiteType::A,
+///         ..Default::default()
+///     },
+/// ))?;
 ///
 /// let near_site_0 = SitesInBall::near_site(&microstate, 0, 1.5);
 ///
-/// let psi_0_a = hoomd_order::k_atic_psi(4.0, near_site_0.point(), near_site_0.iter_sites()
-///     .filter(|s| s.properties.site_type == SiteType::A)
-///     .map(|s| *s.properties.position()));
+/// let psi_0_a = hoomd_order::k_atic_psi(
+///     4.0,
+///     near_site_0.point(),
+///     near_site_0
+///         .iter_sites()
+///         .filter(|s| s.properties.site_type == SiteType::A)
+///         .map(|s| *s.properties.position()),
+/// );
 /// # Ok(())
 /// # }
 /// ```
@@ -166,7 +208,8 @@ impl<P, B, S, X, C> SitesInBall<'_, P, B, S, X, C> {
     }
 }
 
-impl<'a, P, B, S, X, C> SitesInBall<'a, P, B, S, X, C> where
+impl<'a, P, B, S, X, C> SitesInBall<'a, P, B, S, X, C>
+where
     P: Copy + Metric,
     S: Position<Position = P>,
     X: PointsNearBall<P, SiteKey>,
@@ -198,7 +241,7 @@ impl<'a, P, B, S, X, C> SitesInBall<'a, P, B, S, X, C> where
             point: *microstate.sites()[site_index].properties.position(),
             r,
             ignore_site_tag: Some(microstate.sites()[site_index].site_tag),
-            microstate
+            microstate,
         }
     }
 
@@ -217,7 +260,8 @@ impl<'a, P, B, S, X, C> SitesInBall<'a, P, B, S, X, C> where
     /// microstate.add_body(Body::point(Cartesian::from([1.0, 0.0])))?;
     /// microstate.add_body(Body::point(Cartesian::from([2.0, 0.0])))?;
     ///
-    /// let near_position_1_0 = SitesInBall::near_point(&microstate, [1.0, 0.0].into(), 1.5);
+    /// let near_position_1_0 =
+    ///     SitesInBall::near_point(&microstate, [1.0, 0.0].into(), 1.5);
     /// assert_eq!(near_position_1_0.iter_sites().count(), 3);
     /// # Ok(())
     /// # }
@@ -232,7 +276,7 @@ impl<'a, P, B, S, X, C> SitesInBall<'a, P, B, S, X, C> where
             point,
             r,
             ignore_site_tag: None,
-            microstate
+            microstate,
         }
     }
 
@@ -240,7 +284,10 @@ impl<'a, P, B, S, X, C> SitesInBall<'a, P, B, S, X, C> where
     ///
     /// # Examples
     /// ```
-    /// use hoomd_microstate::{Body, Microstate, Transform, property::{Point, Position}};
+    /// use hoomd_microstate::{
+    ///     Body, Microstate, Transform,
+    ///     property::{Point, Position},
+    /// };
     /// use hoomd_order::SitesInBall;
     /// use hoomd_vector::Cartesian;
     ///
@@ -263,7 +310,10 @@ impl<'a, P, B, S, X, C> SitesInBall<'a, P, B, S, X, C> where
     /// }
     ///
     /// impl Transform<SiteProperties> for BodyProperties {
-    ///     fn transform(&self, site_properties: &SiteProperties) -> SiteProperties {
+    ///     fn transform(
+    ///         &self,
+    ///         site_properties: &SiteProperties,
+    ///     ) -> SiteProperties {
     ///         SiteProperties {
     ///             position: self.position + site_properties.position,
     ///             ..*site_properties
@@ -273,31 +323,63 @@ impl<'a, P, B, S, X, C> SitesInBall<'a, P, B, S, X, C> where
     ///
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let mut microstate = Microstate::new();
-    /// microstate.add_body(Body::single_site(Point::new(Cartesian::from([0.0, 0.0])), SiteProperties::default()))?;
-    /// microstate.add_body(Body::single_site(Point::new(Cartesian::from([1.0, 0.0])), SiteProperties::default()))?;
-    /// microstate.add_body(Body::single_site(Point::new(Cartesian::from([0.0, 1.0])), SiteProperties::default()))?;
-    /// microstate.add_body(Body::single_site(Point::new(Cartesian::from([-1.0, 0.0])), SiteProperties::default()))?;
-    /// microstate.add_body(Body::single_site(Point::new(Cartesian::from([0.0, -1.0])), SiteProperties::default()))?;
-    /// microstate.add_body(Body::single_site(Point::new(Cartesian::from([1.0, 1.0])), SiteProperties { site_type: SiteType::A, ..Default::default() }))?;
-    /// microstate.add_body(Body::single_site(Point::new(Cartesian::from([-1.0, -1.0])), SiteProperties { site_type: SiteType::A, ..Default::default() }))?;
+    /// microstate.add_body(Body::single_site(
+    ///     Point::new(Cartesian::from([0.0, 0.0])),
+    ///     SiteProperties::default(),
+    /// ))?;
+    /// microstate.add_body(Body::single_site(
+    ///     Point::new(Cartesian::from([1.0, 0.0])),
+    ///     SiteProperties::default(),
+    /// ))?;
+    /// microstate.add_body(Body::single_site(
+    ///     Point::new(Cartesian::from([0.0, 1.0])),
+    ///     SiteProperties::default(),
+    /// ))?;
+    /// microstate.add_body(Body::single_site(
+    ///     Point::new(Cartesian::from([-1.0, 0.0])),
+    ///     SiteProperties::default(),
+    /// ))?;
+    /// microstate.add_body(Body::single_site(
+    ///     Point::new(Cartesian::from([0.0, -1.0])),
+    ///     SiteProperties::default(),
+    /// ))?;
+    /// microstate.add_body(Body::single_site(
+    ///     Point::new(Cartesian::from([1.0, 1.0])),
+    ///     SiteProperties {
+    ///         site_type: SiteType::A,
+    ///         ..Default::default()
+    ///     },
+    /// ))?;
+    /// microstate.add_body(Body::single_site(
+    ///     Point::new(Cartesian::from([-1.0, -1.0])),
+    ///     SiteProperties {
+    ///         site_type: SiteType::A,
+    ///         ..Default::default()
+    ///     },
+    /// ))?;
     ///
     /// let near_site_0 = SitesInBall::near_site(&microstate, 0, 1.5);
     ///
-    /// let psi_0_a = hoomd_order::k_atic_psi(4.0, near_site_0.point(), near_site_0.iter_sites()
-    ///     .filter(|s| s.properties.site_type == SiteType::A)
-    ///     .map(|s| *s.properties.position()));
+    /// let psi_0_a = hoomd_order::k_atic_psi(
+    ///     4.0,
+    ///     near_site_0.point(),
+    ///     near_site_0
+    ///         .iter_sites()
+    ///         .filter(|s| s.properties.site_type == SiteType::A)
+    ///         .map(|s| *s.properties.position()),
+    /// );
     /// # Ok(())
     /// # }
     /// ```
     #[inline(always)]
     pub fn iter_sites(&self) -> impl Iterator<Item = &Site<S>> {
-        self.microstate.iter_sites_near(&self.point, self.r)
-            .filter(|s| {
-                match self.ignore_site_tag {
-                    None => true,
-                    Some(site_tag) => site_tag != s.site_tag,
-            }})
-            .filter(|s| self.point.distance_squared(s.properties.position()) < self.r.powi(2) )
+        self.microstate
+            .iter_sites_near(&self.point, self.r)
+            .filter(|s| match self.ignore_site_tag {
+                None => true,
+                Some(site_tag) => site_tag != s.site_tag,
+            })
+            .filter(|s| self.point.distance_squared(s.properties.position()) < self.r.powi(2))
     }
 
     /// Iterate over all matching site positions.
@@ -318,7 +400,11 @@ impl<'a, P, B, S, X, C> SitesInBall<'a, P, B, S, X, C> where
     ///
     /// let near_site_0 = SitesInBall::near_site(&microstate, 0, 1.5);
     ///
-    /// let psi_0 = hoomd_order::k_atic_psi(4.0, near_site_0.point(), near_site_0.iter_site_positions().copied());
+    /// let psi_0 = hoomd_order::k_atic_psi(
+    ///     4.0,
+    ///     near_site_0.point(),
+    ///     near_site_0.iter_site_positions().copied(),
+    /// );
     /// # Ok(())
     /// # }
     /// ```
@@ -356,10 +442,16 @@ mod tests {
         sorted_sites.sort_by_key(|a| a.site_tag);
 
         itertools::assert_equal(sorted_sites.iter().map(|s| s.site_tag), [0, 2, 5]);
-        itertools::assert_equal(near_site_1.iter_site_tags(), sites.iter().map(|s| s.site_tag));
-        itertools::assert_equal(near_site_1.iter_site_positions().copied(), sites.iter().map(|s| s.properties.position));
-        
-        Ok(())        
+        itertools::assert_equal(
+            near_site_1.iter_site_tags(),
+            sites.iter().map(|s| s.site_tag),
+        );
+        itertools::assert_equal(
+            near_site_1.iter_site_positions().copied(),
+            sites.iter().map(|s| s.properties.position),
+        );
+
+        Ok(())
     }
     #[test]
     fn near_point() -> anyhow::Result<()> {
@@ -377,9 +469,15 @@ mod tests {
         sorted_sites.sort_by_key(|a| a.site_tag);
 
         itertools::assert_equal(sorted_sites.iter().map(|s| s.site_tag), [0, 1, 2, 5]);
-        itertools::assert_equal(near_point.iter_site_tags(), sites.iter().map(|s| s.site_tag));
-        itertools::assert_equal(near_point.iter_site_positions().copied(), sites.iter().map(|s| s.properties.position));
-        
-        Ok(())        
+        itertools::assert_equal(
+            near_point.iter_site_tags(),
+            sites.iter().map(|s| s.site_tag),
+        );
+        itertools::assert_equal(
+            near_point.iter_site_positions().copied(),
+            sites.iter().map(|s| s.properties.position),
+        );
+
+        Ok(())
     }
 }

--- a/hoomd-order/src/sites_in_ball.rs
+++ b/hoomd-order/src/sites_in_ball.rs
@@ -1,0 +1,335 @@
+// Copyright (c) 2024-2026 The Regents of the University of Michigan.
+// Part of hoomd-rs, released under the BSD 3-Clause License.
+
+//! Implement `SitesInBall`
+
+use hoomd_microstate::{Microstate, Site, SiteKey, property::Position};
+use hoomd_spatial::PointsNearBall;
+use hoomd_vector::Metric;
+
+/// Find all sites in a [`Microstate`] with positions inside a ball of radius *r*.
+///
+/// In other words, find all neighboring sites within a specific distance of a given
+/// point.
+///
+/// When the given [`Microstate`] has periodic boundary conditions, *r* must
+/// be less than or equal to the boundary's maximum interaction range. Exercise caution,
+/// as this condition is not validated. Set *r* too large and [`SitesInBall`] will
+/// find the correct sites near the center of the boundary, but will miss some neighbors
+/// near the edge. TODO: revisit *why* this is not an error - it seems that Microstate could
+/// check this and panic....
+///
+/// Construct [`SitesInBall`] with [`near_site`] to find the neighbors of a site
+/// (excluding the site itself). Construct [`SitesInBall`] with [`near_point`] to find
+/// all sites (no exclusions) within a distance of the given point.
+///
+/// After construction, call one or more `iter_` methods to iterate over the
+/// matching sites. When the [`Microstate`] has periodic boundary conditions,
+/// matches may be ghost sites with positions outside the boundary: no wrapping
+/// is necessary as [`Microstate`] has already accounted for it.
+///
+/// # Examples
+///
+/// For example, use [`iter_site_positions`] to compute an order parameter
+/// of all sites near another site:
+/// ```
+/// use hoomd_microstate::{Body, Microstate};
+/// use hoomd_order::SitesInBall;
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])))?;
+/// microstate.add_body(Body::point(Cartesian::from([1.0, 0.0])))?;
+/// microstate.add_body(Body::point(Cartesian::from([0.0, 1.0])))?;
+/// microstate.add_body(Body::point(Cartesian::from([-1.0, 0.0])))?;
+/// microstate.add_body(Body::point(Cartesian::from([0.0, -1.0])))?;
+///
+/// let near_site_0 = SitesInBall::near_site(&microstate, 0, 1.5);
+///
+/// let psi_0 = hoomd_order::k_atic_psi(4.0, near_site_0.point(), near_site_0.iter_site_positions().copied());
+/// # Ok(())
+/// # }
+/// ```
+/// 
+/// Use [`iter_sites`] to perform additional filtering. For example, compute an order parameter
+/// only on neighboring sites of type *A*:
+/// ```
+/// use hoomd_microstate::{Body, Microstate, Transform, property::{Point, Position}};
+/// use hoomd_order::SitesInBall;
+/// use hoomd_vector::Cartesian;
+///
+/// type PositionVector = Cartesian<2>;
+/// type BodyProperties = Point<PositionVector>;
+///
+/// #[derive(Clone, Copy, Default, PartialEq)]
+/// enum SiteType {
+///     #[default]
+///     A,
+///     B,
+/// }
+///
+/// #[derive(Clone, Copy, Default, Position)]
+/// struct SiteProperties {
+///     /// The site's position.
+///     position: PositionVector,
+///     /// The site's type.
+///     site_type: SiteType,
+/// }
+///
+/// impl Transform<SiteProperties> for BodyProperties {
+///     fn transform(&self, site_properties: &SiteProperties) -> SiteProperties {
+///         SiteProperties {
+///             position: self.position + site_properties.position,
+///             ..*site_properties
+///         }
+///     }
+/// }
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut microstate = Microstate::new();
+/// microstate.add_body(Body::single_site(Point::new(Cartesian::from([0.0, 0.0])), SiteProperties::default()))?;
+/// microstate.add_body(Body::single_site(Point::new(Cartesian::from([1.0, 0.0])), SiteProperties::default()))?;
+/// microstate.add_body(Body::single_site(Point::new(Cartesian::from([0.0, 1.0])), SiteProperties::default()))?;
+/// microstate.add_body(Body::single_site(Point::new(Cartesian::from([-1.0, 0.0])), SiteProperties::default()))?;
+/// microstate.add_body(Body::single_site(Point::new(Cartesian::from([0.0, -1.0])), SiteProperties::default()))?;
+/// microstate.add_body(Body::single_site(Point::new(Cartesian::from([1.0, 1.0])), SiteProperties { site_type: SiteType::A, ..Default::default() }))?;
+/// microstate.add_body(Body::single_site(Point::new(Cartesian::from([-1.0, -1.0])), SiteProperties { site_type: SiteType::A, ..Default::default() }))?;
+///
+/// let near_site_0 = SitesInBall::near_site(&microstate, 0, 1.5);
+///
+/// let psi_0_a = hoomd_order::k_atic_psi(4.0, near_site_0.point(), near_site_0.iter_sites()
+///     .filter(|s| s.properties.site_type == SiteType::A)
+///     .map(|s| *s.properties.position()));
+/// # Ok(())
+/// # }
+/// ```
+///
+/// [`near_site`]: Self::near_site
+/// [`near_point`]: Self::near_point
+/// [`iter_site_positions`]: Self::iter_site_positions
+/// [`iter_sites`]: Self::iter_sites
+pub struct SitesInBall<'a, P, B, S, X, C> {
+    /// The center of the ball.
+    point: P,
+    /// Radius of the ball.
+    r: f64,
+    /// Ignore sites with this tag.
+    ignore_site_tag: Option<usize>,
+    /// Search for sites in this microstate.
+    microstate: &'a Microstate<B, S, X, C>,
+}
+
+impl<P, B, S, X, C> SitesInBall<'_, P, B, S, X, C> {
+    /// The point at the center of the ball.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_microstate::{Body, Microstate};
+    /// use hoomd_order::SitesInBall;
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut microstate = Microstate::new();
+    /// microstate.add_body(Body::point(Cartesian::from([1.0, 2.0])))?;
+    ///
+    /// let near_site_0 = SitesInBall::near_site(&microstate, 0, 1.5);
+    /// assert_eq!(near_site_0.point(), &[1.0, 2.0].into());
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn point(&self) -> &P {
+        &self.point
+    }
+
+    /// The radius of the ball.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_microstate::{Body, Microstate};
+    /// use hoomd_order::SitesInBall;
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut microstate = Microstate::new();
+    /// microstate.add_body(Body::point(Cartesian::from([1.0, 2.0])))?;
+    ///
+    /// let near_site_0 = SitesInBall::near_site(&microstate, 0, 1.5);
+    /// assert_eq!(near_site_0.r(), 1.5);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn r(&self) -> f64 {
+        self.r
+    }
+}
+
+impl<'a, P, B, S, X, C> SitesInBall<'a, P, B, S, X, C> where
+    P: Copy + Metric,
+    S: Position<Position = P>,
+    X: PointsNearBall<P, SiteKey>,
+{
+    /// Match sites in the given microstate with positions that are within a distance
+    /// *r* of the given site. The given site is *excluded* from the iterator despite the
+    /// fact that it a distance of zero from itself.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_microstate::{Body, Microstate};
+    /// use hoomd_order::SitesInBall;
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut microstate = Microstate::new();
+    /// microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])))?;
+    /// microstate.add_body(Body::point(Cartesian::from([1.0, 0.0])))?;
+    /// microstate.add_body(Body::point(Cartesian::from([2.0, 0.0])))?;
+    ///
+    /// let near_site_1 = SitesInBall::near_site(&microstate, 1, 1.5);
+    /// assert_eq!(near_site_1.iter_sites().count(), 2);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn near_site(microstate: &'a Microstate<B, S, X, C>, site_index: usize, r: f64) -> Self {
+        Self {
+            point: *microstate.sites()[site_index].properties.position(),
+            r,
+            ignore_site_tag: Some(microstate.sites()[site_index].site_tag),
+            microstate
+        }
+    }
+
+    /// Match sites in the given microstate with positions that are within a distance
+    /// *r* of the given point in space, including sites at a distance of zero.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_microstate::{Body, Microstate};
+    /// use hoomd_order::SitesInBall;
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut microstate = Microstate::new();
+    /// microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])))?;
+    /// microstate.add_body(Body::point(Cartesian::from([1.0, 0.0])))?;
+    /// microstate.add_body(Body::point(Cartesian::from([2.0, 0.0])))?;
+    ///
+    /// let near_position_1_0 = SitesInBall::near_point(&microstate, [1.0, 0.0].into(), 1.5);
+    /// assert_eq!(near_position_1_0.iter_sites().count(), 3);
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// TODO: What should happen when `point` is outside boundary? Should we construct
+    /// a temporary point site and wrap it? That would make `near_point` fallible, but perhaps
+    /// that is a good thing.
+    #[inline]
+    pub fn near_point(microstate: &'a Microstate<B, S, X, C>, point: P, r: f64) -> Self {
+        Self {
+            point,
+            r,
+            ignore_site_tag: None,
+            microstate
+        }
+    }
+
+    /// Iterate over all matching sites.
+    ///
+    /// # Examples
+    /// ```
+    /// use hoomd_microstate::{Body, Microstate, Transform, property::{Point, Position}};
+    /// use hoomd_order::SitesInBall;
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// type PositionVector = Cartesian<2>;
+    /// type BodyProperties = Point<PositionVector>;
+    ///
+    /// #[derive(Clone, Copy, Default, PartialEq)]
+    /// enum SiteType {
+    ///     #[default]
+    ///     A,
+    ///     B,
+    /// }
+    ///
+    /// #[derive(Clone, Copy, Default, Position)]
+    /// struct SiteProperties {
+    ///     /// The site's position.
+    ///     position: PositionVector,
+    ///     /// The site's type.
+    ///     site_type: SiteType,
+    /// }
+    ///
+    /// impl Transform<SiteProperties> for BodyProperties {
+    ///     fn transform(&self, site_properties: &SiteProperties) -> SiteProperties {
+    ///         SiteProperties {
+    ///             position: self.position + site_properties.position,
+    ///             ..*site_properties
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut microstate = Microstate::new();
+    /// microstate.add_body(Body::single_site(Point::new(Cartesian::from([0.0, 0.0])), SiteProperties::default()))?;
+    /// microstate.add_body(Body::single_site(Point::new(Cartesian::from([1.0, 0.0])), SiteProperties::default()))?;
+    /// microstate.add_body(Body::single_site(Point::new(Cartesian::from([0.0, 1.0])), SiteProperties::default()))?;
+    /// microstate.add_body(Body::single_site(Point::new(Cartesian::from([-1.0, 0.0])), SiteProperties::default()))?;
+    /// microstate.add_body(Body::single_site(Point::new(Cartesian::from([0.0, -1.0])), SiteProperties::default()))?;
+    /// microstate.add_body(Body::single_site(Point::new(Cartesian::from([1.0, 1.0])), SiteProperties { site_type: SiteType::A, ..Default::default() }))?;
+    /// microstate.add_body(Body::single_site(Point::new(Cartesian::from([-1.0, -1.0])), SiteProperties { site_type: SiteType::A, ..Default::default() }))?;
+    ///
+    /// let near_site_0 = SitesInBall::near_site(&microstate, 0, 1.5);
+    ///
+    /// let psi_0_a = hoomd_order::k_atic_psi(4.0, near_site_0.point(), near_site_0.iter_sites()
+    ///     .filter(|s| s.properties.site_type == SiteType::A)
+    ///     .map(|s| *s.properties.position()));
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline(always)]
+    pub fn iter_sites(&self) -> impl Iterator<Item = &Site<S>> {
+        self.microstate.iter_sites_near(&self.point, self.r)
+            .filter(|s| {
+                match self.ignore_site_tag {
+                    None => true,
+                    Some(site_tag) => site_tag != s.site_tag,
+            }})
+            .filter(|s| self.point.distance_squared(s.properties.position()) < self.r.powi(2) )
+    }
+
+    /// Iterate over all matching site positions.
+    ///
+    /// # Example
+    /// ```
+    /// use hoomd_microstate::{Body, Microstate};
+    /// use hoomd_order::SitesInBall;
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut microstate = Microstate::new();
+    /// microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])))?;
+    /// microstate.add_body(Body::point(Cartesian::from([1.0, 0.0])))?;
+    /// microstate.add_body(Body::point(Cartesian::from([0.0, 1.0])))?;
+    /// microstate.add_body(Body::point(Cartesian::from([-1.0, 0.0])))?;
+    /// microstate.add_body(Body::point(Cartesian::from([0.0, -1.0])))?;
+    ///
+    /// let near_site_0 = SitesInBall::near_site(&microstate, 0, 1.5);
+    ///
+    /// let psi_0 = hoomd_order::k_atic_psi(4.0, near_site_0.point(), near_site_0.iter_site_positions().copied());
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline(always)]
+    pub fn iter_site_positions(&self) -> impl Iterator<Item = &P> {
+        self.iter_sites().map(|s| s.properties.position())
+    }
+
+    /// Iterate over all matching site tags.
+    #[inline(always)]
+    pub fn iter_site_tags(&self) -> impl Iterator<Item = usize> {
+        self.iter_sites().map(|s| s.site_tag)
+    }
+}

--- a/hoomd-order/src/sites_in_ball.rs
+++ b/hoomd-order/src/sites_in_ball.rs
@@ -333,3 +333,53 @@ impl<'a, P, B, S, X, C> SitesInBall<'a, P, B, S, X, C> where
         self.iter_sites().map(|s| s.site_tag)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hoomd_microstate::Body;
+    use hoomd_vector::Cartesian;
+
+    #[test]
+    fn near_site() -> anyhow::Result<()> {
+        let mut microstate = Microstate::new();
+        microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])))?;
+        microstate.add_body(Body::point(Cartesian::from([1.0, 0.0])))?;
+        microstate.add_body(Body::point(Cartesian::from([2.0, 0.0])))?;
+        microstate.add_body(Body::point(Cartesian::from([1.0, 2.0])))?;
+        microstate.add_body(Body::point(Cartesian::from([1.0, -2.0])))?;
+        microstate.add_body(Body::point(Cartesian::from([1.0, 0.0])))?;
+
+        let near_site_1 = SitesInBall::near_site(&microstate, 1, 1.5);
+        let sites = near_site_1.iter_sites().collect::<Vec<_>>();
+        let mut sorted_sites = sites.clone();
+        sorted_sites.sort_by_key(|a| a.site_tag);
+
+        itertools::assert_equal(sorted_sites.iter().map(|s| s.site_tag), [0, 2, 5]);
+        itertools::assert_equal(near_site_1.iter_site_tags(), sites.iter().map(|s| s.site_tag));
+        itertools::assert_equal(near_site_1.iter_site_positions().copied(), sites.iter().map(|s| s.properties.position));
+        
+        Ok(())        
+    }
+    #[test]
+    fn near_point() -> anyhow::Result<()> {
+        let mut microstate = Microstate::new();
+        microstate.add_body(Body::point(Cartesian::from([0.0, 0.0])))?;
+        microstate.add_body(Body::point(Cartesian::from([1.0, 0.0])))?;
+        microstate.add_body(Body::point(Cartesian::from([2.0, 0.0])))?;
+        microstate.add_body(Body::point(Cartesian::from([1.0, 2.0])))?;
+        microstate.add_body(Body::point(Cartesian::from([1.0, -2.0])))?;
+        microstate.add_body(Body::point(Cartesian::from([1.0, 0.0])))?;
+
+        let near_point = SitesInBall::near_point(&microstate, [1.0, 0.0].into(), 1.5);
+        let sites = near_point.iter_sites().collect::<Vec<_>>();
+        let mut sorted_sites = sites.clone();
+        sorted_sites.sort_by_key(|a| a.site_tag);
+
+        itertools::assert_equal(sorted_sites.iter().map(|s| s.site_tag), [0, 1, 2, 5]);
+        itertools::assert_equal(near_point.iter_site_tags(), sites.iter().map(|s| s.site_tag));
+        itertools::assert_equal(near_point.iter_site_positions().copied(), sites.iter().map(|s| s.properties.position));
+        
+        Ok(())        
+    }
+}

--- a/hoomd-order/src/steinhardt.rs
+++ b/hoomd-order/src/steinhardt.rs
@@ -7,7 +7,10 @@ use std::f64::consts::PI;
 
 use hoomd_vector::{Cartesian, InnerProduct};
 
-use crate::math::{SphericalHarmonic, SphericalHarmonicOutputs};
+use crate::{
+    Error,
+    math::{SphericalHarmonic, SphericalHarmonicOutputs},
+};
 
 /// Compute the 3D Steinhardt order parameters $` q_{Lm} `$ and $` q_L `$.
 ///
@@ -32,7 +35,7 @@ use crate::math::{SphericalHarmonic, SphericalHarmonicOutputs};
 /// [`q_lm`]: Self::q_lm
 /// [`new`]: Self::new
 ///
-/// # Example
+/// # Examples
 ///
 /// Compute $` q_4 `$ for all sites in a microstate:
 /// ```
@@ -85,6 +88,77 @@ use crate::math::{SphericalHarmonic, SphericalHarmonicOutputs};
 /// # Ok(())
 /// # }
 /// ```
+///
+/// Compute the averaged $` q_4 `$ for all sites in a microstate using
+/// [`average_over_neighbors`]. First, compute the  $` q_{Lm} `$ values for each
+/// site. Then average them over the site *and* all its neighbors (by using a
+/// `near_point` query). Finally, compute $` q_4 `$ by applying the rotational
+/// invariance operation to the averaged $` q_{Lm} `$:
+/// ```
+/// use std::collections::HashMap;
+///
+/// use hoomd_geometry::shape::Cuboid;
+/// use hoomd_microstate::{Body, Microstate, Replicate, boundary::Periodic};
+/// use hoomd_order::{SitesInBall, Steinhardt};
+/// use hoomd_spatial::VecCell;
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let model_maximum_interaction_range: f64 = 1.0;
+/// let order_maximum_neighbor_distance: f64 = 1.5;
+/// let maximum_interaction_range =
+///     model_maximum_interaction_range.max(order_maximum_neighbor_distance);
+///
+/// let unit_cell_cube = Cuboid::with_equal_edges(1.0.try_into()?);
+/// let periodic_unit_cell = Periodic::new(0.0, unit_cell_cube)?;
+/// let vec_cell = VecCell::builder()
+///     .nominal_search_radius(model_maximum_interaction_range.try_into()?)
+///     .maximum_search_radius(maximum_interaction_range)
+///     .build();
+/// let microstate = Microstate::builder()
+///     .boundary(periodic_unit_cell)
+///     .spatial_data(vec_cell)
+///     .bodies([Body::point(Cartesian::default())])
+///     .try_build()?
+///     .replicate_with_maximum_interaction_range(
+///         [16; 3],
+///         maximum_interaction_range,
+///     )?;
+///
+/// let steinhardt = Steinhardt::<4>::new();
+/// let mut q_lm = HashMap::new();
+/// for (site_index, site) in microstate.sites().iter().enumerate() {
+///     let neighbors = SitesInBall::near_site(
+///         &microstate,
+///         site_index,
+///         order_maximum_neighbor_distance,
+///     );
+///     q_lm.insert(
+///         site.site_tag,
+///         steinhardt.q_lm(
+///             &site.properties.position,
+///             neighbors.iter_site_positions().copied(),
+///         )?,
+///     );
+/// }
+///
+/// let q_average_lm = hoomd_order::average_over_neighbors(&q_lm, |site_tag| {
+///    let site_index = microstate.site_indices()[site_tag].expect("site tag should be present");
+///    SitesInBall::near_point(&microstate,
+///    microstate.sites()[site_index].properties.position,
+///    order_maximum_neighbor_distance,
+///    )
+///    .iter_site_tags()
+///    .collect::<Vec<_>>()
+/// })?;
+///
+/// let q_average_4: HashMap<usize, f64> = q_average_lm.iter().map(|(&site_tag, q_lm_j)|
+///    (site_tag, Steinhardt::make_rotationally_invariant(q_lm_j))).collect();
+/// # Ok(())
+/// # }
+/// ```
+///
+/// [`average_over_neighbors`]: crate::average_over_neighbors
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Steinhardt<const L: usize> {
     /// Compute the spherical harmonics.
@@ -117,7 +191,7 @@ impl<const L: usize> Steinhardt<L> {
     ///
     /// # Errors
     ///
-    /// [`hoomd_vector::Error::InvalidVectorMagnitude`] when any $` |\vec{r}_j - \vec{r}| = 0 `$.
+    /// [`Error::InvalidDeltaR3`] when any $` |\vec{r}_j - \vec{r}| = 0 `$.
     ///
     /// # Example
     ///
@@ -153,12 +227,14 @@ impl<const L: usize> Steinhardt<L> {
         &self,
         r: &Cartesian<3>,
         neighbors: I,
-    ) -> Result<SphericalHarmonicOutputs<L>, hoomd_vector::Error> {
+    ) -> Result<SphericalHarmonicOutputs<L>, Error> {
         let mut total = SphericalHarmonicOutputs::default();
         let mut count: usize = 0;
 
         for r_j in neighbors {
-            let (delta_r_unit, _) = (r_j - *r).to_unit()?;
+            let (delta_r_unit, _) = (r_j - *r)
+                .to_unit()
+                .map_err(|e| Error::InvalidDeltaR3(r_j, *r, e))?;
             total += self.spherical_harmonic.evaluate(&delta_r_unit);
             count += 1;
         }
@@ -193,7 +269,7 @@ impl<const L: usize> Steinhardt<L> {
     ///
     /// # Errors
     ///
-    /// [`hoomd_vector::Error::InvalidVectorMagnitude`] when any $` |\vec{r}_j - \vec{r}| = 0 `$.
+    /// [`Error::InvalidDeltaR3`] when any $` |\vec{r}_j - \vec{r}| = 0 `$.
     ///
     /// # Example
     ///
@@ -232,8 +308,25 @@ impl<const L: usize> Steinhardt<L> {
         &self,
         r: &Cartesian<3>,
         neighbors: I,
-    ) -> Result<f64, hoomd_vector::Error> {
+    ) -> Result<f64, Error> {
         let q_lm = self.q_lm(r, neighbors)?;
         Ok(Self::make_rotationally_invariant(&q_lm))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_delta_r() {
+        let steinhardt = Steinhardt::<6>::new();
+
+        let neighbors = [[1.0, 1.0, 1.0].into()];
+
+        assert!(matches!(
+            steinhardt.q_lm(&[1.0, 1.0, 1.0].into(), neighbors),
+            Err(Error::InvalidDeltaR3(_, _, _))
+        ));
     }
 }

--- a/hoomd-order/src/steinhardt.rs
+++ b/hoomd-order/src/steinhardt.rs
@@ -1,0 +1,147 @@
+// Copyright (c) 2024-2026 The Regents of the University of Michigan.
+// Part of hoomd-rs, released under the BSD 3-Clause License.
+
+//! Implement `Steinhardt`
+
+use std::f64::consts::PI;
+
+use hoomd_vector::{Cartesian, InnerProduct};
+
+use crate::math::{SphericalHarmonic, SphericalHarmonicOutputs};
+
+/// Compute the 3D Steinhardt order parameters $` q_{Lm} `$ and $` q_L `$.
+///
+/// [Steinhardt, Nelson, and Ronchetti 1983](https://doi.org/10.1103/PhysRevB.28.784)
+/// introduces the order parameter $` q_{Lm} `$ and its rotationally invariant counterpart,
+/// $` q_L `$.
+///
+/// Let the `neighbors` iterator produce `n` points $` \vec{r}_j `$.
+/// The order parameters are then:
+/// ```math
+/// \begin{align*}
+/// q_{Lm} &= \frac{1}{n} \sum_j Y_L^m \left( \frac{\vec{r}_j - \vec{r}}{\lvert \vec{r}_j - \vec{r} \rvert} \right) \\
+/// q_L &= \sqrt{\frac{4 \pi}{2L + 1} \sum_{m=-L}^L \lvert q_{Lm} \rvert^2} \\
+/// \end{align*}
+/// ```
+#[derive(Copy, Clone, Debug, Default)]
+pub struct Steinhardt<const L: usize> {
+    /// Compute the spherical harmonics.
+    spherical_harmonic: SphericalHarmonic<L>
+}
+
+impl<const L: usize> Steinhardt<L> {
+    /// Construct a new Steinhardt order parameter evaluator with degree `L`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_order::Steinhardt;
+    ///
+    /// let steinhardt = Steinhardt::<6>::new();
+    /// ```
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            spherical_harmonic: SphericalHarmonic::new()
+        }
+    }
+
+    /// Compute $` q_{Lm} `$.
+    ///
+    /// ```math
+    /// q_{Lm} = \frac{1}{n} \sum_j Y_L^m \left( \frac{\vec{r}_j - \vec{r}}{\lvert \vec{r}_j - \vec{r} \rvert} \right)
+    /// ```
+    /// where the `neighbors` iterator produces `n` points $` \vec{r}_j `$.
+    ///
+    /// # Errors
+    ///
+    /// [`hoomd_vector::Error::InvalidVectorMagnitude`] when any $` |\vec{r}_j - \vec{r}| = 0 `$.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hoomd_order::Steinhardt;
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let steinhardt = Steinhardt::<6>::new();
+    /// let fcc_bonds: Vec<Cartesian<3>> = [
+    ///     [-1.0, -1.0,  0.0], [-1.0,  1.0,  0.0], [1.0, -1.0,  0.0], [1.0,  1.0,  0.0],
+    ///     [-1.0,  0.0, -1.0], [-1.0,  0.0,  1.0], [1.0,  0.0, -1.0], [1.0,  0.0,  1.0],
+    ///     [ 0.0, -1.0, -1.0], [ 0.0, -1.0,  1.0], [0.0,  1.0, -1.0], [0.0,  1.0,  1.0],
+    /// ].map(Cartesian::<3>::from).to_vec();
+    ///
+    /// let q_lm = steinhardt.q_lm(&Cartesian::default(), fcc_bonds)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn q_lm<I: IntoIterator<Item=Cartesian<3>>>(&self, r: &Cartesian<3>, neighbors: I) -> Result<SphericalHarmonicOutputs<L>, hoomd_vector::Error> {
+        let mut total = SphericalHarmonicOutputs::default();
+        let mut count: usize = 0;
+
+        for r_j in neighbors {
+            let (delta_r_unit, _) = (r_j - *r).to_unit()?;
+            total += self.spherical_harmonic.evaluate(&delta_r_unit);
+            count += 1;
+        }
+
+        Ok(total / (count as f64))
+    }
+
+    /// Compute $` q_L `$ given $` q_{Lm} `$.
+    ///
+    /// ```math
+    /// q_L = \sqrt{\frac{4 \pi}{2L + 1} \sum_{m=-L}^L \lvert q_{Lm} \rvert^2}
+    /// ```
+    #[inline]
+    pub fn make_rotationally_invariant(q_lm: &SphericalHarmonicOutputs<L>) -> f64 {
+        let mut sum_squared = q_lm[0].norm_sqr();
+        for i in 1..=L {
+            sum_squared += 2.0 * q_lm[i].norm_sqr();
+        }
+        (4.0 * PI / (2 * L + 1) as f64 * sum_squared).sqrt()
+    }
+
+    /// Compute $` q_L `$ given $` \vec{r} `$ and a set of neighbors $` \vec{r}_j `$.
+    ///
+    /// ```math
+    /// q_L = \sqrt{\frac{4 \pi}{2L + 1} \sum_{m=-L}^L \lvert q_{Lm} \rvert^2}
+    /// ```
+    /// where
+    /// ```math
+    /// q_{Lm} = \frac{1}{n} \sum_j Y_L^m \left( \frac{\vec{r}_j - \vec{r}}{\lvert \vec{r}_j - \vec{r} \rvert} \right)
+    /// ```
+    /// and the `neighbors` iterator produces `n` points $` \vec{r}_j `$.
+    ///
+    /// # Errors
+    ///
+    /// [`hoomd_vector::Error::InvalidVectorMagnitude`] when any $` |\vec{r}_j = \vec{r}| = 0 `$.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use approxim::assert_relative_eq;
+    ///
+    /// use hoomd_order::Steinhardt;
+    /// use hoomd_vector::Cartesian;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let steinhardt = Steinhardt::<6>::new();
+    /// let fcc_bonds: Vec<Cartesian<3>> = [
+    ///     [-1.0, -1.0,  0.0], [-1.0,  1.0,  0.0], [1.0, -1.0,  0.0], [1.0,  1.0,  0.0],
+    ///     [-1.0,  0.0, -1.0], [-1.0,  0.0,  1.0], [1.0,  0.0, -1.0], [1.0,  0.0,  1.0],
+    ///     [ 0.0, -1.0, -1.0], [ 0.0, -1.0,  1.0], [0.0,  1.0, -1.0], [0.0,  1.0,  1.0],
+    /// ].map(Cartesian::<3>::from).to_vec();
+    ///
+    /// let q_l = steinhardt.q_l(&Cartesian::default(), fcc_bonds)?;
+    /// assert_relative_eq!(q_l, 0.57452416, epsilon = 1e-6);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn q_l<I: IntoIterator<Item=Cartesian<3>>>(&self, r: &Cartesian<3>, neighbors: I) -> Result<f64, hoomd_vector::Error> {
+        let q_lm = self.q_lm(r, neighbors)?;
+        Ok(Self::make_rotationally_invariant(&q_lm))
+    }
+}

--- a/hoomd-order/src/steinhardt.rs
+++ b/hoomd-order/src/steinhardt.rs
@@ -32,7 +32,48 @@ use crate::math::{SphericalHarmonic, SphericalHarmonicOutputs};
 /// [`q_lm`]: Self::q_lm
 /// [`new`]: Self::new
 ///
-/// TODO: Example with microstate and steinhardt on all sites using `SitesInBall`.
+/// # Example
+///
+/// Compute $` \q_4 `$ for all sites in a microstate:
+/// ```
+/// use std::collections::HashMap;
+///
+/// use hoomd_geometry::shape::Cuboid;
+/// use hoomd_microstate::{Microstate, Body, Replicate, boundary::Periodic};
+/// use hoomd_order::{SitesInBall, Steinhardt};
+/// use hoomd_spatial::VecCell;
+/// use hoomd_vector::Cartesian;
+///
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let model_maximum_interaction_range: f64 = 1.0;
+/// let order_maximum_neighbor_distance: f64 = 1.5;
+/// let maximum_interaction_range = model_maximum_interaction_range.max(order_maximum_neighbor_distance);
+///
+/// let unit_cell_cube = Cuboid::with_equal_edges(1.0.try_into()?);
+/// let periodic_unit_cell = Periodic::new(0.0, unit_cell_cube)?;
+/// let vec_cell = VecCell::builder()
+///     .nominal_search_radius(model_maximum_interaction_range.try_into()?)
+///     .maximum_search_radius(maximum_interaction_range)
+///     .build();
+/// let microstate = Microstate::builder()
+///     .boundary(periodic_unit_cell)
+///     .spatial_data(vec_cell)
+///     .bodies([Body::point(Cartesian::default())])
+///     .try_build()?
+///     .replicate_with_maximum_interaction_range(
+///         [16; 3],
+///         maximum_interaction_range,
+///     )?;
+///
+/// let steinhardt = Steinhardt::<4>::new();
+/// let mut q_4 = HashMap::new();
+/// for (site_index, site) in microstate.sites().iter().enumerate() {
+///     let neighbors = SitesInBall::near_site(&microstate, site_index, order_maximum_neighbor_distance);
+///     q_4.insert(site.site_tag, steinhardt.q_l(&site.properties.position, neighbors.iter_site_positions().copied())?);
+/// }
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Steinhardt<const L: usize> {
     /// Compute the spherical harmonics.

--- a/hoomd-order/src/steinhardt.rs
+++ b/hoomd-order/src/steinhardt.rs
@@ -34,12 +34,12 @@ use crate::math::{SphericalHarmonic, SphericalHarmonicOutputs};
 ///
 /// # Example
 ///
-/// Compute $` \q_4 `$ for all sites in a microstate:
+/// Compute $` q_4 `$ for all sites in a microstate:
 /// ```
 /// use std::collections::HashMap;
 ///
 /// use hoomd_geometry::shape::Cuboid;
-/// use hoomd_microstate::{Microstate, Body, Replicate, boundary::Periodic};
+/// use hoomd_microstate::{Body, Microstate, Replicate, boundary::Periodic};
 /// use hoomd_order::{SitesInBall, Steinhardt};
 /// use hoomd_spatial::VecCell;
 /// use hoomd_vector::Cartesian;
@@ -47,7 +47,8 @@ use crate::math::{SphericalHarmonic, SphericalHarmonicOutputs};
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let model_maximum_interaction_range: f64 = 1.0;
 /// let order_maximum_neighbor_distance: f64 = 1.5;
-/// let maximum_interaction_range = model_maximum_interaction_range.max(order_maximum_neighbor_distance);
+/// let maximum_interaction_range =
+///     model_maximum_interaction_range.max(order_maximum_neighbor_distance);
 ///
 /// let unit_cell_cube = Cuboid::with_equal_edges(1.0.try_into()?);
 /// let periodic_unit_cell = Periodic::new(0.0, unit_cell_cube)?;
@@ -68,8 +69,18 @@ use crate::math::{SphericalHarmonic, SphericalHarmonicOutputs};
 /// let steinhardt = Steinhardt::<4>::new();
 /// let mut q_4 = HashMap::new();
 /// for (site_index, site) in microstate.sites().iter().enumerate() {
-///     let neighbors = SitesInBall::near_site(&microstate, site_index, order_maximum_neighbor_distance);
-///     q_4.insert(site.site_tag, steinhardt.q_l(&site.properties.position, neighbors.iter_site_positions().copied())?);
+///     let neighbors = SitesInBall::near_site(
+///         &microstate,
+///         site_index,
+///         order_maximum_neighbor_distance,
+///     );
+///     q_4.insert(
+///         site.site_tag,
+///         steinhardt.q_l(
+///             &site.properties.position,
+///             neighbors.iter_site_positions().copied(),
+///         )?,
+///     );
 /// }
 /// # Ok(())
 /// # }
@@ -77,7 +88,7 @@ use crate::math::{SphericalHarmonic, SphericalHarmonicOutputs};
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Steinhardt<const L: usize> {
     /// Compute the spherical harmonics.
-    spherical_harmonic: SphericalHarmonic<L>
+    spherical_harmonic: SphericalHarmonic<L>,
 }
 
 impl<const L: usize> Steinhardt<L> {
@@ -93,7 +104,7 @@ impl<const L: usize> Steinhardt<L> {
     #[inline]
     pub fn new() -> Self {
         Self {
-            spherical_harmonic: SphericalHarmonic::new()
+            spherical_harmonic: SphericalHarmonic::new(),
         }
     }
 
@@ -117,17 +128,32 @@ impl<const L: usize> Steinhardt<L> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let steinhardt = Steinhardt::<6>::new();
     /// let fcc_bonds: Vec<Cartesian<3>> = [
-    ///     [-1.0, -1.0,  0.0], [-1.0,  1.0,  0.0], [1.0, -1.0,  0.0], [1.0,  1.0,  0.0],
-    ///     [-1.0,  0.0, -1.0], [-1.0,  0.0,  1.0], [1.0,  0.0, -1.0], [1.0,  0.0,  1.0],
-    ///     [ 0.0, -1.0, -1.0], [ 0.0, -1.0,  1.0], [0.0,  1.0, -1.0], [0.0,  1.0,  1.0],
-    /// ].map(Cartesian::<3>::from).to_vec();
+    ///     [-1.0, -1.0, 0.0],
+    ///     [-1.0, 1.0, 0.0],
+    ///     [1.0, -1.0, 0.0],
+    ///     [1.0, 1.0, 0.0],
+    ///     [-1.0, 0.0, -1.0],
+    ///     [-1.0, 0.0, 1.0],
+    ///     [1.0, 0.0, -1.0],
+    ///     [1.0, 0.0, 1.0],
+    ///     [0.0, -1.0, -1.0],
+    ///     [0.0, -1.0, 1.0],
+    ///     [0.0, 1.0, -1.0],
+    ///     [0.0, 1.0, 1.0],
+    /// ]
+    /// .map(Cartesian::<3>::from)
+    /// .to_vec();
     ///
     /// let q_lm = steinhardt.q_lm(&Cartesian::default(), fcc_bonds)?;
     /// # Ok(())
     /// # }
     /// ```
     #[inline]
-    pub fn q_lm<I: IntoIterator<Item=Cartesian<3>>>(&self, r: &Cartesian<3>, neighbors: I) -> Result<SphericalHarmonicOutputs<L>, hoomd_vector::Error> {
+    pub fn q_lm<I: IntoIterator<Item = Cartesian<3>>>(
+        &self,
+        r: &Cartesian<3>,
+        neighbors: I,
+    ) -> Result<SphericalHarmonicOutputs<L>, hoomd_vector::Error> {
         let mut total = SphericalHarmonicOutputs::default();
         let mut count: usize = 0;
 
@@ -167,7 +193,7 @@ impl<const L: usize> Steinhardt<L> {
     ///
     /// # Errors
     ///
-    /// [`hoomd_vector::Error::InvalidVectorMagnitude`] when any $` |\vec{r}_j = \vec{r}| = 0 `$.
+    /// [`hoomd_vector::Error::InvalidVectorMagnitude`] when any $` |\vec{r}_j - \vec{r}| = 0 `$.
     ///
     /// # Example
     ///
@@ -180,10 +206,21 @@ impl<const L: usize> Steinhardt<L> {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let steinhardt = Steinhardt::<6>::new();
     /// let fcc_bonds: Vec<Cartesian<3>> = [
-    ///     [-1.0, -1.0,  0.0], [-1.0,  1.0,  0.0], [1.0, -1.0,  0.0], [1.0,  1.0,  0.0],
-    ///     [-1.0,  0.0, -1.0], [-1.0,  0.0,  1.0], [1.0,  0.0, -1.0], [1.0,  0.0,  1.0],
-    ///     [ 0.0, -1.0, -1.0], [ 0.0, -1.0,  1.0], [0.0,  1.0, -1.0], [0.0,  1.0,  1.0],
-    /// ].map(Cartesian::<3>::from).to_vec();
+    ///     [-1.0, -1.0, 0.0],
+    ///     [-1.0, 1.0, 0.0],
+    ///     [1.0, -1.0, 0.0],
+    ///     [1.0, 1.0, 0.0],
+    ///     [-1.0, 0.0, -1.0],
+    ///     [-1.0, 0.0, 1.0],
+    ///     [1.0, 0.0, -1.0],
+    ///     [1.0, 0.0, 1.0],
+    ///     [0.0, -1.0, -1.0],
+    ///     [0.0, -1.0, 1.0],
+    ///     [0.0, 1.0, -1.0],
+    ///     [0.0, 1.0, 1.0],
+    /// ]
+    /// .map(Cartesian::<3>::from)
+    /// .to_vec();
     ///
     /// let q_l = steinhardt.q_l(&Cartesian::default(), fcc_bonds)?;
     /// assert_relative_eq!(q_l, 0.57452416, epsilon = 1e-6);
@@ -191,7 +228,11 @@ impl<const L: usize> Steinhardt<L> {
     /// # }
     /// ```
     #[inline]
-    pub fn q_l<I: IntoIterator<Item=Cartesian<3>>>(&self, r: &Cartesian<3>, neighbors: I) -> Result<f64, hoomd_vector::Error> {
+    pub fn q_l<I: IntoIterator<Item = Cartesian<3>>>(
+        &self,
+        r: &Cartesian<3>,
+        neighbors: I,
+    ) -> Result<f64, hoomd_vector::Error> {
         let q_lm = self.q_lm(r, neighbors)?;
         Ok(Self::make_rotationally_invariant(&q_lm))
     }

--- a/hoomd-order/src/steinhardt.rs
+++ b/hoomd-order/src/steinhardt.rs
@@ -23,6 +23,16 @@ use crate::math::{SphericalHarmonic, SphericalHarmonicOutputs};
 /// q_L &= \sqrt{\frac{4 \pi}{2L + 1} \sum_{m=-L}^L \lvert q_{Lm} \rvert^2} \\
 /// \end{align*}
 /// ```
+///
+/// Construct a [`Steinhardt`] with a given `L`, then call [`q_l`] or [`q_lm`] to evaluate
+/// $` q_L `$ or $` q_{Lm} `$ respectively. Use the same [`Steinhardt`] for may calls to
+/// [`q_l`] and/or [`q_lm`] as [`new`] is computationally expensive.
+///
+/// [`q_l`]: Self::q_l
+/// [`q_lm`]: Self::q_lm
+/// [`new`]: Self::new
+///
+/// TODO: Example with microstate and steinhardt on all sites using `SitesInBall`.
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Steinhardt<const L: usize> {
     /// Compute the spherical harmonics.


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
Building on work @janbridley started in #293, this PR implements the k-atic and Steinhardt order parameters. It also sketches the overall design for future order parameter methods.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Allow users to compute order parameters entirely within the Rust toolchain. For example, users could use order parameters in metadynamics simulations. See `ARCHITECTURE.md` for a complete motivation.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
New unit tests.

<!--- Please build the documentation and check that any changes to
      documentation display properly. -->

## Checklist:

- [X] I have reviewed the [**Contributor Guidelines**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/CONTRIBUTING.md).
- [X] I agree with the terms of the [**hoomd-rs Contributor Agreement**](https://github.com/glotzerlab/hoomd-rs/blob/trunk/ContributorAgreement.md).
- [X] My name is on the list of contributors (`doc/src/credits.md`) in the pull request source branch.
- [ ] I have summarized these changes in `release-notes.md` following the established format.
